### PR TITLE
Update Android's README.md Maven Url

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -19,12 +19,7 @@ allprojects {
         google()
         jcenter()
         maven {
-            credentials {
-                // user@password with read only access
-                username "beagle"
-                password "Xq7wAh3xDkGN"
-            }
-            url 'https://repo-iti.zup.com.br/repository/beagle-jars-all/'
+            url 'https://dl.bintray.com/zupit/repo'
         }
     }
 }


### PR DESCRIPTION
**Problem:**
Our Android README.md its outdated.

**Solution:**
Update the url to point to Bintray.