### PR TITLE
Renaming toView method

### DIFF
--- a/android/android-declarative/src/main/java/br/com/zup/beagle/widget/core/ViewConvertable.kt
+++ b/android/android-declarative/src/main/java/br/com/zup/beagle/widget/core/ViewConvertable.kt
@@ -21,5 +21,5 @@ import android.view.View
 import br.com.zup.beagle.core.ServerDrivenComponent
 
 interface ViewConvertable : ServerDrivenComponent {
-    fun toView(context: Context): View
+    fun buildView(context: Context): View
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/engine/renderer/ui/ViewConvertableRenderer.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/engine/renderer/ui/ViewConvertableRenderer.kt
@@ -23,6 +23,6 @@ import br.com.zup.beagle.widget.core.ViewConvertable
 
 internal class ViewConvertableRenderer(override val component: ViewConvertable) : UIViewRenderer<ViewConvertable>() {
     override fun buildView(rootView: RootView): View {
-        return component.toView(rootView.getContext())
+        return component.buildView(rootView.getContext())
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/widget/pager/PageIndicator.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/widget/pager/PageIndicator.kt
@@ -39,7 +39,7 @@ data class PageIndicator(
         this.viewFactory = viewFactory
     }
 
-    override fun toView(context: Context) = viewFactory.makePageIndicator(context).apply {
+    override fun buildView(context: Context) = viewFactory.makePageIndicator(context).apply {
         pageIndicator = this
         setSelectedColor(Color.parseColor(selectedColor))
         setUnselectedColor(Color.parseColor(unselectedColor))

--- a/android/beagle/src/main/java/br/com/zup/beagle/widget/ui/UndefinedWidget.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/widget/ui/UndefinedWidget.kt
@@ -37,7 +37,7 @@ internal class UndefinedWidget : InputWidget(), PageIndicatorComponent {
 
     override fun getValue(): Any = ""
 
-    override fun toView(context: Context): View = UndefinedViewRenderer(this).build(
+    override fun buildView(context: Context): View = UndefinedViewRenderer(this).build(
         ActivityRootView(context as AppCompatActivity)
     )
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/engine/renderer/layout/PageViewRendererTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/engine/renderer/layout/PageViewRendererTest.kt
@@ -100,7 +100,7 @@ class PageViewRendererTest : BaseTest() {
     fun build_when_page_indicator_is_not_null() {
         // GIVEN
         every { pageView.pageIndicator } returns pageIndicatorComponent
-        every { pageIndicatorComponent.toView(any()) } returns pageIndicatorView
+        every { pageIndicatorComponent.buildView(any()) } returns pageIndicatorView
 
         // WHEN
         pageViewRenderer.build(rootView)

--- a/android/beagle/src/test/java/br/com/zup/beagle/engine/renderer/ui/PageIndicatorViewRendererTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/engine/renderer/ui/PageIndicatorViewRendererTest.kt
@@ -18,7 +18,6 @@ package br.com.zup.beagle.engine.renderer.ui
 
 import android.content.Context
 import android.graphics.Color
-import br.com.zup.beagle.engine.renderer.RootView
 import br.com.zup.beagle.extensions.once
 import br.com.zup.beagle.testutil.RandomData
 import br.com.zup.beagle.testutil.setPrivateField
@@ -27,7 +26,6 @@ import br.com.zup.beagle.view.ViewFactory
 import br.com.zup.beagle.widget.pager.PageIndicator
 import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockkStatic
 import io.mockk.verify
@@ -62,7 +60,7 @@ class PageIndicatorViewTest {
 
     @Test
     fun toView_should_return_BeaglePageIndicatorView_and_set_colors() {
-        val view = pageIndicator.toView(context)
+        val view = pageIndicator.buildView(context)
 
         assertEquals(beaglePageIndicatorView, view)
         verify(exactly = once()) { beaglePageIndicatorView.setSelectedColor(0) }

--- a/android/beagle/src/test/java/br/com/zup/beagle/engine/renderer/ui/ViewConvertableRendererTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/engine/renderer/ui/ViewConvertableRendererTest.kt
@@ -51,7 +51,7 @@ class ViewConvertableRendererTest : BaseTest() {
     @Test
     fun build_should_make_a_native_view() {
         // Given
-        every { widget.toView(rootView.getContext()) } returns view
+        every { widget.buildView(rootView.getContext()) } returns view
 
         // When
         val actual = viewConvertableRenderer.build(rootView)

--- a/android/beagle/src/test/java/br/com/zup/beagle/mockdata/CustomWidget.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/mockdata/CustomWidget.kt
@@ -21,7 +21,7 @@ import android.view.View
 import br.com.zup.beagle.widget.core.WidgetView
 
 class CustomWidget : WidgetView() {
-    override fun toView(context: Context): View {
+    override fun buildView(context: Context): View {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/mockdata/FormInputView.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/mockdata/FormInputView.kt
@@ -29,7 +29,7 @@ class CustomInputWidget : InputWidget() {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
-    override fun toView(context: Context): View {
+    override fun buildView(context: Context): View {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 }

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/CustomPageIndicator.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/CustomPageIndicator.kt
@@ -46,7 +46,7 @@ data class CustomPageIndicator(
         customPageIndicatorView.setCount(pages)
     }
 
-    override fun toView(context: Context) = CustomPageIndicatorView(context).apply {
+    override fun buildView(context: Context) = CustomPageIndicatorView(context).apply {
         customPageIndicatorView = this
         setIndexChangedListener { index ->
             output.swapToPage(index)

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/MutableText.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/MutableText.kt
@@ -26,7 +26,7 @@ data class MutableText(
     val secondText: String = "",
     val color: String = "#000000"
 ): WidgetView() {
-    override fun toView(context: Context) = TextView(context).apply {
+    override fun buildView(context: Context) = TextView(context).apply {
         val color = Color.parseColor(color)
         text = firstText
         setTextColor(color)

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/SampleTextField.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/SampleTextField.kt
@@ -34,7 +34,7 @@ class SampleTextField(private val placeholder: String) : InputWidget() {
         textFieldView.error = message
     }
 
-    override fun toView(context: Context) = EditText(context).apply {
+    override fun buildView(context: Context) = EditText(context).apply {
         textFieldView = this
         textFieldView.hint = placeholder
         textFieldView.isSingleLine = true

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/TextField.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/TextField.kt
@@ -42,7 +42,7 @@ data class TextField(
 
     private lateinit var textFieldView: EditText
 
-    override fun toView(context: Context) = EditText(context).apply {
+    override fun buildView(context: Context) = EditText(context).apply {
         textFieldView = this
         bind()
 


### PR DESCRIPTION
Renaming toView method on ViewConvertable to avoid conflict with WidgetExtensions toView