### PR TITLE
Enable carryforward in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -40,12 +40,13 @@ flags:
   ios:
     paths:
       - iOS/
+    carryforward: true
   android:
     paths:
       - android/
       - backend/
       - common/
-
+    carryforward: true
 ignore:
  - "iOS/Sources/BeagleUI/**/Tests/"
  - "iOS/Sources/BeagleUI/**/*Test*.swift"


### PR DESCRIPTION
https://docs.codecov.io/docs/carryforward-flags
This option will be help to disable upload all coverages of flags, like now some PR there are showing the error because don't upload the codecov of  some flag, but don't need because.