### PR TITLE
fix: extension function loadView to viewgroups with wrap_content height

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/utils/ViewExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/utils/ViewExtensions.kt
@@ -18,32 +18,15 @@ package br.com.zup.beagle.utils
 
 import android.app.Activity
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Path
-import android.graphics.RectF
 import android.graphics.drawable.GradientDrawable
 import android.util.TypedValue
 import android.view.View
-import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import androidx.core.view.children
-import androidx.core.view.size
-import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.core.AppearanceComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
-import br.com.zup.beagle.data.BeagleViewModel
-import br.com.zup.beagle.data.serializer.BeagleSerializer
-import br.com.zup.beagle.engine.renderer.ActivityRootView
-import br.com.zup.beagle.engine.renderer.FragmentRootView
-import br.com.zup.beagle.engine.renderer.RootView
 import br.com.zup.beagle.view.BeagleImageView
-import br.com.zup.beagle.view.BeagleView
-import br.com.zup.beagle.view.ScreenRequest
-import br.com.zup.beagle.view.StateChangedListener
 import br.com.zup.beagle.view.ViewFactory
 
 internal var viewExtensionsViewFactory = ViewFactory()

--- a/android/beagle/src/main/java/br/com/zup/beagle/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/utils/ViewGroupExtensions.kt
@@ -26,36 +26,31 @@ import br.com.zup.beagle.data.serializer.BeagleSerializer
 import br.com.zup.beagle.engine.renderer.ActivityRootView
 import br.com.zup.beagle.engine.renderer.FragmentRootView
 import br.com.zup.beagle.engine.renderer.RootView
-import br.com.zup.beagle.view.RenderCompletedListener
+import br.com.zup.beagle.view.OnStateChanged
 import br.com.zup.beagle.view.ScreenRequest
-import br.com.zup.beagle.view.StateChangedListener
 
 internal var beagleSerializerFactory = BeagleSerializer()
 
-fun ViewGroup.loadView(activity: AppCompatActivity,
-                       screenRequest: ScreenRequest,
-                       listener: StateChangedListener? = null
-) {
+fun ViewGroup.loadView(activity: AppCompatActivity, screenRequest: ScreenRequest, listener: OnStateChanged? = null) {
     loadView(this, ActivityRootView(activity), screenRequest, listener)
 }
 
-fun ViewGroup.loadView(fragment: Fragment, screenRequest: ScreenRequest, listener: StateChangedListener? = null) {
+fun ViewGroup.loadView(fragment: Fragment, screenRequest: ScreenRequest, listener: OnStateChanged? = null) {
     loadView(this, FragmentRootView(fragment), screenRequest, listener)
 }
 
-private fun loadView(viewGroup: ViewGroup,
-                     rootView: RootView,
-                     screenRequest: ScreenRequest,
-                     listener: StateChangedListener?
+private fun loadView(
+    viewGroup: ViewGroup,
+    rootView: RootView,
+    screenRequest: ScreenRequest,
+    listener: OnStateChanged?
 ) {
     val view = viewExtensionsViewFactory.makeBeagleView(viewGroup.context).apply {
         loadView(rootView, screenRequest)
         stateChangedListener = listener
     }
-    view.renderCompletedListener = object : RenderCompletedListener {
-        override fun onLoadCompleted() {
-            viewGroup.addView(view)
-        }
+    view.loadCompletedListener = {
+        viewGroup.addView(view)
     }
 }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/utils/ViewGroupExtensions.kt
@@ -21,34 +21,42 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.children
-import androidx.core.view.size
 import androidx.fragment.app.Fragment
 import br.com.zup.beagle.data.serializer.BeagleSerializer
 import br.com.zup.beagle.engine.renderer.ActivityRootView
 import br.com.zup.beagle.engine.renderer.FragmentRootView
 import br.com.zup.beagle.engine.renderer.RootView
-import br.com.zup.beagle.utils.toView
-import br.com.zup.beagle.utils.viewExtensionsViewFactory
-import br.com.zup.beagle.view.BeagleView
+import br.com.zup.beagle.view.RenderCompletedListener
 import br.com.zup.beagle.view.ScreenRequest
 import br.com.zup.beagle.view.StateChangedListener
 
 internal var beagleSerializerFactory = BeagleSerializer()
 
-fun ViewGroup.loadView(activity: AppCompatActivity, screenRequest: ScreenRequest) {
-    loadView(this, ActivityRootView(activity), screenRequest)
+fun ViewGroup.loadView(activity: AppCompatActivity,
+                       screenRequest: ScreenRequest,
+                       listener: StateChangedListener? = null
+) {
+    loadView(this, ActivityRootView(activity), screenRequest, listener)
 }
 
-fun ViewGroup.loadView(fragment: Fragment, screenRequest: ScreenRequest) {
-    loadView(this, FragmentRootView(fragment), screenRequest)
+fun ViewGroup.loadView(fragment: Fragment, screenRequest: ScreenRequest, listener: StateChangedListener? = null) {
+    loadView(this, FragmentRootView(fragment), screenRequest, listener)
 }
 
-private fun loadView(viewGroup: ViewGroup, rootView: RootView, screenRequest: ScreenRequest) {
-    viewGroup.addView(
-        viewExtensionsViewFactory.makeBeagleView(viewGroup.context).apply {
-            this.loadView(rootView, screenRequest)
+private fun loadView(viewGroup: ViewGroup,
+                     rootView: RootView,
+                     screenRequest: ScreenRequest,
+                     listener: StateChangedListener?
+) {
+    val view = viewExtensionsViewFactory.makeBeagleView(viewGroup.context).apply {
+        loadView(rootView, screenRequest)
+        stateChangedListener = listener
+    }
+    view.renderCompletedListener = object : RenderCompletedListener {
+        override fun onLoadCompleted() {
+            viewGroup.addView(view)
         }
-    )
+    }
 }
 
 private fun <T> isAssignableFrom(
@@ -86,16 +94,4 @@ internal inline fun <reified T> ViewGroup.findChildViewForType(type: Class<T>): 
 fun ViewGroup.renderScreen(context: Context, screenJson: String) {
     removeAllViewsInLayout()
     addView(beagleSerializerFactory.deserializeComponent(screenJson).toView(context))
-}
-
-fun ViewGroup.setBeagleStateChangedListener(listener: StateChangedListener) {
-    check(size != 0) { "Did you miss to call loadView()?" }
-
-    val view = children.find { it is BeagleView } as? BeagleView
-
-    if (view != null) {
-        view.stateChangedListener = listener
-    } else {
-        throw IllegalStateException("Did you miss to call loadView()?")
-    }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/view/BeagleView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/view/BeagleView.kt
@@ -26,27 +26,23 @@ import br.com.zup.beagle.engine.renderer.RootView
 import br.com.zup.beagle.interfaces.OnStateUpdatable
 import br.com.zup.beagle.utils.implementsGenericTypeOf
 
+typealias OnStateChanged = (state: BeagleViewState) -> Unit
+
+typealias OnLoadCompleted = () -> Unit
+
 sealed class BeagleViewState {
     data class Error(val throwable: Throwable) : BeagleViewState()
     object LoadStarted : BeagleViewState()
     object LoadFinished : BeagleViewState()
 }
 
-interface StateChangedListener {
-    fun onStateChanged(state: BeagleViewState)
-}
-
-interface RenderCompletedListener {
-    fun onLoadCompleted()
-}
-
 internal class BeagleView(
     context: Context
 ) : BeagleFlexView(context) {
 
-    var stateChangedListener: StateChangedListener? = null
+    var stateChangedListener: OnStateChanged? = null
 
-    var renderCompletedListener: RenderCompletedListener? = null
+    var loadCompletedListener: OnLoadCompleted? = null
 
     private lateinit var rootView: RootView
 
@@ -84,11 +80,11 @@ internal class BeagleView(
         } else {
             BeagleViewState.LoadFinished
         }
-        stateChangedListener?.onStateChanged(state)
+        stateChangedListener?.invoke(state)
     }
 
     private fun handleError(throwable: Throwable) {
-        stateChangedListener?.onStateChanged(BeagleViewState.Error(throwable))
+        stateChangedListener?.invoke(BeagleViewState.Error(throwable))
     }
 
     private fun renderComponent(component: ServerDrivenComponent, view: View? = null) {
@@ -102,7 +98,7 @@ internal class BeagleView(
         } else {
             removeAllViewsInLayout()
             addServerDrivenComponent(component, rootView)
-            renderCompletedListener?.onLoadCompleted()
+            loadCompletedListener?.invoke()
         }
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/view/BeagleView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/view/BeagleView.kt
@@ -36,11 +36,17 @@ interface StateChangedListener {
     fun onStateChanged(state: BeagleViewState)
 }
 
+interface RenderCompletedListener {
+    fun onLoadCompleted()
+}
+
 internal class BeagleView(
     context: Context
 ) : BeagleFlexView(context) {
 
     var stateChangedListener: StateChangedListener? = null
+
+    var renderCompletedListener: RenderCompletedListener? = null
 
     private lateinit var rootView: RootView
 
@@ -96,6 +102,7 @@ internal class BeagleView(
         } else {
             removeAllViewsInLayout()
             addServerDrivenComponent(component, rootView)
+            renderCompletedListener?.onLoadCompleted()
         }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/utils/ViewExtensionsKtTest.kt
@@ -37,6 +37,7 @@ import br.com.zup.beagle.setup.DesignSystem
 import br.com.zup.beagle.testutil.RandomData
 import br.com.zup.beagle.view.BeagleButtonView
 import br.com.zup.beagle.view.BeagleView
+import br.com.zup.beagle.view.RenderCompletedListener
 import br.com.zup.beagle.view.ScreenRequest
 import br.com.zup.beagle.view.StateChangedListener
 import br.com.zup.beagle.view.ViewFactory
@@ -56,7 +57,6 @@ import org.junit.Test
 import kotlin.test.assertFails
 
 private val URL = RandomData.httpUrl()
-private const val ERROR_MESSAGE = "Did you miss to call loadView()?"
 private val screenRequest = ScreenRequest(URL)
 
 class ViewExtensionsKtTest : BaseTest() {
@@ -69,7 +69,7 @@ class ViewExtensionsKtTest : BaseTest() {
     private lateinit var activity: AppCompatActivity
     @MockK
     private lateinit var viewFactory: ViewFactory
-    @MockK
+    @RelaxedMockK
     private lateinit var beagleView: BeagleView
     @MockK
     private lateinit var stateChangedListener: StateChangedListener
@@ -117,49 +117,50 @@ class ViewExtensionsKtTest : BaseTest() {
 
     @Test
     fun loadView_should_create_BeagleView_and_call_loadView_with_fragment() {
+        // When
         viewGroup.loadView(fragment, screenRequest)
 
-        assertEquals(beagleView, viewSlot.captured)
+        // Then
         verify { viewFactory.makeBeagleView(activity) }
         verify { beagleView.loadView(any<FragmentRootView>(), screenRequest) }
     }
 
     @Test
     fun loadView_should_create_BeagleView_and_call_loadView_with_activity() {
+        // When
         viewGroup.loadView(activity, screenRequest)
 
-        assertEquals(beagleView, viewSlot.captured)
+        // Then
         verify { viewFactory.makeBeagleView(activity) }
         verify { beagleView.loadView(any<ActivityRootView>(), screenRequest) }
     }
 
     @Test
-    fun setBeagleStateChangedListener_should_throws_exception_when_no_child_has_found() {
+    fun `loadView should addView when load complete`() {
         // Given
-        every { viewGroup.childCount } returns 0
+        val slot = slot<RenderCompletedListener>()
+        every { beagleView.renderCompletedListener = capture(slot) } just Runs
 
-        // When Then
-        assertFails(ERROR_MESSAGE) { viewGroup.setBeagleStateChangedListener(stateChangedListener) }
+        // When
+        viewGroup.loadView(fragment, screenRequest)
+        slot.captured.onLoadCompleted()
+
+        // Then
+        assertEquals(beagleView, viewSlot.captured)
+        verify (exactly = once()) { viewGroup.addView(beagleView) }
     }
 
     @Test
-    fun setBeagleStateChangedListener_should_throws_exception_when_no_BeagleView_has_found() {
+    fun `loadView should set stateChangedListener to beagleView`() {
         // Given
-        every { viewGroup.childCount } returns 1
-        every { viewGroup.getChildAt(any()) } returns mockk()
+        val slot = slot<StateChangedListener>()
+        every { beagleView.stateChangedListener = capture(slot) } just Runs
 
-        // When Then
-        assertFails(ERROR_MESSAGE) { viewGroup.setBeagleStateChangedListener(stateChangedListener) }
-    }
+        // When
+        viewGroup.loadView(fragment, screenRequest, stateChangedListener)
 
-    @Test
-    fun setBeagleStateChangedListener_should_set_stateChangedListener_to_BeagleView() {
-        // Given
-        every { viewGroup.childCount } returns 1
-        every { viewGroup.getChildAt(any()) } returns beagleView
-
-        // When Then
-        assertFails(ERROR_MESSAGE) { viewGroup.setBeagleStateChangedListener(stateChangedListener) }
+        // Then
+        assertEquals(slot.captured, stateChangedListener)
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/utils/ViewExtensionsKtTest.kt
@@ -17,8 +17,6 @@
 package br.com.zup.beagle.utils
 
 import android.app.Activity
-import android.content.res.TypedArray
-import android.graphics.drawable.Drawable
 import android.os.IBinder
 import android.view.View
 import android.view.ViewGroup
@@ -28,7 +26,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.TextViewCompat
 import androidx.fragment.app.Fragment
 import br.com.zup.beagle.BaseTest
-import br.com.zup.beagle.engine.mapper.ViewMapper
 import br.com.zup.beagle.engine.renderer.ActivityRootView
 import br.com.zup.beagle.engine.renderer.FragmentRootView
 import br.com.zup.beagle.extensions.once
@@ -37,24 +34,21 @@ import br.com.zup.beagle.setup.DesignSystem
 import br.com.zup.beagle.testutil.RandomData
 import br.com.zup.beagle.view.BeagleButtonView
 import br.com.zup.beagle.view.BeagleView
-import br.com.zup.beagle.view.RenderCompletedListener
+import br.com.zup.beagle.view.OnLoadCompleted
+import br.com.zup.beagle.view.OnStateChanged
 import br.com.zup.beagle.view.ScreenRequest
-import br.com.zup.beagle.view.StateChangedListener
 import br.com.zup.beagle.view.ViewFactory
-import br.com.zup.beagle.widget.ui.Button
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.just
-import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import kotlin.test.assertFails
 
 private val URL = RandomData.httpUrl()
 private val screenRequest = ScreenRequest(URL)
@@ -72,8 +66,8 @@ class ViewExtensionsKtTest : BaseTest() {
     @RelaxedMockK
     private lateinit var beagleView: BeagleView
     @MockK
-    private lateinit var stateChangedListener: StateChangedListener
-    @MockK(relaxed = true)
+    private lateinit var onStateChanged: OnStateChanged
+    @RelaxedMockK
     private lateinit var inputMethodManager: InputMethodManager
     @MockK
     private lateinit var iBinder: IBinder
@@ -138,12 +132,12 @@ class ViewExtensionsKtTest : BaseTest() {
     @Test
     fun `loadView should addView when load complete`() {
         // Given
-        val slot = slot<RenderCompletedListener>()
-        every { beagleView.renderCompletedListener = capture(slot) } just Runs
+        val slot = slot<OnLoadCompleted>()
+        every { beagleView.loadCompletedListener = capture(slot) } just Runs
 
         // When
         viewGroup.loadView(fragment, screenRequest)
-        slot.captured.onLoadCompleted()
+        slot.captured.invoke()
 
         // Then
         assertEquals(beagleView, viewSlot.captured)
@@ -153,14 +147,14 @@ class ViewExtensionsKtTest : BaseTest() {
     @Test
     fun `loadView should set stateChangedListener to beagleView`() {
         // Given
-        val slot = slot<StateChangedListener>()
+        val slot = slot<OnStateChanged>()
         every { beagleView.stateChangedListener = capture(slot) } just Runs
 
         // When
-        viewGroup.loadView(fragment, screenRequest, stateChangedListener)
+        viewGroup.loadView(fragment, screenRequest, onStateChanged)
 
         // Then
-        assertEquals(slot.captured, stateChangedListener)
+        assertEquals(slot.captured, onStateChanged)
     }
 
     @Test


### PR DESCRIPTION
**Description**
When the extension function `loadView` was called from a viewgroup with `wrap_content` height, Beagle did not render the content.

**Issue**
Fix #217 

BREAKING CHANGE: The extension function `setBeagleStateChangedListener` has been incorporated into `loadView`