### PR TITLE
feat: Expose fragment transition API

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/view/BeagleActivity.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/view/BeagleActivity.kt
@@ -21,9 +21,12 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.WindowManager
+import androidx.annotation.AnimRes
+import androidx.annotation.AnimatorRes
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.R
@@ -113,6 +116,13 @@ abstract class BeagleActivity : AppCompatActivity() {
 
     abstract fun onServerDrivenContainerStateChanged(state: ServerDrivenState)
 
+    open fun getScreenTransitionAnimation() = ScreenTransitionAnimation(
+        R.anim.slide_from_right,
+        R.anim.none_animation,
+        R.anim.none_animation,
+        R.anim.slide_to_right
+    )
+
     override fun onCreate(savedInstanceState: Bundle?) {
         BeagleEnvironment.beagleSdk.designSystem?.let {
             setTheme(it.theme())
@@ -163,15 +173,18 @@ abstract class BeagleActivity : AppCompatActivity() {
     }
 
     private fun showScreen(screenName: String?, component: ServerDrivenComponent) {
-        val transaction = supportFragmentManager
+        val transition = getScreenTransitionAnimation()
+
+        supportFragmentManager
             .beginTransaction()
             .setCustomAnimations(
-                R.anim.slide_from_right, R.anim.none_animation,
-                R.anim.none_animation, R.anim.slide_to_right
+                transition.enter,
+                transition.exit,
+                transition.popEnter,
+                transition.popExit
             )
             .replace(getServerDrivenContainerId(), BeagleFragment.newInstance(component))
-
-        transaction.addToBackStack(screenName)
-        transaction.commit()
+            .addToBackStack(screenName)
+            .commit()
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/view/BeagleActivity.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/view/BeagleActivity.kt
@@ -21,12 +21,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.WindowManager
-import androidx.annotation.AnimRes
-import androidx.annotation.AnimatorRes
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.R
@@ -116,7 +113,7 @@ abstract class BeagleActivity : AppCompatActivity() {
 
     abstract fun onServerDrivenContainerStateChanged(state: ServerDrivenState)
 
-    open fun getScreenTransitionAnimation() = ScreenTransitionAnimation(
+    open fun getFragmentTransitionAnimation() = FragmentTransitionAnimation(
         R.anim.slide_from_right,
         R.anim.none_animation,
         R.anim.none_animation,
@@ -173,7 +170,7 @@ abstract class BeagleActivity : AppCompatActivity() {
     }
 
     private fun showScreen(screenName: String?, component: ServerDrivenComponent) {
-        val transition = getScreenTransitionAnimation()
+        val transition = getFragmentTransitionAnimation()
 
         supportFragmentManager
             .beginTransaction()

--- a/android/beagle/src/main/java/br/com/zup/beagle/view/FragmentTransitionAnimation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/view/FragmentTransitionAnimation.kt
@@ -19,7 +19,7 @@ package br.com.zup.beagle.view
 import androidx.annotation.AnimRes
 import androidx.annotation.AnimatorRes
 
-data class ScreenTransitionAnimation(
+data class FragmentTransitionAnimation(
     @AnimatorRes
     @AnimRes
     val enter: Int,

--- a/android/beagle/src/main/java/br/com/zup/beagle/view/ScreenTransitionAnimation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/view/ScreenTransitionAnimation.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.view
+
+import androidx.annotation.AnimRes
+import androidx.annotation.AnimatorRes
+
+data class ScreenTransitionAnimation(
+    @AnimatorRes
+    @AnimRes
+    val enter: Int,
+    @AnimatorRes
+    @AnimRes
+    val exit: Int,
+    @AnimatorRes
+    @AnimRes
+    val popEnter: Int,
+    @AnimatorRes
+    @AnimRes
+    val popExit: Int
+)

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/activities/SampleServerDrivenActivity.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/activities/SampleServerDrivenActivity.kt
@@ -20,9 +20,11 @@ import android.os.Bundle
 import android.view.View
 import android.widget.ProgressBar
 import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.FragmentTransaction
 import br.com.zup.beagle.annotation.BeagleComponent
 import br.com.zup.beagle.sample.R
 import br.com.zup.beagle.view.BeagleActivity
+import br.com.zup.beagle.view.ScreenTransitionAnimation
 import br.com.zup.beagle.view.ServerDrivenState
 import com.google.android.material.snackbar.Snackbar
 
@@ -50,4 +52,11 @@ class SampleServerDrivenActivity : BeagleActivity() {
             Snackbar.make(findViewById(android.R.id.content), "Error", Snackbar.LENGTH_LONG).show()
         }
     }
+
+    override fun getScreenTransitionAnimation() = ScreenTransitionAnimation(
+        br.com.zup.beagle.R.anim.slide_from_right,
+        br.com.zup.beagle.R.anim.none_animation,
+        br.com.zup.beagle.R.anim.none_animation,
+        br.com.zup.beagle.R.anim.slide_to_right
+    )
 }

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/activities/SampleServerDrivenActivity.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/activities/SampleServerDrivenActivity.kt
@@ -20,11 +20,10 @@ import android.os.Bundle
 import android.view.View
 import android.widget.ProgressBar
 import androidx.appcompat.widget.Toolbar
-import androidx.fragment.app.FragmentTransaction
 import br.com.zup.beagle.annotation.BeagleComponent
 import br.com.zup.beagle.sample.R
 import br.com.zup.beagle.view.BeagleActivity
-import br.com.zup.beagle.view.ScreenTransitionAnimation
+import br.com.zup.beagle.view.FragmentTransitionAnimation
 import br.com.zup.beagle.view.ServerDrivenState
 import com.google.android.material.snackbar.Snackbar
 
@@ -53,7 +52,7 @@ class SampleServerDrivenActivity : BeagleActivity() {
         }
     }
 
-    override fun getScreenTransitionAnimation() = ScreenTransitionAnimation(
+    override fun getFragmentTransitionAnimation() = FragmentTransitionAnimation(
         br.com.zup.beagle.R.anim.slide_from_right,
         br.com.zup.beagle.R.anim.none_animation,
         br.com.zup.beagle.R.anim.none_animation,


### PR DESCRIPTION
### Problem
We don't have a way to customize the fragment transition when new screen navigation happens.

### Solution
I create a new method that could be overridden from `BeagleActivity` called `fun getScreenTransitionAnimation(): ScreenTransitionAnimation` and now the developer can override this method and customize the fragment transition.

Fixes: #142 