### PR TITLE
feat: resgister custom actions

### DIFF
--- a/iOS/Schema/BeagleSchema.xcodeproj/project.pbxproj
+++ b/iOS/Schema/BeagleSchema.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		C864D2D7247C240200E7A1F9 /* ShowNativeDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D285247C240200E7A1F9 /* ShowNativeDialog.swift */; };
 		C864D2D8247C240200E7A1F9 /* FormRemoteAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D287247C240200E7A1F9 /* FormRemoteAction.swift */; };
 		C864D2D9247C240200E7A1F9 /* FormValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D289247C240200E7A1F9 /* FormValidation.swift */; };
-		C864D2DA247C240200E7A1F9 /* CustomAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D28B247C240200E7A1F9 /* CustomAction.swift */; };
+		C864D2DA247C240200E7A1F9 /* FormLocalAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D28B247C240200E7A1F9 /* FormLocalAction.swift */; };
 		C864D2DB247C240200E7A1F9 /* RawAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D28C247C240200E7A1F9 /* RawAction.swift */; };
 		C864D2DC247C240200E7A1F9 /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D28E247C240200E7A1F9 /* Accessibility.swift */; };
 		C864D2DD247C240200E7A1F9 /* UnitValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D290247C240200E7A1F9 /* UnitValue.swift */; };
@@ -179,7 +179,7 @@
 		C864D285247C240200E7A1F9 /* ShowNativeDialog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShowNativeDialog.swift; sourceTree = "<group>"; };
 		C864D287247C240200E7A1F9 /* FormRemoteAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormRemoteAction.swift; sourceTree = "<group>"; };
 		C864D289247C240200E7A1F9 /* FormValidation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormValidation.swift; sourceTree = "<group>"; };
-		C864D28B247C240200E7A1F9 /* CustomAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomAction.swift; sourceTree = "<group>"; };
+		C864D28B247C240200E7A1F9 /* FormLocalAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormLocalAction.swift; sourceTree = "<group>"; };
 		C864D28C247C240200E7A1F9 /* RawAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawAction.swift; sourceTree = "<group>"; };
 		C864D28E247C240200E7A1F9 /* Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
 		C864D290247C240200E7A1F9 /* UnitValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitValue.swift; sourceTree = "<group>"; };
@@ -798,7 +798,7 @@
 		C8BB30B924870422002DD3C1 /* Types */ = {
 			isa = PBXGroup;
 			children = (
-				C864D28B247C240200E7A1F9 /* CustomAction.swift */,
+				C864D28B247C240200E7A1F9 /* FormLocalAction.swift */,
 				C864D287247C240200E7A1F9 /* FormRemoteAction.swift */,
 				C864D289247C240200E7A1F9 /* FormValidation.swift */,
 				C864D281247C240200E7A1F9 /* Navigate */,
@@ -1184,7 +1184,7 @@
 			files = (
 				C864D2A7247C240200E7A1F9 /* FormInputComponent.swift in Sources */,
 				C864D2E0247C240200E7A1F9 /* Flex.swift in Sources */,
-				C864D2DA247C240200E7A1F9 /* CustomAction.swift in Sources */,
+				C864D2DA247C240200E7A1F9 /* FormLocalAction.swift in Sources */,
 				C864D2CA247C240200E7A1F9 /* Image.swift in Sources */,
 				C864D2BB247C240200E7A1F9 /* AutoDecodable.generated.swift in Sources */,
 				C89E0C4A2492AFEB00005FCF /* Style.swift in Sources */,

--- a/iOS/Schema/Sources/Action/Types/FormLocalAction.swift
+++ b/iOS/Schema/Sources/Action/Types/FormLocalAction.swift
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-import XCTest
-@testable import BeagleUI
-import BeagleSchema
+import Foundation
 
-final class CustomActionHandlerTests: XCTestCase {
+/// An action to handle form submit locally
+public struct FormLocalAction: RawAction, AutoInitiable {
     
-    func test_whenHandleCustomAction_shouldCallHandler() {
-        // Given
-        let actionName = "action-name"
-        let action = CustomAction(name: actionName, data: [:])
-        let sut = CustomActionHandling()
-        var didHandleActioin = false
-        sut[actionName] = { _, _, _ in
-            didHandleActioin = true
-        }
-        
-        // When
-        sut.handle(action: action, controller: BeagleControllerStub()) { _ in }
-        
-        // Then
-        XCTAssertTrue(didHandleActioin)
+    public let name: String
+    public let data: [String: String]
+
+// sourcery:inline:auto:FormLocalAction.Init
+    public init(
+        name: String,
+        data: [String: String]
+    ) {
+        self.name = name
+        self.data = data
     }
+// sourcery:end
 }

--- a/iOS/Schema/Sources/Decoding/ComponentDecoder.swift
+++ b/iOS/Schema/Sources/Decoding/ComponentDecoder.swift
@@ -20,6 +20,7 @@ public protocol ComponentDecoding {
     typealias Error = ComponentDecodingError
     
     func register<T: RawComponent>(_ type: T.Type, for typeName: String)
+    func register<A: RawAction>(_ type: A.Type, for typeName: String)
     func componentType(forType type: String) -> Decodable.Type?
     func actionType(forType type: String) -> Decodable.Type?
     func decodeComponent(from data: Data) throws -> RawComponent
@@ -52,6 +53,10 @@ final public class ComponentDecoder: ComponentDecoding {
     
     public func register<T: RawComponent>(_ type: T.Type, for typeName: String) {
         registerComponent(type, key: key(name: typeName, namespace: .custom))
+    }
+    
+    public func register<A: RawAction>(_ type: A.Type, for typeName: String) {
+        registerAction(type, key: key(name: typeName, namespace: .custom))
     }
     
     public func componentType(forType type: String) -> Decodable.Type? {
@@ -109,7 +114,7 @@ final public class ComponentDecoder: ComponentDecoding {
         registerAction(Navigate.self, key: key(name: "PopToView", namespace: .beagle))
         registerAction(FormValidation.self, key: key(name: "FormValidation", namespace: .beagle))
         registerAction(ShowNativeDialog.self, key: key(name: "ShowNativeDialog", namespace: .beagle))
-        registerAction(CustomAction.self, key: key(name: "CustomAction", namespace: .beagle))
+        registerAction(FormLocalAction.self, key: key(name: "FormLocalAction", namespace: .beagle))
         registerAction(FormRemoteAction.self, key: key(name: "FormRemoteAction", namespace: .beagle))
     }
     

--- a/iOS/Schema/Sources/Decoding/Tests/ComponentDecoderTests.swift
+++ b/iOS/Schema/Sources/Decoding/Tests/ComponentDecoderTests.swift
@@ -97,6 +97,26 @@ public final class ComponentDecoderTests: XCTestCase {
             XCTFail("decoding failed"); return
         }
     }
+    
+    func testRegisterAndDecodeCustomAction() throws {
+        let data = """
+        {
+            "_beagleAction_":"custom:testcustomaction",
+            "value": 42
+        }
+        """.data(using: .utf8)!
+
+        sut.register(TestAction.self, for: "TestCustomAction")
+        let action = try sut.decodeAction(from: data)
+        let testAction = action as? TestAction
+
+        XCTAssertNotNil(testAction)
+        XCTAssertEqual(testAction?.value, 42)
+    }
+
+    private class TestAction: RawAction {
+        let value: Int
+    }
 }
 
 // MARK: - Testing Helpers

--- a/iOS/Schema/Sources/Decoding/Tests/__Snapshots__/ComponentDecoderTests/testIfAllActionsAreBeingRegistered.1.txt
+++ b/iOS/Schema/Sources/Decoding/Tests/__Snapshots__/ComponentDecoderTests/testIfAllActionsAreBeingRegistered.1.txt
@@ -1,7 +1,7 @@
 ▿ 13 key/value pairs
   ▿ (2 elements)
-    - key: "beagle:customaction"
-    - value: CustomAction
+    - key: "beagle:formlocalaction"
+    - value: FormLocalAction
   ▿ (2 elements)
     - key: "beagle:formremoteaction"
     - value: FormRemoteAction

--- a/iOS/Schema/Sources/Decoding/Tests/__Snapshots__/ComponentDecoderTests/testIfAllDecodersAreBeingRegistered.1.txt
+++ b/iOS/Schema/Sources/Decoding/Tests/__Snapshots__/ComponentDecoderTests/testIfAllDecodersAreBeingRegistered.1.txt
@@ -1,7 +1,7 @@
 ▿ 24 key/value pairs
   ▿ (2 elements)
-    - key: "beagle:action:customaction"
-    - value: CustomAction
+    - key: "beagle:action:formlocalaction"
+    - value: FormLocalAction
   ▿ (2 elements)
     - key: "beagle:action:formremoteaction"
     - value: FormRemoteAction

--- a/iOS/Sources/BeagleUI/BeagleUI.xcodeproj/project.pbxproj
+++ b/iOS/Sources/BeagleUI/BeagleUI.xcodeproj/project.pbxproj
@@ -55,14 +55,14 @@
 		98B7D95623DB2722002622AC /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B7D95523DB2722002622AC /* Observable.swift */; };
 		98FC964C23EA518600A8CEC8 /* ObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FC964B23EA518600A8CEC8 /* ObservableTests.swift */; };
 		A024CF0F24991E42009BB92D /* UIView+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = A024CF0E24991E41009BB92D /* UIView+Style.swift */; };
-		A040DBBC2497E259000F3213 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = A040DBBB2497E259000F3213 /* Action.swift */; };
 		A024CF1124991E4F009BB92D /* UIView+StyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A024CF1024991E4F009BB92D /* UIView+StyleTests.swift */; };
+		A040DBBC2497E259000F3213 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = A040DBBB2497E259000F3213 /* Action.swift */; };
 		A04B19FA23ECA3F7007B4279 /* Screen+Renderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04B19F923ECA3F7007B4279 /* Screen+Renderable.swift */; };
-		A05C74D02497F2BF009DBB66 /* CustomAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74CF2497F2BF009DBB66 /* CustomAction.swift */; };
+		A05C74D02497F2BF009DBB66 /* FormLocalAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74CF2497F2BF009DBB66 /* FormLocalAction.swift */; };
 		A05C74D22497F430009DBB66 /* FormValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74D12497F430009DBB66 /* FormValidation.swift */; };
 		A05C74D42497F4AA009DBB66 /* ShowNativeDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74D32497F4AA009DBB66 /* ShowNativeDialog.swift */; };
 		A05C74D62497F524009DBB66 /* Navigate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74D52497F524009DBB66 /* Navigate.swift */; };
-		A05C74D924980642009DBB66 /* CustomActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74D824980642009DBB66 /* CustomActionTests.swift */; };
+		A05C74D924980642009DBB66 /* FormLocalActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74D824980642009DBB66 /* FormLocalActionTests.swift */; };
 		A05C74DB2498081B009DBB66 /* ShowNativeDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74DA2498081B009DBB66 /* ShowNativeDialogTests.swift */; };
 		A05C74DD2498162B009DBB66 /* FormValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C74DC2498162B009DBB66 /* FormValidationTests.swift */; };
 		A068234C238430C500CEE57A /* ValidatorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A068234B238430C500CEE57A /* ValidatorProvider.swift */; };
@@ -70,8 +70,8 @@
 		A0D608D82448DF8700F7D851 /* ScreenType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D608D52448DF8600F7D851 /* ScreenType.swift */; };
 		A0D608D92448DF8700F7D851 /* ScreenController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D608D62448DF8700F7D851 /* ScreenController.swift */; };
 		A0D608DA2448DF8700F7D851 /* BeagleNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D608D72448DF8700F7D851 /* BeagleNavigationController.swift */; };
-		A0EF0AAC238811AA0019BE83 /* CustomActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EF0AAB238811AA0019BE83 /* CustomActionHandler.swift */; };
-		A0EF0AB9238877460019BE83 /* CustomActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EF0AB8238877460019BE83 /* CustomActionHandlerTests.swift */; };
+		A0EF0AAC238811AA0019BE83 /* LocalFormHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EF0AAB238811AA0019BE83 /* LocalFormHandler.swift */; };
+		A0EF0AB9238877460019BE83 /* LocalFormHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EF0AB8238877460019BE83 /* LocalFormHandlerTests.swift */; };
 		A0EF0ABE238B05A10019BE83 /* ValidatorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EF0ABD238B05A10019BE83 /* ValidatorHandlerTests.swift */; };
 		A0EF0AC2238B0CEC0019BE83 /* SubmitFormGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EF0AC1238B0CEC0019BE83 /* SubmitFormGestureRecognizer.swift */; };
 		A0F454832379701800B146A1 /* TouchableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F454822379701800B146A1 /* TouchableTests.swift */; };
@@ -274,14 +274,14 @@
 		98B7D95523DB2722002622AC /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		98FC964B23EA518600A8CEC8 /* ObservableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableTests.swift; sourceTree = "<group>"; };
 		A024CF0E24991E41009BB92D /* UIView+Style.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Style.swift"; sourceTree = "<group>"; };
-		A040DBBB2497E259000F3213 /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		A024CF1024991E4F009BB92D /* UIView+StyleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+StyleTests.swift"; sourceTree = "<group>"; };
+		A040DBBB2497E259000F3213 /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		A04B19F923ECA3F7007B4279 /* Screen+Renderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Screen+Renderable.swift"; sourceTree = "<group>"; };
-		A05C74CF2497F2BF009DBB66 /* CustomAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAction.swift; sourceTree = "<group>"; };
+		A05C74CF2497F2BF009DBB66 /* FormLocalAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormLocalAction.swift; sourceTree = "<group>"; };
 		A05C74D12497F430009DBB66 /* FormValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormValidation.swift; sourceTree = "<group>"; };
 		A05C74D32497F4AA009DBB66 /* ShowNativeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowNativeDialog.swift; sourceTree = "<group>"; };
 		A05C74D52497F524009DBB66 /* Navigate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigate.swift; sourceTree = "<group>"; };
-		A05C74D824980642009DBB66 /* CustomActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionTests.swift; sourceTree = "<group>"; };
+		A05C74D824980642009DBB66 /* FormLocalActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormLocalActionTests.swift; sourceTree = "<group>"; };
 		A05C74DA2498081B009DBB66 /* ShowNativeDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowNativeDialogTests.swift; sourceTree = "<group>"; };
 		A05C74DC2498162B009DBB66 /* FormValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormValidationTests.swift; sourceTree = "<group>"; };
 		A068234B238430C500CEE57A /* ValidatorProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatorProvider.swift; sourceTree = "<group>"; };
@@ -289,8 +289,8 @@
 		A0D608D52448DF8600F7D851 /* ScreenType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenType.swift; sourceTree = "<group>"; };
 		A0D608D62448DF8700F7D851 /* ScreenController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenController.swift; sourceTree = "<group>"; };
 		A0D608D72448DF8700F7D851 /* BeagleNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeagleNavigationController.swift; sourceTree = "<group>"; };
-		A0EF0AAB238811AA0019BE83 /* CustomActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionHandler.swift; sourceTree = "<group>"; };
-		A0EF0AB8238877460019BE83 /* CustomActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionHandlerTests.swift; sourceTree = "<group>"; };
+		A0EF0AAB238811AA0019BE83 /* LocalFormHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFormHandler.swift; sourceTree = "<group>"; };
+		A0EF0AB8238877460019BE83 /* LocalFormHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFormHandlerTests.swift; sourceTree = "<group>"; };
 		A0EF0ABD238B05A10019BE83 /* ValidatorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatorHandlerTests.swift; sourceTree = "<group>"; };
 		A0EF0AC1238B0CEC0019BE83 /* SubmitFormGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitFormGestureRecognizer.swift; sourceTree = "<group>"; };
 		A0F454822379701800B146A1 /* TouchableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchableTests.swift; sourceTree = "<group>"; };
@@ -704,7 +704,7 @@
 		A05C74CE2497F29E009DBB66 /* Types */ = {
 			isa = PBXGroup;
 			children = (
-				A05C74CF2497F2BF009DBB66 /* CustomAction.swift */,
+				A05C74CF2497F2BF009DBB66 /* FormLocalAction.swift */,
 				A05C74D12497F430009DBB66 /* FormValidation.swift */,
 				A05C74D32497F4AA009DBB66 /* ShowNativeDialog.swift */,
 				A05C74D52497F524009DBB66 /* Navigate.swift */,
@@ -716,7 +716,7 @@
 		A05C74D72498062C009DBB66 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				A05C74D824980642009DBB66 /* CustomActionTests.swift */,
+				A05C74D824980642009DBB66 /* FormLocalActionTests.swift */,
 				A05C74DA2498081B009DBB66 /* ShowNativeDialogTests.swift */,
 				A05C74DC2498162B009DBB66 /* FormValidationTests.swift */,
 			);
@@ -727,7 +727,7 @@
 			isa = PBXGroup;
 			children = (
 				A040DBBB2497E259000F3213 /* Action.swift */,
-				A0EF0AAB238811AA0019BE83 /* CustomActionHandler.swift */,
+				A0EF0AAB238811AA0019BE83 /* LocalFormHandler.swift */,
 				E5223779237C3C5500E555BB /* Touchable+Renderable.swift */,
 				A05C74CE2497F29E009DBB66 /* Types */,
 				C829CEAA23B15F12001B7225 /* Tests */,
@@ -1133,7 +1133,7 @@
 			isa = PBXGroup;
 			children = (
 				9327116623F1F2EF00778B56 /* __Snapshots__ */,
-				A0EF0AB8238877460019BE83 /* CustomActionHandlerTests.swift */,
+				A0EF0AB8238877460019BE83 /* LocalFormHandlerTests.swift */,
 				A0F454822379701800B146A1 /* TouchableTests.swift */,
 			);
 			path = Tests;
@@ -1689,7 +1689,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A0EF0AAC238811AA0019BE83 /* CustomActionHandler.swift in Sources */,
+				A0EF0AAC238811AA0019BE83 /* LocalFormHandler.swift in Sources */,
 				C08D4E452485804400AAAC0A /* OnStateUpdatable.swift in Sources */,
 				57A809D5243E5F0C0034D180 /* CacheDiskManager.swift in Sources */,
 				C85D9BA1238701E60075B6C0 /* PageViewUIComponent.swift in Sources */,
@@ -1732,7 +1732,7 @@
 				931B6E302375BA7400DE73FD /* Theme.swift in Sources */,
 				93B9744F23A2833600B0D1CF /* NetworkClient.swift in Sources */,
 				A05C74D62497F524009DBB66 /* Navigate.swift in Sources */,
-				A05C74D02497F2BF009DBB66 /* CustomAction.swift in Sources */,
+				A05C74D02497F2BF009DBB66 /* FormLocalAction.swift in Sources */,
 				5754314923F207F000EF0E5A /* CacheLRU.swift in Sources */,
 				E73107BC23A971B000188B3D /* BeaglePrefetchHelper.swift in Sources */,
 				C85688BC2433C4A800DD8B60 /* BeagleLogger.swift in Sources */,
@@ -1811,18 +1811,17 @@
 				C0E569152476F026003D413F /* BeaglePrefetchHelpingSpy.swift in Sources */,
 				983E8C992396DFC90018C6CA /* TabViewUIComponentTests.swift in Sources */,
 				A024CF1124991E4F009BB92D /* UIView+StyleTests.swift in Sources */,
-				7C9999532448A2E800D77F07 /* LazyLoadManagerTests.swift in Sources */,
 				7C9999552448A38000D77F07 /* FormManagerTests.swift in Sources */,
 				C08D4E2124857B5A00AAAC0A /* ScreenComponentTests.swift in Sources */,
 				57CBF5AA243F9EF300873997 /* CacheManagerDefaultTests.swift in Sources */,
 				C0291886247C5E4000C3AA13 /* CustomPageIndicator.swift in Sources */,
-				A0EF0AB9238877460019BE83 /* CustomActionHandlerTests.swift in Sources */,
+				A0EF0AB9238877460019BE83 /* LocalFormHandlerTests.swift in Sources */,
 				C8F953162395960200615CF0 /* PageViewUIComponentTests.swift in Sources */,
 				E52236C623745CDC00E555BB /* NSObjectExtensionTests.swift in Sources */,
 				A0F4549A237C1B0F00B146A1 /* BeagleNavigatorTests.swift in Sources */,
 				C08D4E76248593A500AAAC0A /* AccessibilityTests.swift in Sources */,
 				E5A6F4AD2358A76F008906F8 /* XCTestCase+FatalError.swift in Sources */,
-				A05C74D924980642009DBB66 /* CustomActionTests.swift in Sources */,
+				A05C74D924980642009DBB66 /* FormLocalActionTests.swift in Sources */,
 				C86D0CC323B25AE3009CE0EB /* LoadingViewTests.swift in Sources */,
 				C08D4E2A24857BB400AAAC0A /* ContainerTests.swift in Sources */,
 				9800ACFF2455D09B0030109F /* UrlBuilderTests.swift in Sources */,

--- a/iOS/Sources/BeagleUI/Sources/Action/LocalFormHandler.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/LocalFormHandler.swift
@@ -17,24 +17,24 @@
 import Foundation
 import BeagleSchema
 
-/// Your application can define CustomActions, and Beagle will ask to the CustomActionHandler defined by your application
-/// to handle what the custom actions will do.
-public protocol CustomActionHandler {
+/// Your application can handle the form submit by its own using a `FormLocalAction`.
+/// The `LocalFormHandler` defined by your application will be used to achieve it.
+public protocol LocalFormHandler {
 
     /// here you should see which custom action you are receiving, and execute its logic.
-    func handle(action: CustomAction, controller: BeagleController, listener: @escaping Listener)
+    func handle(action: FormLocalAction, controller: BeagleController, listener: @escaping Listener)
 
     /// use it to inform Beagle about the on going execution
-    typealias Listener = (CustomActionState) -> Void
+    typealias Listener = (FormActionState) -> Void
 }
 
-public protocol DependencyCustomActionHandler {
-    var customActionHandler: CustomActionHandler? { get }
+public protocol DependencyLocalFormHandler {
+    var localFormHandler: LocalFormHandler? { get }
 }
 
-public final class CustomActionHandling: CustomActionHandler {
+public final class LocalFormHandling: LocalFormHandler {
     
-    public typealias Handler = (BeagleController, CustomAction, @escaping Listener) -> Void
+    public typealias Handler = (BeagleController, FormLocalAction, @escaping Listener) -> Void
     
     private var handlers: [String: Handler]
     
@@ -42,7 +42,7 @@ public final class CustomActionHandling: CustomActionHandler {
         self.handlers = handlers
     }
     
-    public func handle(action: CustomAction, controller: BeagleController, listener: @escaping Listener) {
+    public func handle(action: FormLocalAction, controller: BeagleController, listener: @escaping Listener) {
         self[action.name]?(controller, action, listener)
     }
     
@@ -56,7 +56,7 @@ public final class CustomActionHandling: CustomActionHandler {
     }
 }
 
-public enum CustomActionState {
+public enum FormActionState {
     case start
     case error(Error)
     case success(action: Action)

--- a/iOS/Sources/BeagleUI/Sources/Action/Tests/LocalFormHandlerTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Tests/LocalFormHandlerTests.swift
@@ -14,21 +14,26 @@
  * limitations under the License.
  */
 
-import Foundation
+import XCTest
+@testable import BeagleUI
+import BeagleSchema
 
-/// A custom action to be implemented by the application
-public struct CustomAction: RawAction, AutoInitiable {
+final class LocalFormHandlerTests: XCTestCase {
     
-    public let name: String
-    public let data: [String: String]
-
-// sourcery:inline:auto:CustomAction.Init
-    public init(
-        name: String,
-        data: [String: String]
-    ) {
-        self.name = name
-        self.data = data
+    func test_whenHandleFormLocalAction_shouldCallHandler() {
+        // Given
+        let actionName = "action-name"
+        let action = FormLocalAction(name: actionName, data: [:])
+        let sut = LocalFormHandling()
+        var didHandleActioin = false
+        sut[actionName] = { _, _, _ in
+            didHandleActioin = true
+        }
+        
+        // When
+        sut.handle(action: action, controller: BeagleControllerStub()) { _ in }
+        
+        // Then
+        XCTAssertTrue(didHandleActioin)
     }
-// sourcery:end
 }

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/FormLocalAction.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/FormLocalAction.swift
@@ -16,9 +16,9 @@
 
 import BeagleSchema
 
-extension CustomAction: Action {
+extension FormLocalAction: Action {
     public func execute(controller: BeagleController, sender: Any) {
-        controller.dependencies.customActionHandler?.handle(action: self, controller: controller) {
+        controller.dependencies.localFormHandler?.handle(action: self, controller: controller) {
             [weak controller] result in guard let controller = controller else { return }
             switch result {
             case .start:

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Tests/FormLocalActionTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Tests/FormLocalActionTests.swift
@@ -19,32 +19,32 @@ import SnapshotTesting
 import BeagleSchema
 @testable import BeagleUI
 
-final class CustomActionTests: XCTestCase {
+final class FormLocalActionTests: XCTestCase {
 
-    func test_whenExecuteCustomAction_shouldUseActionHandler() {
+    func test_whenExecuteFormLocalAction_shouldUseLocalFormHandler() {
         // Given
-        let sut = CustomAction(name: "custom-action", data: [:])
-        let actionSpy = CustomActionHandlerSpy()
+        let sut = FormLocalAction(name: "custom-action", data: [:])
+        let actionSpy = LocalFormHandlerSpy()
         let controller = BeagleControllerStub()
-        controller.dependencies = BeagleScreenDependencies(customActionHandler: actionSpy)
-
+        controller.dependencies = BeagleScreenDependencies(localFormHandler: actionSpy)
+        
         // When
         sut.execute(controller: controller, sender: self)
-
+        
         // Then
         XCTAssertEqual(actionSpy.actionsHandledCount, 1)
     }
-
-    func test_whenExecuteCustomAction_shouldListenToStateChanges() {
+    
+    func test_whenExecuteFormLocalAction_shouldListenToStateChanges() {
         // Given
         let name = "name"
-        let error = NSError(domain: "tests", code: 1, description: "CusomAction")
-        let customAction = CustomAction(name: name, data: [:])
+        let error = NSError(domain: "tests", code: 1, description: "FormLocalAction")
+        let formLocalAction = FormLocalAction(name: name, data: [:])
         let successAction = ActionSpy()
-
+        
         var statesTracker: [ServerDrivenState] = []
         let controller = BeagleControllerStub()
-        let actionHander = CustomActionHandling(handlers: [
+        let actionHander = LocalFormHandling(handlers: [
             name: { _, _, listener in
                 listener(.start)
                 statesTracker.append(controller.serverDrivenState)
@@ -55,11 +55,11 @@ final class CustomActionTests: XCTestCase {
             }
         ])
         controller.dependencies = BeagleScreenDependencies(
-            customActionHandler: actionHander
+            localFormHandler: actionHander
         )
 
         // When
-        customAction.execute(controller: controller, sender: self)
+        formLocalAction.execute(controller: controller, sender: self)
 
         // Then
         assertSnapshot(matching: statesTracker, as: .dump)
@@ -67,10 +67,11 @@ final class CustomActionTests: XCTestCase {
 }
 
 // MARK: - Test helpers
-class CustomActionHandlerSpy: CustomActionHandler {
+
+class LocalFormHandlerSpy: LocalFormHandler {
     private(set) var actionsHandledCount = 0
 
-    func handle(action: CustomAction, controller: BeagleController, listener: @escaping Listener) {
+    func handle(action: FormLocalAction, controller: BeagleController, listener: @escaping Listener) {
         actionsHandledCount += 1
     }
 }

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Tests/__Snapshots__/CustomActionTests/test_whenExecuteCustomAction_shouldListenToStateChanges.1.txt
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Tests/__Snapshots__/CustomActionTests/test_whenExecuteCustomAction_shouldListenToStateChanges.1.txt
@@ -1,8 +1,0 @@
-▿ 3 elements
-  ▿ ServerDrivenState
-    - loading: true
-  ▿ ServerDrivenState
-    ▿ error: Error
-      - action: Error Domain=tests Code=1 "CusomAction" UserInfo={NSLocalizedDescription=CusomAction}
-  ▿ ServerDrivenState
-    - loading: false

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Tests/__Snapshots__/FormLocalActionTests/test_whenExecuteFormLocalAction_shouldListenToStateChanges.1.txt
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Tests/__Snapshots__/FormLocalActionTests/test_whenExecuteFormLocalAction_shouldListenToStateChanges.1.txt
@@ -1,0 +1,8 @@
+▿ 3 elements
+  ▿ ServerDrivenState
+    - loading: true
+  ▿ ServerDrivenState
+    ▿ error: Error
+      - action: Error Domain=tests Code=1 "FormLocalAction" UserInfo={NSLocalizedDescription=FormLocalAction}
+  ▿ ServerDrivenState
+    - loading: false

--- a/iOS/Sources/BeagleUI/Sources/Context/FormManager.swift
+++ b/iOS/Sources/BeagleUI/Sources/Context/FormManager.swift
@@ -90,8 +90,8 @@ class FormManager {
         case let action as FormRemoteAction:
             submitForm(action, inputs: inputs, sender: sender, group: group)
 
-        case let action as CustomAction:
-            let newAction = CustomAction(name: action.name, data: inputs.merging(action.data) { a, _ in return a })
+        case let action as FormLocalAction:
+            let newAction = FormLocalAction(name: action.name, data: inputs.merging(action.data) { a, _ in return a })
             controller.execute(action: newAction, sender: sender)
         default:
             controller.execute(action: action, sender: sender)

--- a/iOS/Sources/BeagleUI/Sources/Context/Tests/FormManagerTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Context/Tests/FormManagerTests.swift
@@ -208,7 +208,7 @@ final class FormManagerTests: XCTestCase {
 
         // When
         FormManager(sender: gesture)?.submitForm()
-        repositoryStub.formCompletion?(.success(CustomAction(name: "custom", data: [:])))
+        repositoryStub.formCompletion?(.success(FormLocalAction(name: "custom", data: [:])))
         
         // Then
         XCTAssert(dataStoreStub.didCallformManagerDidSubmitForm)

--- a/iOS/Sources/BeagleUI/Sources/Networking/Tests/RepositoryTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Networking/Tests/RepositoryTests.swift
@@ -157,6 +157,7 @@ final class RepositoryTests: XCTestCase {
 
 final class ComponentDecodingStub: ComponentDecoding {
     func register<T>(_ type: T.Type, for typeName: String) where T: BeagleSchema.RawComponent {}
+    func register<A>(_ type: A.Type, for typeName: String) where A: BeagleSchema.RawAction {}
     func componentType(forType type: String) -> Decodable.Type? { return nil }
     func actionType(forType type: String) -> Decodable.Type? { return nil }
     

--- a/iOS/Sources/BeagleUI/Sources/Setup/BeagleDependencies.swift
+++ b/iOS/Sources/BeagleUI/Sources/Setup/BeagleDependencies.swift
@@ -22,7 +22,7 @@ public protocol BeagleDependenciesProtocol: BeagleSchema.Dependencies,
     DependencyUrlBuilder,
     DependencyNetworkClient,
     DependencyDeepLinkScreenManaging,
-    DependencyCustomActionHandler,
+    DependencyLocalFormHandler,
     DependencyNavigationController,
     DependencyNavigation,
     DependencyViewConfigurator,
@@ -48,7 +48,7 @@ open class BeagleDependencies: BeagleDependenciesProtocol {
     public var theme: Theme
     public var validatorProvider: ValidatorProvider?
     public var deepLinkHandler: DeepLinkScreenManaging?
-    public var customActionHandler: CustomActionHandler?
+    public var localFormHandler: LocalFormHandler?
     public var repository: Repository
     public var analytics: Analytics?
     public var navigationControllerType: BeagleNavigationController.Type
@@ -87,7 +87,7 @@ open class BeagleDependencies: BeagleDependenciesProtocol {
 
         self.urlBuilder = UrlBuilder()
         self.preFetchHelper = BeaglePreFetchHelper(dependencies: resolver)
-        self.customActionHandler = nil
+        self.localFormHandler = nil
         self.appBundle = Bundle.main
         self.theme = AppTheme(styles: [:])
         self.navigationControllerType = BeagleNavigationController.self
@@ -132,7 +132,7 @@ private class InnerDependenciesResolver: RepositoryDefault.Dependencies,
     var navigationControllerType: BeagleNavigationController.Type { return container().navigationControllerType }
     var navigation: BeagleNavigation { return container().navigation }
     var deepLinkHandler: DeepLinkScreenManaging? { return container().deepLinkHandler }
-    var customActionHandler: CustomActionHandler? { return container().customActionHandler }
+    var localFormHandler: LocalFormHandler? { return container().localFormHandler }
     var logger: BeagleLoggerType { return container().logger }
     var cacheManager: CacheManagerProtocol? { return container().cacheManager }
     var repository: Repository { return container().repository }

--- a/iOS/Sources/BeagleUI/Sources/Setup/BeagleSetup.swift
+++ b/iOS/Sources/BeagleUI/Sources/Setup/BeagleSetup.swift
@@ -34,6 +34,14 @@ public class Beagle {
     ) {
         dependencies.decoder.register(componentType, for: name)
     }
+    
+    /// Register a custom action
+    public static func registerCustomAction<A: Action>(
+        _ name: String,
+        actionType: A.Type
+    ) {
+        dependencies.decoder.register(actionType, for: name)
+    }
 
     public static func screen(_ type: ScreenType) -> BeagleScreenViewController {
         return BeagleScreenViewController(type)

--- a/iOS/Sources/BeagleUI/Sources/Setup/Tests/BeagleSetupTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Setup/Tests/BeagleSetupTests.swift
@@ -34,7 +34,7 @@ final class BeagleSetupTests: XCTestCase {
         dep.deepLinkHandler = DeepLinkHandlerDummy()
         dep.theme = AppThemeDummy()
         dep.validatorProvider = ValidatorProviding()
-        dep.customActionHandler = CustomActionHandlerSpy()
+        dep.localFormHandler = LocalFormHandlerSpy()
         if let url = URL(string: "www.test.com") {
             dep.urlBuilder.baseUrl = url
         }
@@ -98,6 +98,7 @@ final class FormDataStoreHandlerDummy: FormDataStoreHandling {
 
 final class ComponentDecodingDummy: ComponentDecoding {
     func register<T>(_ type: T.Type, for typeName: String) where T: BeagleSchema.RawComponent {}
+    func register<A>(_ type: A.Type, for typeName: String) where A: BeagleSchema.RawAction {}
     func componentType(forType type: String) -> Decodable.Type? { return nil }
     func actionType(forType type: String) -> Decodable.Type? { return nil }
     func decodeComponent(from data: Data) throws -> BeagleSchema.RawComponent { return ComponentDummy() }
@@ -161,7 +162,7 @@ struct BeagleScreenDependencies: BeagleDependenciesProtocol {
     var urlBuilder: UrlBuilderProtocol = UrlBuilder()
     var networkClient: NetworkClient = NetworkClientDummy()
     var deepLinkHandler: DeepLinkScreenManaging?
-    var customActionHandler: CustomActionHandler?
+    var localFormHandler: LocalFormHandler?
     var navigation: BeagleNavigation = BeagleNavigationDummy()
     var windowManager: WindowManager = WindowManagerDumb()
     var opener: URLOpener = URLOpenerDumb()

--- a/iOS/Sources/BeagleUI/Sources/Setup/Tests/__Snapshots__/BeagleSetupTests/testChangedDependencies.1.txt
+++ b/iOS/Sources/BeagleUI/Sources/Setup/Tests/__Snapshots__/BeagleSetupTests/testChangedDependencies.1.txt
@@ -2,15 +2,15 @@
   - analytics: Optional<Analytics>.none
   - appBundle: NSBundle <(null)> (not yet loaded)
   - cacheManager: Optional<CacheManagerProtocol>.none
-  ▿ customActionHandler: Optional<CustomActionHandler>
-    ▿ some: CustomActionHandlerSpy
-      - actionsHandledCount: 0
   - decoder: ComponentDecodingDummy
   ▿ deepLinkHandler: Optional<DeepLinkScreenManaging>
     - some: DeepLinkHandlerDummy
   - flex: (Function)
   ▿ formDataStoreHandler: FormDataStoreHandler
     - dataStore: 0 key/value pairs
+  ▿ localFormHandler: Optional<LocalFormHandler>
+    ▿ some: LocalFormHandlerSpy
+      - actionsHandledCount: 0
   - logger: BeagleLoggerDumb
   - navigation: BeagleNavigator
   - navigationControllerType: BeagleNavigationController

--- a/iOS/Sources/BeagleUI/Sources/Setup/Tests/__Snapshots__/BeagleSetupTests/testDefaultDependencies.1.txt
+++ b/iOS/Sources/BeagleUI/Sources/Setup/Tests/__Snapshots__/BeagleSetupTests/testDefaultDependencies.1.txt
@@ -12,12 +12,11 @@
       - defaultMaxCacheAge: "maxValidAge"
       ▿ dependencies: InnerDependenciesResolver
         - container: (Function)
-  - customActionHandler: Optional<CustomActionHandler>.none
   ▿ decoder: ComponentDecoder
     ▿ actionDecoders: 13 key/value pairs
       ▿ (2 elements)
-        - key: "beagle:customaction"
-        - value: CustomAction
+        - key: "beagle:formlocalaction"
+        - value: FormLocalAction
       ▿ (2 elements)
         - key: "beagle:formremoteaction"
         - value: FormRemoteAction
@@ -119,6 +118,7 @@
   - flex: (Function)
   ▿ formDataStoreHandler: FormDataStoreHandler
     - dataStore: 0 key/value pairs
+  - localFormHandler: Optional<LocalFormHandler>.none
   - logger: BeagleLogger
   - navigation: BeagleNavigator
   - navigationControllerType: BeagleNavigationController


### PR DESCRIPTION
Closes #170 

BREAKING CHANGE: allow register actions like components (under the namespace `custom`: `{"_beagleAction_":"custom:myaction"}`)

BREAKING CHANGE: the action `CustomAction` was used to handle the form submit locally, now it is called `FormLocalAction`