### PR TITLE
fix: handling binding generation when fields are overridden

### DIFF
--- a/backend/processor/src/test/kotlin/br/com/zup/beagle/test/OverrideParentWidgetBindingTest.kt
+++ b/backend/processor/src/test/kotlin/br/com/zup/beagle/test/OverrideParentWidgetBindingTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.test
+
+import br.com.zup.beagle.core.Accessibility
+import br.com.zup.beagle.core.Appearance
+import br.com.zup.beagle.core.Bind
+import br.com.zup.beagle.core.ServerDrivenComponent
+import br.com.zup.beagle.widget.core.Flex
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.test.assertEquals
+
+internal class OverrideParentWidgetBindingTest {
+    companion object {
+        val A = Random.Default.nextBoolean()
+        val B = Random.Default.nextLong()
+        val C = UUID.randomUUID().toString()
+        val ACCESSIBILITY = Accessibility()
+        val APPEARANCE = Appearance()
+        val FLEX = Flex()
+        val CHILD = object : ServerDrivenComponent {}
+        const val EXPRESSION = "@{}"
+    }
+
+    @Test
+    fun test_Value_construction() {
+        val actual = OverrideParentWidgetBinding(
+            Bind.Value(A),
+            Bind.Value(B),
+            Bind.Value(C),
+            ACCESSIBILITY,
+            APPEARANCE,
+            FLEX,
+            CHILD
+        )
+
+        assertEquals(A, actual.a.value)
+        assertEquals(B, actual.b.value)
+        assertEquals(C, actual.c.value)
+        assertEquals(ACCESSIBILITY, actual.accessibility)
+        assertInvariant(actual)
+    }
+
+    @Test
+    fun test_Expression_construction() {
+        val actual = OverrideParentWidgetBinding(
+            Bind.Expression(EXPRESSION),
+            Bind.Expression(EXPRESSION),
+            Bind.Expression(EXPRESSION),
+            ACCESSIBILITY,
+            APPEARANCE,
+            FLEX,
+            CHILD
+        )
+
+        assertEquals(EXPRESSION, actual.a.value)
+        assertEquals(EXPRESSION, actual.b.value)
+        assertEquals(EXPRESSION, actual.c.value)
+        assertInvariant(actual)
+    }
+
+    @Test
+    fun test_Mixed_construction() {
+        val actual = OverrideParentWidgetBinding(
+            Bind.Value(A),
+            Bind.Expression(EXPRESSION),
+            Bind.Value(C),
+            ACCESSIBILITY,
+            APPEARANCE,
+            FLEX,
+            CHILD
+        )
+
+        assertEquals(A, actual.a.value)
+        assertEquals(EXPRESSION, actual.b.value)
+        assertEquals(C, actual.c.value)
+        assertInvariant(actual)
+    }
+
+    private fun assertInvariant(actual: OverrideParentWidgetBinding) {
+        assertEquals(APPEARANCE, actual.appearance)
+        assertEquals(FLEX, actual.flex)
+        assertEquals(CHILD, actual.child)
+        assertEquals(OverrideParentWidget::class.supertypes, OverrideParentWidgetBinding::class.supertypes)
+    }
+}

--- a/backend/processor/src/test/kotlin/br/com/zup/beagle/test/TestCases.kt
+++ b/backend/processor/src/test/kotlin/br/com/zup/beagle/test/TestCases.kt
@@ -17,8 +17,16 @@
 package br.com.zup.beagle.test
 
 import br.com.zup.beagle.annotation.RegisterWidget
+import br.com.zup.beagle.core.Accessibility
+import br.com.zup.beagle.core.AccessibilityComponent
+import br.com.zup.beagle.core.Appearance
+import br.com.zup.beagle.core.AppearanceComponent
+import br.com.zup.beagle.core.FlexComponent
+import br.com.zup.beagle.core.GhostComponent
 import br.com.zup.beagle.core.LayoutComponent
+import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.widget.Widget
+import br.com.zup.beagle.widget.core.Flex
 
 @RegisterWidget
 object BlankWidget : Widget()
@@ -31,7 +39,6 @@ data class InterfaceWidget(val something: Any) : Widget(), LayoutComponent
 
 @RegisterWidget
 data class GenericsWidget(
-//    override val child: ServerDrivenComponent,
     val a: List<Int>,
     val b: Map<String, Any>,
     val c: Collection<List<Set<Double>>>
@@ -64,3 +71,14 @@ class MultiConstructorWidget(val value: String) : Widget() {
 
 @RegisterWidget
 data class VisibilityWidget(private val a: Boolean, internal val b: Byte, protected val c: Int, val d: Long): Widget()
+
+@RegisterWidget
+data class OverrideParentWidget(
+    val a: Boolean,
+    val b: Long,
+    val c: String,
+    override val accessibility: Accessibility?,
+    override val appearance: Appearance?,
+    override val flex: Flex?,
+    override val child: ServerDrivenComponent
+) : AccessibilityComponent, AppearanceComponent, FlexComponent, GhostComponent

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleWidgetBindingHandler.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleWidgetBindingHandler.kt
@@ -49,16 +49,11 @@ class BeagleWidgetBindingHandler(
 
     fun createBindingClass(element: TypeElement) =
         element.visibleGetters.map { this.createBindParameter(it) }.let { parameters ->
-            val bindName = bindClass.qualifiedName
             TypeSpec.classBuilder("${element.simpleName}$SUFFIX")
                 .superclass(this.typeUtils.getKotlinName(element.superclass))
                 .addSuperinterfaces(element.interfaces.map(TypeMirror::asTypeName))
                 .primaryConstructor(FunSpec.constructorFrom(parameters))
-                .addProperties(
-                    parameters.map {
-                        PropertySpec.from(it, bindName != null && !it.type.toString().startsWith(bindName))
-                    }
-                )
+                .addProperties(parameters.map { PropertySpec.from(it, it.tag(Boolean::class) == true) })
         }
 
     private fun createBindParameter(element: ExecutableElement) =
@@ -67,5 +62,5 @@ class BeagleWidgetBindingHandler(
             this.typeUtils.getKotlinName(element.returnType).let {
                 if (element.isOverride) it else bindClass.asTypeName().parameterizedBy(it)
             }
-        ).build()
+        ).tag(Boolean::class, element.isOverride).build()
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -140,6 +140,7 @@ platform :backend do
     gradle(tasks:
         [
             "backend:framework:test",
+            "backend:processor:test",
             "backend:starters:beagle-micronaut-starter:test",
             "backend:starters:beagle-spring-starter:test",
             "backend:sample:micronaut:assemble",


### PR DESCRIPTION
### Problem
Registered widgets which were overriding fields broke the binding generation.

### Solution
When a Widget overrides a field, in the Binding copy have it also override that field.