### PR TITLE
fix: add Android CODEOWNERS as backend owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@ CODEOWNERS
 
 android/  @tuliopereirazup @hernandazevedozup @matheusribeirozup @uziasferreirazup @hthemir @tiagonuneszup @danilorochazup @lucka3s
 iOS/ @theffc @gabcoelho @dantes-git @heliojuniorzup @victormr @yandiaszup @gmarson @marcelomp
-backend/  @LG95 @ze12augusto
+backend/  @LG95 @ze12augusto @tuliopereirazup @hernandazevedozup @matheusribeirozup @uziasferreirazup @hthemir @tiagonuneszup @danilorochazup @lucka3s


### PR DESCRIPTION
### Purpose
Break backend code owner deadlock.