### PR TITLE
docs: Page not found at "Learn how to" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ When deserializing, Beagle turns a `widget` into a `view` applying the styles im
 
 #### Learn how to:
 
-- [Create a Backend project](https://zup-products.gitbook.io/beagle/introducing/beagle-backend)
-- [Create an Android project](https://zup-products.gitbook.io/beagle/introducing/android)
-- [Create an iOS project](https://zup-products.gitbook.io/beagle/introducing/ios)
+- [Create a Backend project](https://docs.usebeagle.io/v/0.2/introducing/beagle-backend)
+- [Create an Android project](https://docs.usebeagle.io/v/0.2/introducing/android)
+- [Create an iOS project](https://docs.usebeagle.io/v/0.2/introducing/ios)
 
 ## Contributing guide
 


### PR DESCRIPTION
Page not found when select options "create a backend project", "create an android project" or "create an ios project" at "learn how to" section.