### PR TITLE
feat: treat nullable fields in binding generation

### DIFF
--- a/backend/processor/src/test/kotlin/br/com/zup/beagle/test/NullableWidgetTest.kt
+++ b/backend/processor/src/test/kotlin/br/com/zup/beagle/test/NullableWidgetTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.test
+
+import br.com.zup.beagle.core.Bind
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+internal class NullableWidgetTest {
+    @Test
+    fun test_Value_construction() {
+        val value = object : Any() {}
+
+        val actual = NullableWidgetBinding(Bind.Value(value))
+
+        assertNotNull(actual.thing)
+        assertEquals(value, actual.thing.value)
+        assertEquals(NullableWidget::class.supertypes, NullableWidgetBinding::class.supertypes)
+    }
+
+    @Test
+    fun test_Expression_construction() {
+        val expression = "@{}"
+
+        val actual = NullableWidgetBinding(Bind.Expression(expression))
+
+        assertNotNull(actual.thing)
+        assertEquals(expression, actual.thing.value)
+        assertEquals(NullableWidget::class.supertypes, NullableWidgetBinding::class.supertypes)
+    }
+
+    @Test
+    fun test_Null_construction() {
+        val actual = NullableWidgetBinding(null)
+
+        assertNull(actual.thing)
+        assertEquals(NullableWidget::class.supertypes, NullableWidgetBinding::class.supertypes)
+    }
+}

--- a/backend/processor/src/test/kotlin/br/com/zup/beagle/test/TestCases.kt
+++ b/backend/processor/src/test/kotlin/br/com/zup/beagle/test/TestCases.kt
@@ -34,7 +34,7 @@ object BlankWidget : Widget()
 data class ConstructorWidget(val something: Any) : Widget()
 
 @RegisterWidget
-data class InterfaceWidget(val something: Any) : Widget()
+data class InterfaceWidget(val something: Any) : ServerDrivenComponent
 
 @RegisterWidget
 data class GenericsWidget(
@@ -81,3 +81,6 @@ data class OverrideParentWidget(
     override val flex: Flex?,
     override val child: ServerDrivenComponent
 ) : AccessibilityComponent, FlexComponent, StyleComponent, GhostComponent
+
+@RegisterWidget
+data class NullableWidget(val thing: Any?)

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleBindingHandler.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleBindingHandler.kt
@@ -31,14 +31,17 @@ import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.TypeElement
 import javax.lang.model.type.TypeMirror
 
-open class BeagleBindingHandler(private val processingEnvironment: ProcessingEnvironment,
-                                private val bindClass: BeagleClass = BIND_ANDROID) {
+open class BeagleBindingHandler(
+    processingEnvironment: ProcessingEnvironment,
+    private val bindClass: BeagleClass = BIND_ANDROID
+) {
     companion object {
         const val BINDING_SUFFIX = "Binding"
         const val GET_BIND_ATTRIBUTES_METHOD = "getBindAttributes"
     }
 
     private val typeUtils = processingEnvironment.typeUtils
+
     fun createBindingClass(element: TypeElement) =
         element.visibleGetters.map { this.createBindParameter(it) }.let { parameters ->
             TypeSpec.classBuilder("${element.simpleName}${BINDING_SUFFIX}")
@@ -51,10 +54,9 @@ open class BeagleBindingHandler(private val processingEnvironment: ProcessingEnv
     fun createBindParameter(element: ExecutableElement) =
         ParameterSpec.builder(
             element.fieldName,
-            this.typeUtils.getKotlinName(element.returnType).let {
-                if (element.isOverride) it else ClassName(bindClass.packageName, bindClass.className)
-                    .parameterizedBy(it)
-            }
+            this.typeUtils.getKotlinName(element.returnType)
+                .let { if (element.isOverride) it else bindClass.asClassName().parameterizedBy(it) }
+                .copy(element.isMarkedNullable)
         ).tag(Boolean::class, element.isOverride).build()
 
     fun getFunctionGetBindAttributes(element: TypeElement): FunSpec {

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleClass.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleClass.kt
@@ -16,11 +16,17 @@
 
 package br.com.zup.beagle.compiler
 
+import com.squareup.kotlinpoet.ClassName
+
 data class BeagleClass(
     val packageName: String,
     val className: String
 ) {
     override fun toString(): String {
         return "$packageName.$className"
+    }
+
+    fun asClassName(): ClassName {
+        return ClassName(packageName, className)
     }
 }

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleProcessorExtensions.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleProcessorExtensions.kt
@@ -27,8 +27,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asTypeName
 import org.jetbrains.annotations.Nullable
-import java.io.File
-import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.AnnotatedConstruct
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
@@ -40,23 +39,22 @@ import javax.lang.model.type.WildcardType
 import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
 
-private val TypeName.kotlin get() = JAVA_TO_KOTLIN[this] ?: this
+private val TypeName.kotlin: TypeName get() = JAVA_TO_KOTLIN[this] ?: this
 
-val ProcessingEnvironment.kaptGeneratedDirectory get() = File(this.options[KAPT_KEY]!!)
-val Element.isMarkedNullable get() = this.getAnnotation(Nullable::class.java) != null
-val ExecutableElement.isOverride get() = this.getAnnotation(Override::class.java) != null
+val AnnotatedConstruct.isMarkedNullable: Boolean get() = this.getAnnotation(Nullable::class.java) != null
+val ExecutableElement.isOverride: Boolean get() = this.getAnnotation(Override::class.java) != null
 
-val ExecutableElement.fieldName
+val ExecutableElement.fieldName: String
     get() = this.simpleName.toString()
         .removePrefix(GET)
         .takeWhile { it != INTERNAL_MARKER }
         .let { it.replaceFirst(it.first(), it.first().toLowerCase()) }
 
-val TypeElement.visibleGetters
+val TypeElement.visibleGetters: List<ExecutableElement>
     get() = this.enclosedElements.filter { it.kind.isField }.map { it.simpleName.toString() }.toSet().let { names ->
         this.enclosedElements
             .filter { it.kind == ElementKind.METHOD && GET in it.simpleName && Modifier.PUBLIC in it.modifiers }
-            .map { it as ExecutableElement }
+            .filterIsInstance<ExecutableElement>()
             .filter { it.fieldName in names }
     }
 
@@ -67,7 +65,7 @@ fun Types.isSubtype(type: TypeMirror, superTypeName: String): Boolean =
         else -> this.directSupertypes(type).any { this.isSubtype(it, superTypeName) }
     }
 
-fun Elements.getPackageAsString(element: Element) = this.getPackageOf(element).toString()
+fun Elements.getPackageAsString(element: Element): String = this.getPackageOf(element).toString()
 
 fun FunSpec.Companion.constructorFrom(parameters: List<ParameterSpec>) =
     this.constructorBuilder().addParameters(parameters).build()


### PR DESCRIPTION
### Problem
Nullability is currently ignored by binding generation.

### Solution
Make the whole type nullable when the original is.