### PR TITLE
feat: Adds registration of custom actions for moshi deserialization by using @RegisterAction

### DIFF
--- a/android/android-processor/src/main/java/br/com/zup/beagle/android/compiler/BeagleSetupProcessor.kt
+++ b/android/android-processor/src/main/java/br/com/zup/beagle/android/compiler/BeagleSetupProcessor.kt
@@ -16,11 +16,13 @@
 
 package br.com.zup.beagle.android.compiler
 
+import br.com.zup.beagle.compiler.ANDROID_ACTION
 import br.com.zup.beagle.compiler.BEAGLE_CONFIG
 import br.com.zup.beagle.compiler.BEAGLE_SDK
 import br.com.zup.beagle.compiler.CUSTOM_ACTION_HANDLER
 import br.com.zup.beagle.compiler.DEEP_LINK_HANDLER
 import br.com.zup.beagle.compiler.HTTP_CLIENT_HANDLER
+import br.com.zup.beagle.compiler.RegisteredActionGenerator
 import br.com.zup.beagle.compiler.error
 import br.com.zup.beagle.widget.Widget
 import com.squareup.kotlinpoet.ClassName
@@ -36,6 +38,7 @@ class BeagleSetupProcessor(
     private val processingEnv: ProcessingEnvironment,
     private val beagleSetupRegisteredWidgetGenerator: BeagleSetupRegisteredWidgetGenerator =
         BeagleSetupRegisteredWidgetGenerator(),
+    private val registeredActionGenerator: RegisteredActionGenerator = RegisteredActionGenerator(),
     private val beagleSetupPropertyGenerator: BeagleSetupPropertyGenerator =
         BeagleSetupPropertyGenerator(processingEnv)
 ) {
@@ -51,6 +54,7 @@ class BeagleSetupProcessor(
             .addModifiers(KModifier.PUBLIC, KModifier.FINAL)
             .addSuperinterface(ClassName(BEAGLE_SDK.packageName, BEAGLE_SDK.className))
             .addFunction(beagleSetupRegisteredWidgetGenerator.generate(roundEnvironment))
+            .addFunction(registeredActionGenerator.generate(roundEnvironment))
             .addProperties(beagleSetupPropertyGenerator.generate(
                 basePackageName,
                 roundEnvironment
@@ -68,6 +72,7 @@ class BeagleSetupProcessor(
             .addImport(HTTP_CLIENT_HANDLER.packageName, HTTP_CLIENT_HANDLER.className)
             .addImport(basePackageName, beagleConfigClassName)
             .addImport(Widget::class, "")
+            .addImport(ClassName(ANDROID_ACTION.packageName, ANDROID_ACTION.className), "")
             .addType(typeSpec)
             .build()
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/BeagleMoshi.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/BeagleMoshi.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.android.data.serializer
 
 import br.com.zup.beagle.android.data.serializer.adapter.ActionJsonAdapterFactory
+import br.com.zup.beagle.android.data.serializer.adapter.AndroidActionJsonAdapterFactory
 import br.com.zup.beagle.android.data.serializer.adapter.BindAdapterFactory
 import br.com.zup.beagle.android.data.serializer.adapter.ContextDataAdapterFactory
 import br.com.zup.beagle.android.data.serializer.adapter.ComponentJsonAdapterFactory
@@ -32,6 +33,7 @@ internal object BeagleMoshi {
             .add(ComponentJsonAdapterFactory.make())
             .add(RouteAdapterFactory())
             .add(ActionJsonAdapterFactory.make())
+            .add(AndroidActionJsonAdapterFactory.make())
             .add(KotlinJsonAdapterFactory())
             .add(ContextDataAdapterFactory())
             .build()

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/ActionJsonAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/ActionJsonAdapterFactory.kt
@@ -16,19 +16,20 @@
 
 package br.com.zup.beagle.android.data.serializer.adapter
 
-import br.com.zup.beagle.widget.core.Action
 import br.com.zup.beagle.action.CustomAction
 import br.com.zup.beagle.action.FormValidation
 import br.com.zup.beagle.action.Navigate
 import br.com.zup.beagle.action.SendRequestAction
 import br.com.zup.beagle.action.ShowNativeDialog
 import br.com.zup.beagle.android.data.serializer.PolymorphicJsonAdapterFactory
+import br.com.zup.beagle.widget.core.Action
 import br.com.zup.beagle.widget.form.FormRemoteAction
-import java.util.*
+import java.util.Locale
 
 private const val BEAGLE_WIDGET_TYPE = "_beagleAction_"
 private const val BEAGLE_NAMESPACE = "beagle"
 
+@Deprecated(message = "This class will be no longer needed. @see new AndroidActionJsonAdapterFactory")
 internal object ActionJsonAdapterFactory {
 
     fun make(): PolymorphicJsonAdapterFactory<Action> {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/AndroidActionJsonAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/AndroidActionJsonAdapterFactory.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.data.serializer.adapter
+
+import br.com.zup.beagle.android.Action
+import br.com.zup.beagle.android.data.serializer.PolymorphicJsonAdapterFactory
+import br.com.zup.beagle.android.setup.BeagleEnvironment
+import java.util.Locale
+
+private const val BEAGLE_WIDGET_TYPE = "_beagleAction_"
+private const val NAMESPACE = "custom"
+
+internal object AndroidActionJsonAdapterFactory {
+
+    fun make(): PolymorphicJsonAdapterFactory<Action> {
+        var factory = PolymorphicJsonAdapterFactory
+            .of(Action::class.java, BEAGLE_WIDGET_TYPE)
+        return registerUserActions(factory)
+    }
+
+    private fun registerUserActions(factory: PolymorphicJsonAdapterFactory<Action>):
+        PolymorphicJsonAdapterFactory<Action> {
+        var newFactory = factory
+        val customActions = BeagleEnvironment.beagleSdk.registeredActions()
+        customActions.forEach {
+            newFactory = newFactory.withSubtype(it, createNamespace(NAMESPACE, it))
+        }
+        return newFactory
+    }
+
+    private fun createNamespace(appNamespace: String, clazz: Class<*>): String {
+        val typeName = clazz.simpleName.toLowerCase(Locale.getDefault())
+        return "$appNamespace:$typeName"
+    }
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
@@ -17,8 +17,9 @@
 package br.com.zup.beagle.android.setup
 
 import android.app.Application
-import br.com.zup.beagle.android.action.CustomActionHandler
 import br.com.zup.beagle.analytics.Analytics
+import br.com.zup.beagle.android.Action
+import br.com.zup.beagle.android.action.CustomActionHandler
 import br.com.zup.beagle.android.form.ValidatorHandler
 import br.com.zup.beagle.android.navigation.DeepLinkHandler
 import br.com.zup.beagle.android.networking.HttpClient
@@ -41,6 +42,7 @@ interface BeagleSdk {
     val analytics: Analytics?
 
     fun registeredWidgets(): List<Class<WidgetView>>
+    fun registeredActions(): List<Class<Action>>
 
     fun init(application: Application) {
         BeagleEnvironment.beagleSdk = this

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
@@ -16,14 +16,13 @@
 
 package br.com.zup.beagle.android.data.serializer
 
-import br.com.zup.beagle.widget.core.Action
 import br.com.zup.beagle.action.CustomAction
 import br.com.zup.beagle.action.FormValidation
 import br.com.zup.beagle.action.Navigate
 import br.com.zup.beagle.action.ShowNativeDialog
-import br.com.zup.beagle.android.mockdata.CustomInputWidget
-import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.android.mockdata.ComponentBinding
+import br.com.zup.beagle.android.mockdata.CustomAndroidAction
+import br.com.zup.beagle.android.mockdata.CustomInputWidget
 import br.com.zup.beagle.android.mockdata.CustomWidget
 import br.com.zup.beagle.android.mockdata.InternalObject
 import br.com.zup.beagle.android.setup.BeagleEnvironment
@@ -31,6 +30,11 @@ import br.com.zup.beagle.android.testutil.RandomData
 import br.com.zup.beagle.android.widget.core.Bind
 import br.com.zup.beagle.android.widget.core.ContextData
 import br.com.zup.beagle.android.widget.core.WidgetView
+import br.com.zup.beagle.android.widget.layout.ScreenComponent
+import br.com.zup.beagle.android.widget.pager.PageIndicator
+import br.com.zup.beagle.android.widget.ui.UndefinedWidget
+import br.com.zup.beagle.core.ServerDrivenComponent
+import br.com.zup.beagle.widget.core.Action
 import br.com.zup.beagle.widget.form.Form
 import br.com.zup.beagle.widget.form.FormInput
 import br.com.zup.beagle.widget.form.FormMethodType
@@ -44,14 +48,11 @@ import br.com.zup.beagle.widget.layout.Spacer
 import br.com.zup.beagle.widget.layout.Stack
 import br.com.zup.beagle.widget.layout.Vertical
 import br.com.zup.beagle.widget.lazy.LazyComponent
-import br.com.zup.beagle.android.widget.pager.PageIndicator
 import br.com.zup.beagle.widget.ui.Button
 import br.com.zup.beagle.widget.ui.Image
 import br.com.zup.beagle.widget.ui.ListView
 import br.com.zup.beagle.widget.ui.NetworkImage
 import br.com.zup.beagle.widget.ui.Text
-import br.com.zup.beagle.android.widget.ui.UndefinedWidget
-import br.com.zup.beagle.android.widget.layout.ScreenComponent
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockkObject
@@ -65,12 +66,18 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import br.com.zup.beagle.android.Action as AndroidAction
 
 @Suppress("UNCHECKED_CAST")
 private val WIDGETS = listOf(
     CustomWidget::class.java as Class<WidgetView>,
     CustomInputWidget::class.java as Class<WidgetView>,
     ComponentBinding::class.java as Class<WidgetView>
+)
+
+@Suppress("UNCHECKED_CAST")
+private val ACTIONS = listOf(
+    CustomAndroidAction::class.java as Class<AndroidAction>
 )
 
 class BeagleMoshiTest {
@@ -86,6 +93,7 @@ class BeagleMoshiTest {
         mockkObject(BeagleEnvironment)
 
         every { BeagleEnvironment.beagleSdk.registeredWidgets() } returns WIDGETS
+        every { BeagleEnvironment.beagleSdk.registeredActions() } returns ACTIONS
     }
 
     @After
@@ -562,6 +570,20 @@ class BeagleMoshiTest {
         // Then
         assertNotNull(actual)
         assertTrue(actual is CustomAction)
+    }
+
+
+    @Test
+    fun make_should_return_moshi_to_deserialize_a_CustomAndroidAction() {
+        // Given
+        val json = makeCustomAndroidActionJson()
+
+        // When
+        val actual = beagleMoshiFactory.moshi.adapter(AndroidAction::class.java).fromJson(json)
+
+        // Then
+        assertNotNull(actual)
+        assertTrue(actual is CustomAndroidAction)
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
@@ -211,6 +211,14 @@ fun makeCustomActionJson() = """
     }
 """
 
+fun makeCustomAndroidActionJson() = """
+    {
+        "_beagleAction_": "custom:customAndroidAction",
+        "value": "${RandomData.string()}",
+        "intValue": ${RandomData.int()}
+    }
+"""
+
 fun makeFormValidationJson() = """
     {
         "_beagleAction_": "beagle:formValidation",

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/CustomAndroidAction.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/CustomAndroidAction.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.mockdata
+
+import br.com.zup.beagle.android.Action
+import br.com.zup.beagle.android.engine.renderer.RootView
+import br.com.zup.beagle.annotation.RegisterAction
+
+@RegisterAction
+data class CustomAndroidAction(
+    val value: String,
+    val intValue: Int
+) : Action {
+    override fun handle(rootView: RootView) {
+
+    }
+}

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleClasses.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleClasses.kt
@@ -89,6 +89,10 @@ val BIND_BACKEND = BeagleClass(
     className = "Bind"
 )
 
+val ANDROID_ACTION = BeagleClass(
+    packageName = "br.com.zup.beagle.android",
+    className = "Action"
+)
 
 val GET_VALUE_NULL = BeagleClass(
     packageName = "br.com.zup.beagle.android.utils",

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/RegisteredActionGenerator.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/RegisteredActionGenerator.kt
@@ -35,11 +35,8 @@ class RegisteredActionGenerator {
             )
         )
 
-        registerAnnotatedClasses.forEachIndexed { index, element ->
-            classValues.append("\t${element}Binding::class.java as Class<Action>")
-            if (index < registerAnnotatedClasses.size - 1) {
-                classValues.append(",\n")
-            }
+        registerAnnotatedClasses.joinToString(",\n") { element ->
+            "\t${element}Binding::class.java as Class<Action>"
         }
 
         return FunSpec.builder("registeredActions")

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/RegisteredActionGenerator.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/RegisteredActionGenerator.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.compiler
+
+import br.com.zup.beagle.annotation.RegisterAction
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.asClassName
+import javax.annotation.processing.RoundEnvironment
+
+class RegisteredActionGenerator {
+
+    fun generate(roundEnvironment: RoundEnvironment): FunSpec {
+        val classValues = StringBuilder()
+        val registerAnnotatedClasses = roundEnvironment.getElementsAnnotatedWith(RegisterAction::class.java)
+        val listReturnType = List::class.asClassName().parameterizedBy(
+            Class::class.asClassName().parameterizedBy(
+                ClassName(ANDROID_ACTION.packageName, ANDROID_ACTION.className)
+            )
+        )
+
+        registerAnnotatedClasses.forEachIndexed { index, element ->
+            classValues.append("\t${element}Binding::class.java as Class<Action>")
+            if (index < registerAnnotatedClasses.size - 1) {
+                classValues.append(",\n")
+            }
+        }
+
+        return FunSpec.builder("registeredActions")
+            .addModifiers(KModifier.OVERRIDE)
+            .returns(listReturnType)
+            .addCode("""
+                        |val registeredActions = listOf<Class<Action>>(
+                        |   $classValues
+                        |)
+                    |""".trimMargin())
+            .addStatement("return registeredActions")
+            .build()
+    }
+}

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/RegisteredActionGenerator.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/RegisteredActionGenerator.kt
@@ -27,7 +27,6 @@ import javax.annotation.processing.RoundEnvironment
 class RegisteredActionGenerator {
 
     fun generate(roundEnvironment: RoundEnvironment): FunSpec {
-        val classValues = StringBuilder()
         val registerAnnotatedClasses = roundEnvironment.getElementsAnnotatedWith(RegisterAction::class.java)
         val listReturnType = List::class.asClassName().parameterizedBy(
             Class::class.asClassName().parameterizedBy(
@@ -35,7 +34,7 @@ class RegisteredActionGenerator {
             )
         )
 
-        registerAnnotatedClasses.joinToString(",\n") { element ->
+        val classValues = registerAnnotatedClasses.joinToString(",\n") { element ->
             "\t${element}Binding::class.java as Class<Action>"
         }
 


### PR DESCRIPTION
Adds registration of custom actions for moshi deserialization by using @RegisterAction

These actions are registered by the user, same as the current registered widgets.

Later this PR We can reuse the logic to generate the boilerplate for the beagle actions