### PR TITLE
feat: rename Button and Form action

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/ComponentInteractionScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/ComponentInteractionScreen.swift
@@ -26,11 +26,11 @@ let componentInteractionScreen: Screen = {
         child: Container(children: [
             Button(
                 text: "Declarative",
-                action: Navigate.pushView(.declarative(declarativeScreen))
+                onPress: [Navigate.pushView(.declarative(declarativeScreen))]
             ),
             Button(
                 text: "Text (JSON)",
-                action: Navigate.openNativeRoute("componentInteractionText")
+                onPress: [Navigate.openNativeRoute("componentInteractionText")]
             )
         ])
     )
@@ -54,10 +54,10 @@ let declarativeScreen: Screen = {
                 Text("@{myContext}"),
                 Button(
                     text: "ok",
-                    action: SetContext(
+                    onPress: [SetContext(
                         context: "myContext",
                         value: "button value"
-                    )
+                    )]
                 )
             ],
             context: Context(id: "myContext", value: "")
@@ -104,11 +104,11 @@ struct ComponentInteractionText: DeeplinkScreen {
                       {
                         "_beagleComponent_": "beagle:button",
                         "text": "ok",
-                        "action": {
+                        "onPress": [{
                           "_beagleAction_": "beagle:setcontext",
                           "context": "myContext",
                           "value": "2"
-                        }
+                        }]
                       }
                     ]
                   }

--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
@@ -36,47 +36,47 @@ struct MainScreen: DeeplinkScreen {
             children: [
                 Button(
                     text: "Navigator",
-                    action: Navigate.pushView(.remote(.NAVIGATE_ENDPOINT, shouldPrefetch: true))
+                    onPress: [Navigate.pushView(.remote(.NAVIGATE_ENDPOINT, shouldPrefetch: true))]
                 ),
                 Button(
                     text: "Form & Lazy Component",
-                    action: Navigate.openNativeRoute(.LAZY_COMPONENTS_ENDPOINT)
+                    onPress: [Navigate.openNativeRoute(.LAZY_COMPONENTS_ENDPOINT)]
                 ),
                 Button(
                     text: "Page View",
-                    action: Navigate.openNativeRoute(.PAGE_VIEW_ENDPOINT)
+                    onPress: [Navigate.openNativeRoute(.PAGE_VIEW_ENDPOINT)]
                 ),
                 Button(
                     text: "Tab View",
-                    action: Navigate.openNativeRoute(.TAB_VIEW_ENDPOINT)
+                    onPress: [Navigate.openNativeRoute(.TAB_VIEW_ENDPOINT)]
                 ),
                 Button(
                     text: "List View",
-                    action: Navigate.openNativeRoute(.LIST_VIEW_ENDPOINT)
+                    onPress: [Navigate.openNativeRoute(.LIST_VIEW_ENDPOINT)]
                 ),
                 Button(
                     text: "Form",
-                    action: Navigate.openNativeRoute(.FORM_ENDPOINT)
+                    onPress: [Navigate.openNativeRoute(.FORM_ENDPOINT)]
                 ),
                 Button(
                     text: "Custom Component",
-                    action: Navigate.openNativeRoute(.CUSTOM_COMPONENT_ENDPOINT)
+                    onPress: [Navigate.openNativeRoute(.CUSTOM_COMPONENT_ENDPOINT)]
                 ),
                 Button(
                     text: "Web View",
-                    action: Navigate.openNativeRoute(.WEB_VIEW_ENDPOINT)
+                    onPress: [Navigate.openNativeRoute(.WEB_VIEW_ENDPOINT)]
                 ),
                 Button(
                     text: "Component Interaction",
-                    action: Navigate.pushView(.declarative(componentInteractionScreen))
+                    onPress: [Navigate.pushView(.declarative(componentInteractionScreen))]
                 ),
                 Button(
                     text: "Send Request",
-                    action: Navigate.pushView(.declarative(sendRequestDeclarativeScreen))
+                    onPress: [Navigate.pushView(.declarative(sendRequestDeclarativeScreen))]
                 ),
                 Button(
                     text: "Sample BFF",
-                    action: Navigate.pushView(.remote(.COMPONENTS_ENDPOINT))
+                    onPress: [Navigate.pushView(.remote(.COMPONENTS_ENDPOINT))]
                 )
             ]
         )

--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
@@ -28,7 +28,7 @@ let sendRequestDeclarativeScreen: Screen = {
             [
                 Button(
                     text: "do request",
-                    action: SendRequest(
+                    onPress: [SendRequest(
                         url: "https://httpbin.org/post",
                         method: .post,
                         data: ["@{myContext}"],
@@ -58,7 +58,7 @@ let sendRequestDeclarativeScreen: Screen = {
                         onFinish: [
                             CustomConsoleLogAction()
                         ]
-                    )
+                    )]
                 )
             ],
             context: Context(id: "myContext", value: "initial value")

--- a/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
+++ b/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
@@ -43,7 +43,7 @@ extension Button {
     enum CodingKeys: String, CodingKey {
         case text
         case styleId
-        case action
+        case onPress
         case clickAnalyticsEvent
     }
 
@@ -52,7 +52,7 @@ extension Button {
 
         text = try container.decode(String.self, forKey: .text)
         styleId = try container.decodeIfPresent(String.self, forKey: .styleId)
-        action = try container.decodeIfPresent(forKey: .action)
+        onPress = try container.decodeIfPresent(forKey: .onPress)
         clickAnalyticsEvent = try container.decodeIfPresent(AnalyticsClick.self, forKey: .clickAnalyticsEvent)
         widgetProperties = try WidgetProperties(from: decoder)
     }

--- a/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
+++ b/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
@@ -103,7 +103,7 @@ extension Container {
 extension Form {
 
     enum CodingKeys: String, CodingKey {
-        case action
+        case onSubmit
         case child
         case group
         case additionalData
@@ -113,7 +113,7 @@ extension Form {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        action = try container.decode(forKey: .action)
+        onSubmit = try container.decodeIfPresent(forKey: .onSubmit)
         child = try container.decode(forKey: .child)
         group = try container.decodeIfPresent(String.self, forKey: .group)
         additionalData = try container.decodeIfPresent([String: String].self, forKey: .additionalData)

--- a/iOS/Schema/Sources/ServerDrivenComponent/Form/Form.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/Form/Form.swift
@@ -20,7 +20,7 @@ public struct Form: RawComponent, AutoInitiableAndDecodable {
     
     // MARK: - Public Properties
 
-    public let action: RawAction
+    public let onSubmit: [RawAction]?
     public let child: RawComponent
     public let group: String?
     public let additionalData: [String: String]?
@@ -28,13 +28,13 @@ public struct Form: RawComponent, AutoInitiableAndDecodable {
     
 // sourcery:inline:auto:Form.Init
     public init(
-        action: RawAction,
+        onSubmit: [RawAction]? = nil,
         child: RawComponent,
         group: String? = nil,
         additionalData: [String: String]? = nil,
         shouldStoreFields: Bool = false
     ) {
-        self.action = action
+        self.onSubmit = onSubmit
         self.child = child
         self.group = group
         self.additionalData = additionalData

--- a/iOS/Schema/Sources/ServerDrivenComponent/Form/Tests/JSON/formComponent.json
+++ b/iOS/Schema/Sources/ServerDrivenComponent/Form/Tests/JSON/formComponent.json
@@ -1,10 +1,10 @@
 {
   "_beagleComponent_" : "beagle:form",
-  "action": {
+  "onSubmit": [{
     "_beagleAction_" : "beagle:formremoteaction",
     "path" : "/sample/form",
     "method" : "POST"
-  },
+  }],
   "additionalData" : {
       "age" : "21",
       "id" : "11111"

--- a/iOS/Schema/Sources/ServerDrivenComponent/Form/Tests/__Snapshots__/FormTests/test_whenDecodingJson_thenItShouldReturnAForm.1.txt
+++ b/iOS/Schema/Sources/ServerDrivenComponent/Form/Tests/__Snapshots__/FormTests/test_whenDecodingJson_thenItShouldReturnAForm.1.txt
@@ -1,7 +1,4 @@
 ▿ Form
-  ▿ action: FormRemoteAction
-    - method: Method.post
-    - path: "/sample/form"
   ▿ additionalData: Optional<Dictionary<String, String>>
     ▿ some: 2 key/value pairs
       ▿ (2 elements)
@@ -146,4 +143,9 @@
           - cornerRadius: Optional<CornerRadius>.none
   ▿ group: Optional<String>
     - some: "group"
+  ▿ onSubmit: Optional<Array<RawAction>>
+    ▿ some: 1 element
+      ▿ FormRemoteAction
+        - method: Method.post
+        - path: "/sample/form"
   - shouldStoreFields: true

--- a/iOS/Schema/Sources/ServerDrivenComponent/Form/Tests/__Snapshots__/FormTests/test_whenDecodingJson_thenItShouldReturnAForm.1.txt
+++ b/iOS/Schema/Sources/ServerDrivenComponent/Form/Tests/__Snapshots__/FormTests/test_whenDecodingJson_thenItShouldReturnAForm.1.txt
@@ -66,8 +66,8 @@
           - style: Optional<Style>.none
       ▿ FormSubmit
         ▿ child: Button
-          - action: Optional<RawAction>.none
           - clickAnalyticsEvent: Optional<AnalyticsClick>.none
+          - onPress: Optional<Array<RawAction>>.none
           ▿ styleId: Optional<String>
             - some: "DesignSystem.Form.Submit"
           - text: "Submit Form"

--- a/iOS/Schema/Sources/Widgets/Button/Button.swift
+++ b/iOS/Schema/Sources/Widgets/Button/Button.swift
@@ -21,7 +21,7 @@ public struct Button: RawWidget, ClickedOnComponent, AutoInitiableAndDecodable {
     // MARK: - Public Properties
     public let text: String
     public let styleId: String?
-    public let action: RawAction?
+    public let onPress: [RawAction]?
     public var clickAnalyticsEvent: AnalyticsClick?
     public var widgetProperties: WidgetProperties
 
@@ -29,13 +29,13 @@ public struct Button: RawWidget, ClickedOnComponent, AutoInitiableAndDecodable {
     public init(
         text: String,
         styleId: String? = nil,
-        action: RawAction? = nil,
+        onPress: [RawAction]? = nil,
         clickAnalyticsEvent: AnalyticsClick? = nil,
         widgetProperties: WidgetProperties = WidgetProperties()
     ) {
         self.text = text
         self.styleId = styleId
-        self.action = action
+        self.onPress = onPress
         self.clickAnalyticsEvent = clickAnalyticsEvent
         self.widgetProperties = widgetProperties
     }

--- a/iOS/Schema/Sources/Widgets/Button/Tests/Json/buttonComponent.json
+++ b/iOS/Schema/Sources/Widgets/Button/Tests/Json/buttonComponent.json
@@ -1,9 +1,9 @@
 {
   "_beagleComponent_": "beagle:Button",
   "text": "button",
-  "action": {
+  "onPress": [{
     "_beagleAction_": "beagle:popStack"
-  },
+  }],
   "style": {
     "backgroundColor": "#800000FF",
     "cornerRadius": {

--- a/iOS/Schema/Sources/Widgets/Button/__Snapshots__/ButtonTests/test_whenDecodingJson_thenItShouldReturnAButton.1.txt
+++ b/iOS/Schema/Sources/Widgets/Button/__Snapshots__/ButtonTests/test_whenDecodingJson_thenItShouldReturnAButton.1.txt
@@ -1,7 +1,8 @@
 ▿ Button
-  ▿ action: Optional<RawAction>
-    - some: Navigate.popStack
   - clickAnalyticsEvent: Optional<AnalyticsClick>.none
+  ▿ onPress: Optional<Array<RawAction>>
+    ▿ some: 1 element
+      - Navigate.popStack
   - styleId: Optional<String>.none
   - text: "button"
   ▿ widgetProperties: WidgetProperties

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Tests/FormValidationTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Tests/FormValidationTests.swift
@@ -32,7 +32,7 @@ final class FormValidationTests: XCTestCase {
         let validationSpy = ValidationErrorListenerSpy()
         validationSpy.beagleFormElement = formInput
         let sender = SubmitFormGestureRecognizer(
-            form: Form(action: ActionDummy(), child: ComponentDummy()),
+            form: Form(child: ComponentDummy()),
             formView: validationSpy,
             formSubmitView: validationSpy,
             controller: controller

--- a/iOS/Sources/BeagleUI/Sources/Analytics/Tests/Json/buttonAnalyticsComponent.json
+++ b/iOS/Sources/BeagleUI/Sources/Analytics/Tests/Json/buttonAnalyticsComponent.json
@@ -1,9 +1,9 @@
 {
    "_beagleComponent_":"beagle:Button",
    "text":"button",
-   "action":{
+   "onPress":[{
       "_beagleAction_":"beagle:popStack"
-   },
+   }],
    "style":{
       "backgroundColor":"#800000FF",
       "cornerRadius":{

--- a/iOS/Sources/BeagleUI/Sources/Analytics/Tests/__Snapshots__/AnalyticsTests/testIfDecodingIsSuccessfullForClickEvent.1.txt
+++ b/iOS/Sources/BeagleUI/Sources/Analytics/Tests/__Snapshots__/AnalyticsTests/testIfDecodingIsSuccessfullForClickEvent.1.txt
@@ -1,6 +1,4 @@
 ▿ Button
-  ▿ action: Optional<RawAction>
-    - some: Navigate.popStack
   ▿ clickAnalyticsEvent: Optional<AnalyticsClick>
     ▿ some: AnalyticsClick
       - category: "mocked category"
@@ -8,6 +6,9 @@
         - some: "mocked label"
       ▿ value: Optional<String>
         - some: "mocked value"
+  ▿ onPress: Optional<Array<RawAction>>
+    ▿ some: 1 element
+      - Navigate.popStack
   - styleId: Optional<String>.none
   - text: "button"
   ▿ widgetProperties: WidgetProperties

--- a/iOS/Sources/BeagleUI/Sources/Components/Button+Renderable/Tests/ButtonTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Components/Button+Renderable/Tests/ButtonTests.swift
@@ -68,7 +68,7 @@ final class ButtonTests: XCTestCase {
         
         let navigatePath = "path-to-prefetch"
         let navigate = Navigate.pushStack(.remote(navigatePath))
-        let button = Button(text: "prefetch", action: navigate)
+        let button = Button(text: "prefetch", onPress: [navigate])
 
         // When
         _ = renderer.render(button)
@@ -80,7 +80,7 @@ final class ButtonTests: XCTestCase {
     func test_action_shouldBeTriggered() {
         // Given
         let action = ActionSpy()
-        let button = Button(text: "Trigger Action", action: action)
+        let button = Button(text: "Trigger Action", onPress: [action])
         let controller = BeagleControllerStub()
         let renderer = BeagleRenderer(controller: controller)
 
@@ -117,7 +117,7 @@ final class ButtonTests: XCTestCase {
         let renderer = BeagleRenderer(controller: controller)
         controller.dependencies = BeagleScreenDependencies(analytics: analytics)
         
-        let button = Button(text: "Trigger analytics click", action: action, clickAnalyticsEvent: .init(category: "some category"))
+        let button = Button(text: "Trigger analytics click", onPress: [action], clickAnalyticsEvent: .init(category: "some category"))
 
         // When
         let view = renderer.render(button)

--- a/iOS/Sources/BeagleUI/Sources/Components/Form+Renderable/Tests/FormTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Components/Form+Renderable/Tests/FormTests.swift
@@ -25,7 +25,6 @@ final class FormTests: XCTestCase {
         // Given
         let submitView = UILabel()
         let sut = Form(
-            action: ActionDummy(),
             child: FormSubmit(child: ComponentDummy(resultView: submitView))
         )
         let controller = BeagleControllerStub()

--- a/iOS/Sources/BeagleUI/Sources/Context/FormManager.swift
+++ b/iOS/Sources/BeagleUI/Sources/Context/FormManager.swift
@@ -56,7 +56,9 @@ class FormManager {
         if sender.form.shouldStoreFields {
             saveFormData(values: values, group: sender.form.group)
         }
-        submitAction(sender.form.action, inputs: values, sender: sender, group: sender.form.group)
+        sender.form.onSubmit?.forEach { action in
+            submitAction(action, inputs: values, sender: sender, group: sender.form.group)
+        }
     }
     
     private func merge(values: inout [String: String], with additionalData: [String: String]?) {

--- a/iOS/Sources/BeagleUI/Sources/Context/Tests/FormManagerTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Context/Tests/FormManagerTests.swift
@@ -23,7 +23,7 @@ final class FormManagerTests: XCTestCase {
     
     private lazy var form: Form = {
         let action = FormRemoteAction(path: "submit", method: .post)
-        let form = Form(action: action, child: Container(children: [
+        let form = Form(onSubmit: [action], child: Container(children: [
             FormInput(name: "name", child: InputComponent(value: "John Doe")),
             FormSubmit(child: Button(text: "Add"), enabled: true)
         ]))
@@ -86,7 +86,7 @@ final class FormManagerTests: XCTestCase {
             return false
         }
 
-        let view = Form(action: ActionDummy(), child: Container(children: [
+        let view = Form(child: Container(children: [
             FormInput(name: "name", required: true, validator: validator1, child: InputComponent(value: "John Doe")),
             FormInput(name: "password", required: true, validator: validator2, child: InputComponent(value: "password")),
             FormSubmit(child: Button(text: "Add"))
@@ -166,7 +166,7 @@ final class FormManagerTests: XCTestCase {
     private let group = "group"
     
     private lazy var formViewWithStorage = Form(
-        action: FormRemoteAction(path: "submit", method: .post),
+        onSubmit: [FormRemoteAction(path: "submit", method: .post)],
         child: Container(children: [
             FormInput(name: "name", required: true, validator: validator3, child: InputComponent(value: "John Doe")),
             FormInput(name: "password", required: true, validator: validator3, child: InputComponent(value: "password")),

--- a/iOS/Sources/BeagleUI/Sources/Logger/Tests/BeagleLoggerTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Logger/Tests/BeagleLoggerTests.swift
@@ -25,7 +25,7 @@ class BeagleLoggerTests: XCTestCase {
 
     func testLogs() {
         // Given
-        let form = Form(action: ActionDummy(), child: ComponentDummy())
+        let form = Form(child: ComponentDummy())
         let path = "path"
 
         let logs: [Log] = [

--- a/iOS/Sources/BeagleUI/Sources/Logger/Tests/__Snapshots__/BeagleLoggerTests/testLogs.1.txt
+++ b/iOS/Sources/BeagleUI/Sources/Logger/Tests/__Snapshots__/BeagleLoggerTests/testLogs.1.txt
@@ -12,13 +12,13 @@ Body=
 Headers= [:]
 
 Number of formInput and values are different. You probably declared formInputs with the same name in form: 
-	 Form(action: BeagleFrameworkTests.ActionDummy(), child: ComponentDummy(), group: nil, additionalData: nil, shouldStoreFields: false)
+	 Form(onSubmit: nil, child: ComponentDummy(), group: nil, additionalData: nil, shouldStoreFields: false)
 
 You probably forgot to declare your FormInput widgets in form: 
-	 Form(action: BeagleFrameworkTests.ActionDummy(), child: ComponentDummy(), group: nil, additionalData: nil, shouldStoreFields: false)
+	 Form(onSubmit: nil, child: ComponentDummy(), group: nil, additionalData: nil, shouldStoreFields: false)
 
 You probably forgot to declare your Submit widget in form: 
-	 Form(action: BeagleFrameworkTests.ActionDummy(), child: ComponentDummy(), group: nil, additionalData: nil, shouldStoreFields: false)
+	 Form(onSubmit: nil, child: ComponentDummy(), group: nil, additionalData: nil, shouldStoreFields: false)
 
 submittedValues(values: ["key1": "value1"])
 

--- a/iOS/Sources/BeagleUI/Sources/Renderer/Tests/BeagleScreenViewControllerTests.swift
+++ b/iOS/Sources/BeagleUI/Sources/Renderer/Tests/BeagleScreenViewControllerTests.swift
@@ -294,6 +294,8 @@ class BeagleControllerStub: BeagleController {
         (action as? Action)?.execute(controller: self, sender: sender)
     }
     
-    func execute(actions: [RawAction]?, with context: Context?, sender: Any) {}
+    func execute(actions: [RawAction]?, with context: Context?, sender: Any) {
+        actions?.forEach { execute(action: $0, sender: sender) }
+    }
     
 }


### PR DESCRIPTION
iOS implementation of `Button` and `Form` changes made in #296 .

BREAKING CHANGE:
- `Button` attribute `action` were renamed to `onPress` and now it's a list of actions.
- `Form` attribute `action` were renamed to `onSubmit` and now it's a list of actions.