### PR TITLE
fix: confirm and alert actions

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
@@ -82,4 +82,3 @@ struct CancelAction: Action {
         print("onPressCancel from Confirm clicked")
     }
 }
-

--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
@@ -41,8 +41,7 @@ let sendRequestDeclarativeScreen: Screen = {
                             Alert(
                                 title: "Success!",
                                 message: "Sucess sending Request",
-                                onPressOk: OkAction(),
-                                labelOk: "OK"
+                                labelOk: "Dismiss"
                             )
                         ],
                         onError: [

--- a/iOS/Schema/Sources/Action/Types/Alert.swift
+++ b/iOS/Schema/Sources/Action/Types/Alert.swift
@@ -21,14 +21,14 @@ import Foundation
 public struct Alert: RawAction, AutoInitiableAndDecodable {
     
     public let title: String?
-    public let message: String
+    public let message: Expression<String>
     public let onPressOk: RawAction?
     public let labelOk: String?
 
 // sourcery:inline:auto:Alert.Init
     public init(
         title: String? = nil,
-        message: String,
+        message: Expression<String>,
         onPressOk: RawAction? = nil,
         labelOk: String? = nil
     ) {

--- a/iOS/Schema/Sources/Action/Types/Alert.swift
+++ b/iOS/Schema/Sources/Action/Types/Alert.swift
@@ -20,14 +20,14 @@ import Foundation
 /// Action to represent a alert
 public struct Alert: RawAction, AutoInitiableAndDecodable {
     
-    public let title: String?
+    public let title: Expression<String>?
     public let message: Expression<String>
     public let onPressOk: RawAction?
     public let labelOk: String?
 
 // sourcery:inline:auto:Alert.Init
     public init(
-        title: String? = nil,
+        title: Expression<String>? = nil,
         message: Expression<String>,
         onPressOk: RawAction? = nil,
         labelOk: String? = nil

--- a/iOS/Schema/Sources/Action/Types/Confirm.swift
+++ b/iOS/Schema/Sources/Action/Types/Confirm.swift
@@ -20,7 +20,7 @@ import Foundation
 /// Action that represents confirm
 public struct Confirm: RawAction, AutoInitiableAndDecodable {
     
-    public let title: String?
+    public let title: Expression<String>?
     public let message: Expression<String>
     public let onPressOk: RawAction?
     public let onPressCancel: RawAction?
@@ -29,7 +29,7 @@ public struct Confirm: RawAction, AutoInitiableAndDecodable {
 
 // sourcery:inline:auto:Confirm.Init
     public init(
-        title: String? = nil,
+        title: Expression<String>? = nil,
         message: Expression<String>,
         onPressOk: RawAction? = nil,
         onPressCancel: RawAction? = nil,

--- a/iOS/Schema/Sources/Action/Types/Confirm.swift
+++ b/iOS/Schema/Sources/Action/Types/Confirm.swift
@@ -21,7 +21,7 @@ import Foundation
 public struct Confirm: RawAction, AutoInitiableAndDecodable {
     
     public let title: String?
-    public let message: String
+    public let message: Expression<String>
     public let onPressOk: RawAction?
     public let onPressCancel: RawAction?
     public let labelOk: String?
@@ -30,7 +30,7 @@ public struct Confirm: RawAction, AutoInitiableAndDecodable {
 // sourcery:inline:auto:Confirm.Init
     public init(
         title: String? = nil,
-        message: String,
+        message: Expression<String>,
         onPressOk: RawAction? = nil,
         onPressCancel: RawAction? = nil,
         labelOk: String? = nil,

--- a/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
+++ b/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
@@ -30,7 +30,7 @@ extension Alert {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        title = try container.decodeIfPresent(String.self, forKey: .title)
+        title = try container.decodeIfPresent(Expression<String>.self, forKey: .title)
         message = try container.decode(Expression<String>.self, forKey: .message)
         onPressOk = try container.decodeIfPresent(forKey: .onPressOk)
         labelOk = try container.decodeIfPresent(String.self, forKey: .labelOk)
@@ -73,7 +73,7 @@ extension Confirm {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        title = try container.decodeIfPresent(String.self, forKey: .title)
+        title = try container.decodeIfPresent(Expression<String>.self, forKey: .title)
         message = try container.decode(Expression<String>.self, forKey: .message)
         onPressOk = try container.decodeIfPresent(forKey: .onPressOk)
         onPressCancel = try container.decodeIfPresent(forKey: .onPressCancel)

--- a/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
+++ b/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
@@ -31,7 +31,7 @@ extension Alert {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         title = try container.decodeIfPresent(String.self, forKey: .title)
-        message = try container.decode(String.self, forKey: .message)
+        message = try container.decode(Expression<String>.self, forKey: .message)
         onPressOk = try container.decodeIfPresent(forKey: .onPressOk)
         labelOk = try container.decodeIfPresent(String.self, forKey: .labelOk)
     }
@@ -74,7 +74,7 @@ extension Confirm {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         title = try container.decodeIfPresent(String.self, forKey: .title)
-        message = try container.decode(String.self, forKey: .message)
+        message = try container.decode(Expression<String>.self, forKey: .message)
         onPressOk = try container.decodeIfPresent(forKey: .onPressOk)
         onPressCancel = try container.decodeIfPresent(forKey: .onPressCancel)
         labelOk = try container.decodeIfPresent(String.self, forKey: .labelOk)

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Alert.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Alert.swift
@@ -23,16 +23,12 @@ extension Alert: Action {
         guard let view = sender as? UIView else { return }
         let alertController = UIAlertController(title: title?.get(with: view), message: message.get(with: view), preferredStyle: .alert)
         
-        if let onPressOk = onPressOk {
-            let alertAction = UIAlertAction(title: labelOk ?? "Ok", style: .default) { _ in
+        let onPressOkAction = UIAlertAction(title: labelOk ?? "Ok", style: .default) { _ in
+            if let onPressOk = self.onPressOk {
                 controller.execute(action: onPressOk, sender: self)
             }
-            alertController.addAction(alertAction)
-        } else {
-            let alertAction = UIAlertAction(title: labelOk ?? "Ok", style: .default)
-            alertController.addAction(alertAction)
         }
-        
+        alertController.addAction(onPressOkAction)
         controller.present(alertController, animated: true)
     }
     

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Alert.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Alert.swift
@@ -20,12 +20,8 @@ import BeagleSchema
 
 extension Alert: Action {
     public func execute(controller: BeagleController, sender: Any) {
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
-        alertController.title = title
-        
-        alertController.message = message.get(with: alertController.view, controller: controller) { messageExpression in
-            alertController.message = messageExpression
-        }
+        guard let view = sender as? UIView else { return }
+        let alertController = UIAlertController(title: title?.get(with: view), message: message.get(with: view), preferredStyle: .alert)
         
         if let onPressOk = onPressOk {
             let alertAction = UIAlertAction(title: labelOk ?? "Ok", style: .default) { _ in

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Alert.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Alert.swift
@@ -20,14 +20,24 @@ import BeagleSchema
 
 extension Alert: Action {
     public func execute(controller: BeagleController, sender: Any) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
+        alertController.title = title
+        
+        alertController.message = message.get(with: alertController.view, controller: controller) { messageExpression in
+            alertController.message = messageExpression
+        }
+        
         if let onPressOk = onPressOk {
-            let alertAction = UIAlertAction(title: labelOk, style: .default) { _ in
+            let alertAction = UIAlertAction(title: labelOk ?? "Ok", style: .default) { _ in
                 controller.execute(action: onPressOk, sender: self)
             }
-            alert.addAction(alertAction)
+            alertController.addAction(alertAction)
+        } else {
+            let alertAction = UIAlertAction(title: labelOk ?? "Ok", style: .default)
+            alertController.addAction(alertAction)
         }
-        controller.present(alert, animated: true)
+        
+        controller.present(alertController, animated: true)
     }
     
 }

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Confirm.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Confirm.swift
@@ -20,13 +20,9 @@ import BeagleSchema
 
 extension Confirm: Action {
     public func execute(controller: BeagleController, sender: Any) {
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
-        alertController.title = title
-        
-        alertController.message = message.get(with: alertController.view, controller: controller) { messageExpression in
-            alertController.message = messageExpression
-        }
-        
+        guard let view = sender as? UIView else { return }
+        let alertController = UIAlertController(title: title?.get(with: view), message: message.get(with: view), preferredStyle: .alert)
+               
         if let onPressOk = onPressOk {
             let onPressOkAction = UIAlertAction(title: labelOk ?? "Ok", style: .default) { _ in
                 controller.execute(action: onPressOk, sender: self)

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Confirm.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Confirm.swift
@@ -30,7 +30,7 @@ extension Confirm: Action {
             }
         }
         
-        let onPressCancelAction = UIAlertAction(title: labelOk ?? "Cancel", style: .default) {
+        let onPressCancelAction = UIAlertAction(title: labelCancel ?? "Cancel", style: .default) {
             [weak controller] _ in guard let controller = controller else { return }
             if let onPressCancel = self.onPressCancel {
                 controller.execute(action: onPressCancel, sender: self)

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Confirm.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Confirm.swift
@@ -23,26 +23,22 @@ extension Confirm: Action {
         guard let view = sender as? UIView else { return }
         let alertController = UIAlertController(title: title?.get(with: view), message: message.get(with: view), preferredStyle: .alert)
                
-        if let onPressOk = onPressOk {
-            let onPressOkAction = UIAlertAction(title: labelOk ?? "Ok", style: .default) { _ in
+        let onPressOkAction = UIAlertAction(title: labelOk ?? "Ok", style: .default) {
+            [weak controller] _ in guard let controller = controller else { return }
+            if let onPressOk = self.onPressOk {
                 controller.execute(action: onPressOk, sender: self)
             }
-            alertController.addAction(onPressOkAction)
-        } else {
-            let labelOkAction = UIAlertAction(title: labelOk ?? "Ok", style: .default)
-            alertController.addAction(labelOkAction)
         }
         
-        if let onPressCancel = onPressCancel {
-            let onPressCancelAction = UIAlertAction(title: labelCancel ?? "Cancel", style: .default) { _ in
+        let onPressCancelAction = UIAlertAction(title: labelOk ?? "Cancel", style: .default) {
+            [weak controller] _ in guard let controller = controller else { return }
+            if let onPressCancel = self.onPressCancel {
                 controller.execute(action: onPressCancel, sender: self)
             }
-            alertController.addAction(onPressCancelAction)
-        } else {
-            let labelCancelAction = UIAlertAction(title: labelCancel ?? "Cancel", style: .default)
-            alertController.addAction(labelCancelAction)
         }
-
+        
+        alertController.addAction(onPressOkAction)
+        alertController.addAction(onPressCancelAction)
         controller.present(alertController, animated: true)
     }
 }

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/Confirm.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/Confirm.swift
@@ -20,19 +20,33 @@ import BeagleSchema
 
 extension Confirm: Action {
     public func execute(controller: BeagleController, sender: Any) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
+        alertController.title = title
+        
+        alertController.message = message.get(with: alertController.view, controller: controller) { messageExpression in
+            alertController.message = messageExpression
+        }
+        
         if let onPressOk = onPressOk {
-            let alertAction = UIAlertAction(title: labelOk, style: .default) { _ in
+            let onPressOkAction = UIAlertAction(title: labelOk ?? "Ok", style: .default) { _ in
                 controller.execute(action: onPressOk, sender: self)
             }
-            alert.addAction(alertAction)
+            alertController.addAction(onPressOkAction)
+        } else {
+            let labelOkAction = UIAlertAction(title: labelOk ?? "Ok", style: .default)
+            alertController.addAction(labelOkAction)
         }
-        if let onPressOk = onPressCancel {
-            let alertAction = UIAlertAction(title: labelCancel, style: .default) { _ in
-                controller.execute(action: onPressOk, sender: self)
+        
+        if let onPressCancel = onPressCancel {
+            let onPressCancelAction = UIAlertAction(title: labelCancel ?? "Cancel", style: .default) { _ in
+                controller.execute(action: onPressCancel, sender: self)
             }
-            alert.addAction(alertAction)
+            alertController.addAction(onPressCancelAction)
+        } else {
+            let labelCancelAction = UIAlertAction(title: labelCancel ?? "Cancel", style: .default)
+            alertController.addAction(labelCancelAction)
         }
-        controller.present(alert, animated: true)
+
+        controller.present(alertController, animated: true)
     }
 }


### PR DESCRIPTION
**Problem**.  #322 
- iOS application crashed when onPressOk property was not set on Alert and Confirm actions.

**Expected behavior**
- Set a default for those cases. 

**Additional Changes** 
- Title and message are now an Expression<String> instead of String.