### PR TITLE
fix: treated empty response body returned with HTTP 304 in Android

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpClientDefault.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpClientDefault.kt
@@ -114,8 +114,6 @@ internal class HttpClientDefault : HttpClient, CoroutineScope {
     }
 
     private fun createResponseData(urlConnection: HttpURLConnection): ResponseData {
-        val byteArray = urlConnection.inputStream.readBytes()
-
         return ResponseData(
             statusCode = urlConnection.responseCode,
             statusText = urlConnection.responseMessage,
@@ -125,7 +123,7 @@ internal class HttpClientDefault : HttpClient, CoroutineScope {
                     .replace("]", "")
                 it.key to headerValue
             }.toMap(),
-            data = byteArray
+            data = urlConnection.inputStream.let { if (it.available() > 0) it.readBytes() else byteArrayOf() }
         )
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/networking/HttpClientDefaultTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/networking/HttpClientDefaultTest.kt
@@ -103,6 +103,7 @@ class HttpClientDefaultTest {
         val headerValue = RandomData.string()
         val headers = mapOf(headerName to listOf(headerValue))
         every { httpURLConnection.headerFields } returns headers
+        every { inputStream.available() } returns 1
 
         lateinit var resultData: ResponseData
         val requestDataSlot = slot<OnSuccess>()


### PR DESCRIPTION
### Problem
Empty response body that came with `HTTP 304` from BFF's cache mechanism lead to HTTP client error. 

### Solution
Check the presence of response body and treat the absence accordingly.

Fixes #300.
