### PR TITLE
fix: replaced presence check with EOF exception handling

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpClientDefault.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpClientDefault.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.io.EOFException
 import java.net.HttpURLConnection
 
 typealias OnSuccess = (responseData: ResponseData) -> Unit
@@ -123,7 +124,11 @@ internal class HttpClientDefault : HttpClient, CoroutineScope {
                     .replace("]", "")
                 it.key to headerValue
             }.toMap(),
-            data = urlConnection.inputStream.let { if (it.available() > 0) it.readBytes() else byteArrayOf() }
+            data = try {
+                urlConnection.inputStream.readBytes()
+            } catch (e: EOFException) {
+                byteArrayOf()
+            }
         )
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/networking/HttpClientDefaultTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/networking/HttpClientDefaultTest.kt
@@ -37,12 +37,14 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.io.EOFException
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 private val BYTE_ARRAY_DATA = byteArrayOf()
@@ -103,7 +105,6 @@ class HttpClientDefaultTest {
         val headerValue = RandomData.string()
         val headers = mapOf(headerName to listOf(headerValue))
         every { httpURLConnection.headerFields } returns headers
-        every { inputStream.available() } returns 1
 
         lateinit var resultData: ResponseData
         val requestDataSlot = slot<OnSuccess>()
@@ -396,6 +397,28 @@ class HttpClientDefaultTest {
 
         // Then
         assertEquals(responseData, errorResult)
+    }
+
+    @Test
+    fun execute_should_read_empty_response() = runBlockingTest {
+        // Given
+        val headerName = RandomData.string()
+        val headerValue = RandomData.string()
+        val headers = mapOf(headerName to listOf(headerValue))
+        every { httpURLConnection.headerFields } returns headers
+        every { inputStream.readBytes() } throws EOFException()
+
+        lateinit var resultData: ResponseData
+        urlRequestDispatchingDefault.execute(makeSimpleRequestData(), onSuccess = {
+            resultData = it
+        }, onError = {
+            fail("Test failed, should execute successfully")
+        })
+
+        assertEquals(STATUS_CODE, resultData.statusCode)
+        assertTrue(resultData.data.isEmpty())
+        assertEquals(headerName, resultData.headers.keys.elementAt(0))
+        assertEquals(headerValue, resultData.headers[headerName])
     }
 
     private fun makeSimpleRequestData() = RequestData(uri)


### PR DESCRIPTION
### Problem
Presence check on Android HTTP client inputstream is failing, leading to empty bodies.

### Solution
Replace check with EOF exception handling when reading body.