### PR TITLE
refactor: readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@
 
 ## What is Beagle?
 
-Beagle is a **cross-platform framework** which facilitates usage of the **Server-Driven UI** concept, **natively** in iOS and Android. By using Beagle, your team could easily change application's layout and data by just changing backend code.
+Beagle is an **open source framework** for **cross-platform** development using the concept of Server-Driven UI.
+
+This framework allow teams to build and alter layouts and data directly through a backend page layout but yet displaying its contents nativelly in a mobile applications and / or yet through web.
+
+It is also possible to create, test and update native application components and screen paths without the need update the mobile application at the store (App Store or Play Store).
+
 #
-#### Goals for Beagle
+### Goals for Beagle
 
 -   Automatic app updates without having to rely on App Store or Play Store slow processes
 
@@ -16,19 +21,22 @@ Beagle is a **cross-platform framework** which facilitates usage of the **Server
 
 -   Easier maintainability and testability
 
--   To be flexible for UI Designers
+-   To be flexible for UI Designers and Developers
+
 #
 #### How it works
 
-Your application will **define** all UI components it can render (Design System) and **register** them inside Beagle. With that, now your BFF (Backend For Frontend) will be able to control how your application will be presented by returning a JSON that describes the interface for each endpoint.
+<img src=https://usebeagle.io/static/fdc419fbc7141bee9f3e734bc3a3fcc0/f3583/mobile-illustration.png>
 
-![](https://blobs.gitbook.com/assets%2F-M-Qy7jZbUpzGRP5GbCZ%2F-M-RRc0XmH0zvxTIpMdW%2F-M-UyUyBv3ZqZpZl8m-E%2FWhatsApp%20Image%202020-02-06%20at%2019.21.26.jpeg?alt=media&token=7ea0eb18-0950-4a0e-af1c-91f836b1c66c)
 
 #### Server-Driven UI
+<img src=https://usebeagle.io/static/34afd90e97b970f68d6445e2eca28a89/0fba7/change-illustration.png>
 
-![](https://blobs.gitbook.com/assets%2F-M-Qy7jZbUpzGRP5GbCZ%2F-M-Vb8Yg30urdiTYjfB3%2F-M-VjxuYL-Q8MKfVharu%2Fimage42.png?alt=media&token=2c64711f-ba57-4754-a213-5a94ff387429)
+**Server-Driven UI** is an implementation paradigm that defines an API to tell the client what components to render and with what content. This can be implemented in all three major platforms: Android, iOS, and the web.
 
-**Server-Driven UI**  is an implementation paradigm that defines how the visual components are settle on a screen, the screen structure and how pages will flow to one another. All this information comes from a server called **Back-end For Front-end** through `JSON` objects. In the Server Driven paradigm the structure and flow between screens is incorporated into the `JSON` objects trafficked with content, which are divided into 3 basic pillars: **content, visual structure and flow (actions)**.  Check the **Beagle** example on the block below:
+All this information comes from a server called **BFF** or **Back-end For Front-end** through `JSON` objects. In the Server Driven paradigm the structure and flow between screens is incorporated into the `JSON` objects trafficked with content, which could be divided into 3 basic pillars: **content, visual structure and flow (actions)**.
+
+Check a **Beagle** example on the code block below:
 
 ```javascript
 {
@@ -75,19 +83,21 @@ Your application will **define** all UI components it can render (Design System)
     }
 }
 ```
-The front-end will set the visual structure and how pages connects and acts on one another natively according to the front-end system. As the application sends all actions to the back end, it responds systematically to each action, which configures our “single source of truth”.
+When recieving this information the front-end will set the screen visual structure and how screen pages connects and acts on one another natively according to the front-end system. As the application sends all actions to the back end, it responds systematically to each action, which configures our Single Source of Truth.
 
 In this model the new features and combinations of UI components can be tested without releases and updates, which practically summarizes an A / B type test.
 
 Different types of styles and layouts can be tested in certain customer's`circles` , which implies several testing possibilities and Analytics data.
 
-##
+#
 
 #### Backend For Frontend
 
-This is the server that provides the `JSON` objects that will be rendered by the front as `views`. With this component, screens and business rules are written only once and thus rendered natively on each platform that Beagle is present on.
+This is a server that provides the `JSON` objects that will be rendered at the frontend as `views`. With in these components, screens and business rules are written only once and thus rendered natively on each platform using Beagle.
+<br>
 
-##
+<img src="https://usebeagle.io/static/d01b8b04150a9f0fd80cd53c29fa4e3c/719de/framework-ilustration.png">
+#
 
 #### Declarative Views
 
@@ -127,7 +137,7 @@ It is the paradigm by which the layouts are declared in the back-end, in a simpl
     }
 }
 ```
-##
+#
 
 #### Serializer
 
@@ -135,7 +145,7 @@ The `Beagle serializer` responsibility is converting a declarative layout into a
 
 To serialize Kotlin classes in JSON objects, Beagle uses _Jackson_.
 
-##
+#
 
 #### Deserializer
 
@@ -143,25 +153,27 @@ The `Beagle deserializer` responsibility is to convert a `JSON` object into a `w
 
 On Android _Moshi_ is used for this purpose.
 
-![](https://blobs.gitbook.com/assets%2F-M-Qy7jZbUpzGRP5GbCZ%2F-M-Vb8Yg30urdiTYjfB3%2F-M-Vj__Tmdf3Px_wVuu2%2FCaptura%20de%20Tela%202020-02-07%20a%CC%80s%2014.25.17.png?alt=media&token=8f788eee-4371-4aca-b079-0ead3b6b0eb4)
+<img src="https://usebeagle.io/static/906d90457bb9641b21d5b8f59da9f555/40a76/web-illustration.png">
 
-Beagle BFF and Beagle Mobile
+Beagle WEB ----------------------------------- Beagle BFF
 
 #
 
-#### Design System Language
+#### Design System
 
-It is an interface that defines a set of methods that must be implemented to define the **application's theme**. The `appDesignSystem` must keep the button styles, text displays, toolbar styles, images and themes. For Beagle to work according to the application design system, it is necessary to have all of these styles implemented. They will be used the moment the visualization is rendered.
+With a Design System you will be able to set styles for your components and views.
+
+It is the design system that registers styles created on the application frontend connecting them to the Server driven components received from the BFF. That is how the application will "know" what style to apply on each component.
+
+The Design system is an interface that defines a set of methods that must be implemented to define the **application's theme** amoung other components. For example, an `appDesignSystem` will keep button styles, text displays, toolbar styles, images and themes. For Beagle to work according to the application design system, it is necessary to have all of these styles implemented. They will be used the moment the visualization is rendered.
 
 ![](https://blobs.gitbook.com/assets%2F-M-Qy7jZbUpzGRP5GbCZ%2F-M-Vb8Yg30urdiTYjfB3%2F-M-VkXqAaAU8k7KAUaLW%2Fimage22.png?alt=media&token=62e91f51-a030-499d-91ca-f5131fd88790)
-
-Design System Language for text, color and scale
 
 #
 
 #### Layout Engine
 
-When rendering the screen the front-end receives a `JSON` object that provides all necessary information through **Beagle** to position the elements on the screen and deserialize it natively for Android or iOS.
+When rendering a screen the front-end receives a `JSON` object that provides all necessary information through **Beagle** to position the elements on the screen
 
 When deserializing, Beagle turns a `widget` into a `view` applying the styles implemented in the `DesignSystem`. At this point, Beagle uses the [**YOGA**](https://yogalayout.com/) rendering engine internally to set the layout's view position and finally render it natively.
 
@@ -169,10 +181,13 @@ When deserializing, Beagle turns a `widget` into a `view` applying the styles im
 
 #### Learn how to:
 
-- [Create a Backend project](https://zup-products.gitbook.io/beagle/introducing/beagle-backend)
-- [Create an Android project](https://zup-products.gitbook.io/beagle/introducing/android)
-- [Create an iOS project](https://zup-products.gitbook.io/beagle/introducing/ios)
+[Create a Backend project](https://docs.usebeagle.io/v/v1.0-en/get-started/installing-beagle/beagle-backend)
+[Create an Android project](https://docs.usebeagle.io/v/v1.0-en/get-started/installing-beagle/android)
+[Create an iOS project](https://docs.usebeagle.io/v/v1.0-en/get-started/installing-beagle/ios)
+[Create an WEB project](https://docs.usebeagle.io/v/v1.0-en/get-started/installing-beagle/web)
+
+<img src = "https://usebeagle.io/static/495f34d913f71babdebf6d6e08bb21dc/0fba7/migre-illustration.png">
 
 ## Contributing guide
 
-Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to add new feature and contribute in general to Beagle
+Please refer to [CONTRIBUTING.md](https://github.com/ZupIT/beagle/blob/master/CONTRIBUTING.md) for details on how to add new feature and contribute in general to Beagle

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Beagle is an **open source framework** for **cross-platform** development using the concept of Server-Driven UI.
 
-This framework allow teams to build and alter layouts and data directly through a backend page layout but yet displaying its contents nativelly in a mobile applications and / or yet through web.
+This framework allow teams to build and alter layouts and data directly through a backend but yet displaying its contents natively in a mobile application and / or through web.
 
 It is also possible to create, test and update native application components and screen paths without the need update the mobile application at the store (App Store or Play Store).
 


### PR DESCRIPTION
The README was refactored and the links were updated into linking the updated documentation.
Since the English DOCs are not yet set the links are connecting to the Portuguese DOCs.
The text and info configuration was slightly changed and revised.