### PR TITLE
ci: update xcode version to 11.5.0

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,7 +42,7 @@ platform :ios do
 
   desc "Pull Request verification"
   lane :pull_request_verification do
-    xcversion(version: "~> 11.4")
+    xcversion(version: "~> 11.5.0")
     iOSSwiftLint
     init_ios_dependencies
     scan(


### PR DESCRIPTION
Problem: 
Fastlane its using Xcode beta version, what is making some tests fail due to different device version.