### PR TITLE
fix: SetContext context parameter renamed to contextId

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/ComponentInteractionScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/ComponentInteractionScreen.swift
@@ -48,7 +48,7 @@ let declarativeScreen: Screen = {
                         TextInput(
                             onChange: [
                                 SetContext(
-                                    context: "context1",
+                                    contextId: "context1",
                                     value: "@{onChange.value}"
                                 )
                             ]
@@ -59,7 +59,7 @@ let declarativeScreen: Screen = {
                             text: "1",
                             onPress: [
                                 SetContext(
-                                    context: "context1",
+                                    contextId: "context1",
                                     value: "update"
                                 )
                             ]
@@ -68,7 +68,7 @@ let declarativeScreen: Screen = {
                             text: "2",
                             onPress: [
                                 SetContext(
-                                    context: "context2",
+                                    contextId: "context2",
                                     value: "update"
                                 )
                             ]

--- a/iOS/Schema/Sources/Action/Types/SetContext.swift
+++ b/iOS/Schema/Sources/Action/Types/SetContext.swift
@@ -15,17 +15,17 @@
  */
 
 public struct SetContext: RawAction, AutoInitiable {
-    public let context: String
+    public let contextId: String
     public let path: Path?
     public let value: DynamicObject
     
 // sourcery:inline:auto:SetContext.Init
     public init(
-        context: String,
+        contextId: String,
         path: Path? = nil,
         value: DynamicObject
     ) {
-        self.context = context
+        self.contextId = contextId
         self.path = path
         self.value = value
     }

--- a/iOS/Schema/Sources/Widgets/TextInput/Tests/JSON/TextInputComponent.json
+++ b/iOS/Schema/Sources/Widgets/TextInput/Tests/JSON/TextInputComponent.json
@@ -6,7 +6,7 @@
   "onChange": [
       {
         "_beagleAction_": "beagle:setcontext",
-        "context": "myContext",
+        "contextId": "myContext",
         "value": "2"
       }
   ],

--- a/iOS/Schema/Sources/Widgets/TextInput/Tests/__Snapshots__/TextInputTests/test_whenDecodingJson_shouldReturnAText.1.txt
+++ b/iOS/Schema/Sources/Widgets/TextInput/Tests/__Snapshots__/TextInputTests/test_whenDecodingJson_shouldReturnAText.1.txt
@@ -5,7 +5,7 @@
   ▿ onChange: Optional<Array<RawAction>>
     ▿ some: 1 element
       ▿ SetContext
-        - context: "myContext"
+        - contextId: "myContext"
         - path: Optional<Path>.none
         ▿ value: DynamicObject
           - string: "2"

--- a/iOS/Sources/BeagleUI/Sources/Action/Types/SetContext.swift
+++ b/iOS/Sources/BeagleUI/Sources/Action/Types/SetContext.swift
@@ -23,13 +23,13 @@ extension SetContext: Action {
         guard let view = sender as? UIView else { return }
         
         let valueEvaluated = value.get(with: view)
-        let contextObserver = view.getContext(with: context)
+        let contextObserver = view.getContext(with: contextId)
 
         if var contextValue = contextObserver?.value.value, let path = path {
             contextValue.set(valueEvaluated, forPath: path)
-            contextObserver?.value = Context(id: context, value: contextValue)
+            contextObserver?.value = Context(id: contextId, value: contextValue)
         } else {
-            contextObserver?.value = Context(id: context, value: valueEvaluated)
+            contextObserver?.value = Context(id: contextId, value: valueEvaluated)
         }
     }
 }

--- a/iOS/Sources/BeagleUI/Sources/Components/WebView+Renderable/WebView+Renderable.swift
+++ b/iOS/Sources/BeagleUI/Sources/Components/WebView+Renderable/WebView+Renderable.swift
@@ -20,7 +20,7 @@ import BeagleSchema
 
 extension WebView: ServerDrivenComponent {
     public func toView(renderer: BeagleRenderer) -> UIView {
-        var view = WebViewUIComponent(model: WebViewUIComponent.Model(url: ""))
+        let view = WebViewUIComponent(model: WebViewUIComponent.Model(url: ""))
         renderer.observe(url, andUpdate: \.model, in: view) {
             WebViewUIComponent.Model(url: $0)
         }


### PR DESCRIPTION
Rename context parameter in SetContext to contextId