### PR TITLE
chore: new Xcode Scheme called "All" that will build and test everything

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,7 @@ platform :ios do
     carthage(
       command: "bootstrap",
       platform: "iOS",
-      project_directory: "iOS/Sources/Beagle/", cache_builds: true
+      project_directory: "iOS/", cache_builds: true
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,7 +47,7 @@ platform :ios do
     init_ios_dependencies
     scan(
       workspace: "iOS/Beagle.xcworkspace/",
-      scheme: "Beagle",
+      scheme: "All",
       device: "iPhone 11"
     )
     commit_hash = last_git_commit[:commit_hash]

--- a/iOS/Cartfile
+++ b/iOS/Cartfile
@@ -1,0 +1,2 @@
+github "pointfreeco/swift-snapshot-testing"
+github "daltoniam/Starscream" == 4.0.3

--- a/iOS/Cartfile.resolved
+++ b/iOS/Cartfile.resolved
@@ -1,1 +1,2 @@
+github "daltoniam/Starscream" "4.0.3"
 github "pointfreeco/swift-snapshot-testing" "1.7.2"

--- a/iOS/Schema/BeagleSchema.xcodeproj/project.pbxproj
+++ b/iOS/Schema/BeagleSchema.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		C08D4EF3248A7C1D00AAAC0A /* WidgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08D4EEA248A7C1600AAAC0A /* WidgetTests.swift */; };
 		C08D4EF4248A7C2E00AAAC0A /* widgetWithAllAttributes.json in Resources */ = {isa = PBXBuildFile; fileRef = C08D4EEC248A7C1600AAAC0A /* widgetWithAllAttributes.json */; };
 		C0FBBD212475803900B72A9B /* BeagleSchema.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0FBBD172475803900B72A9B /* BeagleSchema.framework */; };
-		C0FBBD3324759EDD00B72A9B /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0FBBD3224759EDD00B72A9B /* SnapshotTesting.framework */; };
+		C838415E24A4483400EDD344 /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C838415D24A4483400EDD344 /* SnapshotTesting.framework */; };
 		C864D2A2247C240200E7A1F9 /* FormSubmit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D221247C240200E7A1F9 /* FormSubmit.swift */; };
 		C864D2A4247C240200E7A1F9 /* FormInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D224247C240200E7A1F9 /* FormInput.swift */; };
 		C864D2A5247C240200E7A1F9 /* FormInputHidden.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864D225247C240200E7A1F9 /* FormInputHidden.swift */; };
@@ -158,7 +158,7 @@
 		C08D4EF5248A7C5900AAAC0A /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		C0FBBD172475803900B72A9B /* BeagleSchema.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BeagleSchema.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0FBBD202475803900B72A9B /* BeagleSchemaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BeagleSchemaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		C0FBBD3224759EDD00B72A9B /* SnapshotTesting.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SnapshotTesting.framework; path = Carthage/Build/iOS/SnapshotTesting.framework; sourceTree = "<group>"; };
+		C838415D24A4483400EDD344 /* SnapshotTesting.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SnapshotTesting.framework; path = ../Carthage/Build/iOS/SnapshotTesting.framework; sourceTree = "<group>"; };
 		C864D220247C240200E7A1F9 /* FormSubmitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormSubmitTests.swift; sourceTree = "<group>"; };
 		C864D221247C240200E7A1F9 /* FormSubmit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormSubmit.swift; sourceTree = "<group>"; };
 		C864D224247C240200E7A1F9 /* FormInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormInput.swift; sourceTree = "<group>"; };
@@ -272,7 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C0FBBD212475803900B72A9B /* BeagleSchema.framework in Frameworks */,
-				C0FBBD3324759EDD00B72A9B /* SnapshotTesting.framework in Frameworks */,
+				C838415E24A4483400EDD344 /* SnapshotTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -408,7 +408,7 @@
 		C0FBBD3124759EDD00B72A9B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C0FBBD3224759EDD00B72A9B /* SnapshotTesting.framework */,
+				C838415D24A4483400EDD344 /* SnapshotTesting.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1047,7 +1047,7 @@
 				C0FBBD1C2475803900B72A9B /* Sources */,
 				C0FBBD1D2475803900B72A9B /* Frameworks */,
 				C0FBBD1E2475803900B72A9B /* Resources */,
-				C0FBBD362475A10700B72A9B /* Run Carthage Script */,
+				C838416224A4656E00EDD344 /* Run Carthage Script */,
 			);
 			buildRules = (
 			);
@@ -1161,26 +1161,6 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		C0FBBD362475A10700B72A9B /* Run Carthage Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/SnapshotTesting.framework",
-			);
-			name = "Run Carthage Script";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SnapshotTesting.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n/usr/local/bin/carthage copy-frameworks\n";
-		};
 		C0FBBE1A2475CA4E00B72A9B /* Sourcery Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1198,6 +1178,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n../Sources/Beagle/CodeGeneration/sourceryScript.sh\n";
+		};
+		C838416224A4656E00EDD344 /* Run Carthage Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../Carthage/Build/iOS/SnapshotTesting.framework",
+			);
+			name = "Run Carthage Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SnapshotTesting.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1481,7 +1481,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1503,7 +1503,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/iOS/Schema/Cartfile
+++ b/iOS/Schema/Cartfile
@@ -1,1 +1,0 @@
-github "pointfreeco/swift-snapshot-testing"

--- a/iOS/Schema/Sources/Action/Types/Navigate/Tests/Json/pushview.json
+++ b/iOS/Schema/Sources/Action/Types/Navigate/Tests/Json/pushview.json
@@ -1,7 +1,7 @@
 {
     "_beagleAction_": "beagle:pushView",
     "route": {
-        "route": "schema://path",
+        "url": "schema://path",
         "shouldPrefetch": true,
         "fallback": {
             "child" : {

--- a/iOS/Schema/Sources/Action/Types/Navigate/Tests/Json/resetapplication.json
+++ b/iOS/Schema/Sources/Action/Types/Navigate/Tests/Json/resetapplication.json
@@ -1,6 +1,6 @@
 {
     "_beagleAction_": "beagle:resetapplication",
     "route": {
-        "route": "schema://path"
+        "url": "schema://path"
     }
 }

--- a/iOS/Schema/Sources/Action/Types/Navigate/Tests/Json/resetstack.json
+++ b/iOS/Schema/Sources/Action/Types/Navigate/Tests/Json/resetstack.json
@@ -1,6 +1,6 @@
 {
     "_beagleAction_": "beagle:resetstack",
     "route": {
-        "route": "schema://path"
+        "url": "schema://path"
     }
 }

--- a/iOS/Sources/Beagle/Beagle.xcodeproj/project.pbxproj
+++ b/iOS/Sources/Beagle/Beagle.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		C829CF2323B197CF001B7225 /* FormInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A77640237DC140002F5515 /* FormInputTests.swift */; };
 		C829CF2A23B197FB001B7225 /* RepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50B2840236350B9005E2E6D /* RepositoryTests.swift */; };
 		C8311A6924099A8700E95C15 /* WidgetStateObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8311A6824099A8700E95C15 /* WidgetStateObservable.swift */; };
+		C838416024A4485700EDD344 /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C838415F24A4485700EDD344 /* SnapshotTesting.framework */; };
 		C852A0F3247F246B009535D9 /* BeagleRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C852A0F2247F246B009535D9 /* BeagleRenderer.swift */; };
 		C85688BB2433C4A400DD8B60 /* BeagleMessageLogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C03910724250772003E6FCD /* BeagleMessageLogs.swift */; };
 		C85688BC2433C4A800DD8B60 /* BeagleLoggerDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C03910924250FC6003E6FCD /* BeagleLoggerDefault.swift */; };
@@ -182,7 +183,6 @@
 		C89FFA942412EA4200C1B53B /* UrlBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89FFA932412EA4200C1B53B /* UrlBuilder.swift */; };
 		C8D5F01C24A3FD740037B11C /* BeagleSchema.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8D5F01B24A3FD740037B11C /* BeagleSchema.framework */; };
 		C8D5F02024A3FD840037B11C /* YogaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8D5F01F24A3FD840037B11C /* YogaKit.framework */; };
-		C8E42FD123C7C98000B1963F /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8E42FCF23C7C89800B1963F /* SnapshotTesting.framework */; };
 		C8F953162395960200615CF0 /* PageViewUIComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F95314239595C500615CF0 /* PageViewUIComponentTests.swift */; };
 		E50B284523639299005E2E6D /* BeagleScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50B284423639299005E2E6D /* BeagleScreenViewControllerTests.swift */; };
 		E516E61023705BED006620B1 /* BeagleViewBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E516E60F23705BED006620B1 /* BeagleViewBuilderTests.swift */; };
@@ -395,6 +395,7 @@
 		C829CF1123B1967D001B7225 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		C829CF1323B196C1001B7225 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		C8311A6824099A8700E95C15 /* WidgetStateObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStateObservable.swift; sourceTree = "<group>"; };
+		C838415F24A4485700EDD344 /* SnapshotTesting.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SnapshotTesting.framework; path = ../../Carthage/Build/iOS/SnapshotTesting.framework; sourceTree = "<group>"; };
 		C852A0F2247F246B009535D9 /* BeagleRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeagleRenderer.swift; sourceTree = "<group>"; };
 		C85688C12433F87400DD8B60 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		C85D9BA0238701E60075B6C0 /* PageViewUIComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewUIComponent.swift; sourceTree = "<group>"; };
@@ -480,7 +481,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E5CE41EC2332B9B600295277 /* Beagle.framework in Frameworks */,
-				C8E42FD123C7C98000B1963F /* SnapshotTesting.framework in Frameworks */,
+				C838416024A4485700EDD344 /* SnapshotTesting.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1467,6 +1468,7 @@
 		E53524A923310F5A00D1A0C9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C838415F24A4485700EDD344 /* SnapshotTesting.framework */,
 				C8D5F01F24A3FD840037B11C /* YogaKit.framework */,
 				C8D5F01B24A3FD740037B11C /* BeagleSchema.framework */,
 				57A8098D243CF5020034D180 /* CoreData.framework */,
@@ -1687,7 +1689,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/SnapshotTesting.framework",
+				"$(SRCROOT)/../../Carthage/Build/iOS/SnapshotTesting.framework",
 			);
 			name = "Carthage Run Script";
 			outputFileListPaths = (
@@ -2122,7 +2124,7 @@
 				DEVELOPMENT_TEAM = YKYJK8YBGT;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/../../Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = BeagleTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -2146,7 +2148,7 @@
 				DEVELOPMENT_TEAM = YKYJK8YBGT;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/../../Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = BeagleTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/iOS/Sources/Beagle/Beagle.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/iOS/Sources/Beagle/Beagle.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "932925CE2327E11000A61F01"
+               BuildableName = "Beagle.framework"
+               BlueprintName = "Beagle"
+               ReferencedContainer = "container:Beagle.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "932925AD2327E0E400A61F01"
+               BuildableName = "BeagleDemo.app"
+               BlueprintName = "BeagleDemo"
+               ReferencedContainer = "container:../../Example/BeagleDemo/BeagleDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7623CF7D24254C9600688C4B"
+               BuildableName = "BeaglePreview.framework"
+               BlueprintName = "BeaglePreview"
+               ReferencedContainer = "container:../Preview/BeaglePreview.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7615576724801E7700E1EEEE"
+               BuildableName = "BeaglePreviewDemo.app"
+               BlueprintName = "BeaglePreviewDemo"
+               ReferencedContainer = "container:../../Example/BeaglePreviewDemo/BeaglePreviewDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C0FBBD162475803900B72A9B"
+               BuildableName = "BeagleSchema.framework"
+               BlueprintName = "BeagleSchema"
+               ReferencedContainer = "container:../../Schema/BeagleSchema.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "932925CE2327E11000A61F01"
+            BuildableName = "Beagle.framework"
+            BlueprintName = "Beagle"
+            ReferencedContainer = "container:Beagle.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0FBBD162475803900B72A9B"
+            BuildableName = "BeagleSchema.framework"
+            BlueprintName = "BeagleSchema"
+            ReferencedContainer = "container:../../Schema/BeagleSchema.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E5CE41E62332B9B600295277"
+               BuildableName = "BeagleTests.xctest"
+               BlueprintName = "BeagleTests"
+               ReferencedContainer = "container:Beagle.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C09F410D249BDEE8002605EE"
+               BuildableName = "BeagleDemoTests.xctest"
+               BlueprintName = "BeagleDemoTests"
+               ReferencedContainer = "container:../../Example/BeagleDemo/BeagleDemo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C0FBBD1F2475803900B72A9B"
+               BuildableName = "BeagleSchemaTests.xctest"
+               BlueprintName = "BeagleSchemaTests"
+               ReferencedContainer = "container:../../Schema/BeagleSchema.xcodeproj">
+            </BuildableReference>
+            <LocationScenarioReference
+               identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+               referenceType = "1">
+            </LocationScenarioReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "932925AD2327E0E400A61F01"
+            BuildableName = "BeagleDemo.app"
+            BlueprintName = "BeagleDemo"
+            ReferencedContainer = "container:../../Example/BeagleDemo/BeagleDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "932925CE2327E11000A61F01"
+            BuildableName = "Beagle.framework"
+            BlueprintName = "Beagle"
+            ReferencedContainer = "container:Beagle.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS/Sources/Beagle/Beagle.xcodeproj/xcshareddata/xcschemes/Beagle.xcscheme
+++ b/iOS/Sources/Beagle/Beagle.xcodeproj/xcshareddata/xcschemes/Beagle.xcscheme
@@ -56,9 +56,9 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "932925CE2327E11000A61F01"
-            BuildableName = "BeagleUI.framework"
-            BlueprintName = "BeagleUI"
-            ReferencedContainer = "container:BeagleUI.xcodeproj">
+            BuildableName = "Beagle.framework"
+            BlueprintName = "Beagle"
+            ReferencedContainer = "container:Beagle.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
       <Testables>

--- a/iOS/Sources/Beagle/Cartfile
+++ b/iOS/Sources/Beagle/Cartfile
@@ -1,1 +1,0 @@
-github "pointfreeco/swift-snapshot-testing"

--- a/iOS/Sources/Beagle/Cartfile.resolved
+++ b/iOS/Sources/Beagle/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "pointfreeco/swift-snapshot-testing" "1.7.2"

--- a/iOS/Sources/Preview/BeaglePreview.xcodeproj/project.pbxproj
+++ b/iOS/Sources/Preview/BeaglePreview.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		761557A62480249800E1EEEE /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 761557A52480249800E1EEEE /* Starscream.framework */; };
-		761557A72480249800E1EEEE /* Starscream.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 761557A52480249800E1EEEE /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7623CF8324254C9600688C4B /* BeaglePreview.h in Headers */ = {isa = PBXBuildFile; fileRef = 7623CF8124254C9600688C4B /* BeaglePreview.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7623CF8D24254D3900688C4B /* BeaglePreviewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7623CF8A24254D3900688C4B /* BeaglePreviewConfig.swift */; };
 		7623CF8E24254D3900688C4B /* BeaglePreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7623CF8B24254D3900688C4B /* BeaglePreviewViewController.swift */; };
@@ -18,6 +16,7 @@
 		7659EC61247C482400F5BE17 /* BeaglePreviewDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7659EC60247C482400F5BE17 /* BeaglePreviewDependencies.swift */; };
 		C8330590249BF6A40091FE5E /* Beagle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C833058F249BF6A40091FE5E /* Beagle.framework */; };
 		C8330591249BF6A40091FE5E /* Beagle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C833058F249BF6A40091FE5E /* Beagle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C838415B24A447FD00EDD344 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C838415A24A447FD00EDD344 /* Starscream.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -28,7 +27,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				C8330591249BF6A40091FE5E /* Beagle.framework in Embed Frameworks */,
-				761557A72480249800E1EEEE /* Starscream.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -48,6 +46,7 @@
 		7659EC5B247C3EFD00F5BE17 /* WSConnectionHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WSConnectionHandler.swift; sourceTree = "<group>"; };
 		7659EC60247C482400F5BE17 /* BeaglePreviewDependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeaglePreviewDependencies.swift; sourceTree = "<group>"; };
 		C833058F249BF6A40091FE5E /* Beagle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Beagle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C838415A24A447FD00EDD344 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = ../../Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,7 +55,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C8330590249BF6A40091FE5E /* Beagle.framework in Frameworks */,
-				761557A62480249800E1EEEE /* Starscream.framework in Frameworks */,
+				C838415B24A447FD00EDD344 /* Starscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,6 +105,7 @@
 		7623CF902425529A00688C4B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C838415A24A447FD00EDD344 /* Starscream.framework */,
 				C833058F249BF6A40091FE5E /* Beagle.framework */,
 				761557AB2480250700E1EEEE /* BeagleUI.framework */,
 				761557A52480249800E1EEEE /* Starscream.framework */,
@@ -136,6 +136,7 @@
 				7623CF7B24254C9600688C4B /* Frameworks */,
 				7623CF7C24254C9600688C4B /* Resources */,
 				761557A42480230F00E1EEEE /* Embed Frameworks */,
+				C838416324A4662200EDD344 /* Run Carthage Script */,
 			);
 			buildRules = (
 			);
@@ -187,6 +188,29 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		C838416324A4662200EDD344 /* Run Carthage Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../../Carthage/Build/iOS/Starscream.framework",
+			);
+			name = "Run Carthage Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Starscream.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		7623CF7A24254C9600688C4B /* Sources */ = {
@@ -340,7 +364,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/../../Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -369,7 +393,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/../../Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/iOS/Sources/Preview/Cartfile
+++ b/iOS/Sources/Preview/Cartfile
@@ -1,1 +1,0 @@
-github "daltoniam/Starscream" == 4.0.3

--- a/iOS/Sources/Preview/Cartfile.resolved
+++ b/iOS/Sources/Preview/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "daltoniam/Starscream" "4.0.3"


### PR DESCRIPTION
- created an Xcode Scheme named `All` that will be used locally during development and on CI to properly build and test all code
- all targets that use Carthage are now referencing to the same folder that contains all dependencies
- ⚠️ Codecov is still NOT working, but it's better to avoid test failing than coverage drop for now