### PR TITLE
fix: disable warnings about documentation

### DIFF
--- a/dokka.gradle
+++ b/dokka.gradle
@@ -24,4 +24,8 @@ dokka {
     outputDirectory = "$buildDir/javadoc"
 
     disableAutoconfiguration = false
+
+    configuration {
+        reportUndocumented = false
+    }
 }


### PR DESCRIPTION
Always start a new release the gradle show warnings about documentation, I disabled to this moment because need to discuss with the team about documentation