### PR TITLE
fix: pageView size is defined by the parent size

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageView.kt
@@ -28,6 +28,11 @@ import br.com.zup.beagle.android.view.ViewFactory
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.WidgetView
 import br.com.zup.beagle.core.ServerDrivenComponent
+import br.com.zup.beagle.core.Style
+import br.com.zup.beagle.widget.core.Flex
+import br.com.zup.beagle.widget.core.Size
+import br.com.zup.beagle.widget.core.UnitType
+import br.com.zup.beagle.widget.core.UnitValue
 
 data class PageView(
     val children: List<ServerDrivenComponent>,
@@ -42,18 +47,15 @@ data class PageView(
     private val viewRendererFactory: ViewRendererFactory = ViewRendererFactory()
 
     override fun buildView(rootView: RootView): View {
-        val container = viewFactory.makeBeagleFlexView(rootView.getContext())
+        val style = Style(flex = Flex(grow = 1.0))
 
         val viewPager = viewFactory.makeViewPager(rootView.getContext()).apply {
             adapter = PageViewAdapter(rootView, children, viewFactory)
         }
 
-        // this container is needed because this view fill the parent completely
-        val containerViewPager =
-            viewFactory.makeBeagleFlexView(rootView.getContext()).apply {
-                addView(viewPager)
-            }
-        container.addView(containerViewPager)
+        val container = viewFactory.makeBeagleFlexView(rootView.getContext(), style).apply {
+            addView(viewPager, style)
+        }
 
         pageIndicator?.let {
             val pageIndicatorView = viewRendererFactory.make(it).build(rootView)

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ScrollViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ScrollViewFragment.kt
@@ -37,7 +37,9 @@ import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.components.layout.ScrollView
 import br.com.zup.beagle.android.components.Text
 import br.com.zup.beagle.android.components.layout.Screen
+import br.com.zup.beagle.android.components.page.PageView
 import br.com.zup.beagle.ext.applyStyle
+import br.com.zup.beagle.widget.Widget
 
 class ScrollViewFragment : Fragment() {
 
@@ -62,6 +64,11 @@ class ScrollViewFragment : Fragment() {
 
     private fun buildScrollView() = ScrollView(
         children = listOf(
+            Container(
+                children = listOf(
+                    buildPager()
+                )
+            ).applyStyle(Style(size = Size(height = UnitValue(100.0, UnitType.REAL)))),
             Image(
                 PathType.Remote(
                     "https://www.petlove.com.br/images/breeds/193436/profile/original/beagle-p.jpg?1532538271"
@@ -83,6 +90,29 @@ class ScrollViewFragment : Fragment() {
             Text("Text 10").applyStyle(style)
         )
     )
+
+    private fun buildPager(): PageView {
+        return PageView(
+            children = listOf(
+                buildPage("Page 1"),
+                buildPage("Page 2")
+            )
+        )
+    }
+
+    private fun buildPage(text: String): Widget {
+        return Container(
+            children = listOf(
+                Text(text = text)
+            )
+        ).applyStyle(
+            Style(
+                size = Size(height = 100.unitReal()),
+                backgroundColor = "#ff9800",
+                cornerRadius = CornerRadius(radius = 8.0)
+            )
+        )
+    }
 
     companion object {
 


### PR DESCRIPTION
**Context**
The `PageView` component in some cases was unable to define its size. Given this behavior, it now occupies the size that the parent view has available.

**Issues**
This PR fix #286 and #287 