### PR TITLE
fix: image placeholder on Android and Backend

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -64,7 +64,8 @@ data class Image(
                     }
                 }
                 is PathType.Remote -> {
-                    val requestOptions = getGlideRequestOptions(pathType.placeholder)
+                    val placeholder = pathType.placeholder?.mobileId
+                    val requestOptions = getGlideRequestOptions(placeholder)
                     imageView.loadImage(pathType, requestOptions)
                 }
             }
@@ -116,5 +117,5 @@ data class Image(
 
 sealed class PathType {
     data class Local(val mobileId: String) : PathType()
-    data class Remote(val url: String, val placeholder: String? = null) : PathType()
+    data class Remote(val url: String, val placeholder: Local? = null) : PathType()
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -104,17 +104,9 @@ data class Image(
     }
 
     private fun getPlaceholder(placeholder: String?): Int? =
-        placeholder?.let{
+        placeholder?.let {
             BeagleEnvironment.beagleSdk.designSystem?.image(it)
         }
-        val designSystem = BeagleEnvironment.beagleSdk.designSystem
-        if (designSystem != null) {
-            placeholder?.let {
-                return designSystem.image(it)
-            }
-        }
-        return null
-    }
 
 }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -28,10 +28,8 @@ import br.com.zup.beagle.android.engine.mapper.ViewMapper
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.utils.observeBindChanges
 import br.com.zup.beagle.android.view.ViewFactory
-import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.WidgetView
-import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.widget.core.ImageContentMode
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
@@ -40,15 +38,12 @@ import com.bumptech.glide.request.transition.Transition
 
 data class Image(
     val path: Bind<PathType>,
-    val mode: ImageContentMode? = null,
-    val placeholder: PathType.Local? = null) : WidgetView() {
+    val mode: ImageContentMode? = null) : WidgetView() {
     constructor(
         path: PathType,
-        mode: ImageContentMode? = null,
-        placeholder: PathType.Local? = null) : this(
+        mode: ImageContentMode? = null) : this(
         valueOf(path),
-        mode,
-        placeholder
+        mode
     )
 
     @Transient
@@ -69,7 +64,7 @@ data class Image(
                     }
                 }
                 is PathType.Remote -> {
-                    val requestOptions = getGlideRequestOptions()
+                    val requestOptions = getGlideRequestOptions(pathType.placeholder)
                     imageView.loadImage(pathType, requestOptions)
                 }
             }
@@ -99,7 +94,7 @@ data class Image(
     }
 
     @SuppressLint("CheckResult")
-    private fun getGlideRequestOptions(): RequestOptions {
+    private fun getGlideRequestOptions(placeholder: String?): RequestOptions {
         val requestOptions = RequestOptions()
         getPlaceholder(placeholder)?.let {
             requestOptions.placeholder(it)
@@ -107,11 +102,11 @@ data class Image(
         return requestOptions
     }
 
-    private fun getPlaceholder(image: PathType.Local?): Int? {
+    private fun getPlaceholder(placeholder: String?): Int? {
         val designSystem = BeagleEnvironment.beagleSdk.designSystem
-        if (designSystem != null && image != null) {
-            placeholder?.let { pathType ->
-                return designSystem.image(pathType.mobileId)
+        if (designSystem != null) {
+            placeholder?.let {
+                return designSystem.image(it)
             }
         }
         return null
@@ -121,5 +116,5 @@ data class Image(
 
 sealed class PathType {
     data class Local(val mobileId: String) : PathType()
-    data class Remote(val url: String) : PathType()
+    data class Remote(val url: String, val placeholder: String? = null) : PathType()
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -103,7 +103,10 @@ data class Image(
         return requestOptions
     }
 
-    private fun getPlaceholder(placeholder: String?): Int? {
+    private fun getPlaceholder(placeholder: String?): Int? =
+        placeholder?.let{
+            BeagleEnvironment.beagleSdk.designSystem?.image(it)
+        }
         val designSystem = BeagleEnvironment.beagleSdk.designSystem
         if (designSystem != null) {
             placeholder?.let {

--- a/backend/backend-widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/Image.kt
+++ b/backend/backend-widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/Image.kt
@@ -45,7 +45,7 @@ data class Image(
  * @param url the URL from which the image can be obtained
  * @param placeholder the image that will used as placeholder when set a remote image.
  * */
-sealed class ImagePath(val url: String?, val placeholder: String? = null) {
+sealed class ImagePath(val url: String?, val placeholder: Local? = null) {
     /**
      * Define an image whose data is local to the client app.
      *
@@ -66,5 +66,5 @@ sealed class ImagePath(val url: String?, val placeholder: String? = null) {
      * @param remoteUrl reference the path where the image should be fetched from.
      * @param placeholder reference an image natively in your mobile app local styles file to be used as placeholder.
      * */
-    class Remote(remoteUrl: String, placeholder : String?) : ImagePath(remoteUrl, placeholder)
+    class Remote(remoteUrl: String, placeholder : Local?) : ImagePath(remoteUrl, placeholder)
 }

--- a/backend/backend-widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/Image.kt
+++ b/backend/backend-widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/Image.kt
@@ -29,15 +29,12 @@ import br.com.zup.beagle.widget.core.ImageContentMode
  */
 data class Image(
     val path: Bind<ImagePath>,
-    val mode: ImageContentMode? = null,
-    val placeholder: ImagePath.Local? = null) : Widget(){
+    val mode: ImageContentMode? = null) : Widget(){
     constructor(
         path: ImagePath,
-        mode: ImageContentMode? = null,
-        placeholder: ImagePath.Local? = null) : this(
+        mode: ImageContentMode? = null) : this(
         valueOf(path),
-        mode,
-        placeholder
+        mode
     )
 }
 
@@ -46,8 +43,9 @@ data class Image(
  * Define the source of image data to populate the image view.
  *
  * @param url the URL from which the image can be obtained
+ * @param placeholder the image that will used as placeholder when set a remote image.
  * */
-sealed class ImagePath(val url: String?) {
+sealed class ImagePath(val url: String?, val placeholder: String? = null) {
     /**
      * Define an image whose data is local to the client app.
      *
@@ -66,6 +64,7 @@ sealed class ImagePath(val url: String?) {
      * Define an image whose data needs to be downloaded from a source external to the client app.
      *
      * @param remoteUrl reference the path where the image should be fetched from.
+     * @param placeholder reference an image natively in your mobile app local styles file to be used as placeholder.
      * */
-    class Remote(remoteUrl: String) : ImagePath(remoteUrl)
+    class Remote(remoteUrl: String, placeholder : String?) : ImagePath(remoteUrl, placeholder)
 }

--- a/backend/backend-widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/Image.kt
+++ b/backend/backend-widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/Image.kt
@@ -66,5 +66,5 @@ sealed class ImagePath(val url: String?, val placeholder: Local? = null) {
      * @param remoteUrl reference the path where the image should be fetched from.
      * @param placeholder reference an image natively in your mobile app local styles file to be used as placeholder.
      * */
-    class Remote(remoteUrl: String, placeholder : Local?) : ImagePath(remoteUrl, placeholder)
+    class Remote(remoteUrl: String, placeholder : Local? = null) : ImagePath(remoteUrl, placeholder)
 }


### PR DESCRIPTION
## Description

The Image widget in android and backend had the placeholder on constructor, This allowed to set a placeholder even if the image was local. To solve and look like the IOS, I change the PathType.Remote (on Android) and to have the placeholder and remove the attribute placeholder on Image widget

## Related Issues

#418 

## Tests

No tests was added. I just run the already existing test to ensure that they were functioning normally

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*