### PR TITLE
fix: LiveData onActive to not call twice

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/ActionRequestViewModel.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/ActionRequestViewModel.kt
@@ -56,7 +56,9 @@ private class FetchComponentLiveData(
 ) : LiveData<ActionRequestViewModel.FetchViewState>(), CoroutineScope {
 
     override fun onActive() {
-        fetchData()
+        if (value == null) {
+            fetchData()
+        }
     }
 
     private fun fetchData() {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
@@ -80,17 +80,18 @@ internal class BeagleViewModel(
         }
     }
 
-    private class FetchComponentLiveData(private val screenRequest: ScreenRequest,
-                                         private val screen: ScreenComponent?,
-                                         private val componentRequester: ComponentRequester,
-                                         private val urlObservable: AtomicReference<UrlObservable>,
-                                         override val coroutineContext: CoroutineContext) : LiveData<ViewState>(),
-        CoroutineScope {
+    private class FetchComponentLiveData(
+        private val screenRequest: ScreenRequest,
+        private val screen: ScreenComponent?,
+        private val componentRequester: ComponentRequester,
+        private val urlObservable: AtomicReference<UrlObservable>,
+        override val coroutineContext: CoroutineContext
+    ) : LiveData<ViewState>(), CoroutineScope {
 
         override fun onActive() {
-            fetchComponents()
-
-            super.onActive()
+            if (value == null) {
+                fetchComponents()
+            }
         }
 
         private fun fetchComponents() {


### PR DESCRIPTION
## Description

When onResume is called and BeagleViewModel LiveData onResume is called, it fetch the screen again.

## Related Issues

Fixes: #415 