### PR TITLE
fix: applyStyle method uses flex object

### DIFF
--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ContainerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ContainerTest.kt
@@ -41,6 +41,8 @@ class ContainerTest : BaseComponentTest() {
     override fun setUp() {
         super.setUp()
 
+        every { style.copy(flex = any()) } returns style
+
         container = Container(containerChildren).applyStyle(style)
     }
 
@@ -50,7 +52,7 @@ class ContainerTest : BaseComponentTest() {
         container.buildView(rootView)
 
         // THEN
-        verify(exactly = once()) {  anyConstructed<ViewFactory>().makeBeagleFlexView(rootView.getContext(), style) }
+        verify(exactly = once()) { anyConstructed<ViewFactory>().makeBeagleFlexView(rootView.getContext(), style) }
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ContainerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ContainerTest.kt
@@ -32,7 +32,7 @@ import org.junit.Test
 
 class ContainerTest : BaseComponentTest() {
 
-    private val style: Style = mockk()
+    private val style: Style = mockk(relaxed = true)
 
     private val containerChildren = listOf<ServerDrivenComponent>(mockk<Container>())
 

--- a/backend/sample/core/src/main/kotlin/br/com/zup/beagle/sample/builder/TextScreenBuilder.kt
+++ b/backend/sample/core/src/main/kotlin/br/com/zup/beagle/sample/builder/TextScreenBuilder.kt
@@ -16,15 +16,13 @@
 
 package br.com.zup.beagle.sample.builder
 
-import br.com.zup.beagle.widget.action.Alert
 import br.com.zup.beagle.core.Style
-import br.com.zup.beagle.ext.applyFlex
 import br.com.zup.beagle.ext.applyStyle
 import br.com.zup.beagle.ext.unitReal
 import br.com.zup.beagle.sample.constants.SCREEN_TEXT_STYLE
 import br.com.zup.beagle.sample.constants.STEEL_BLUE
+import br.com.zup.beagle.widget.action.Alert
 import br.com.zup.beagle.widget.core.EdgeValue
-import br.com.zup.beagle.widget.core.Flex
 import br.com.zup.beagle.widget.layout.Container
 import br.com.zup.beagle.widget.layout.NavigationBar
 import br.com.zup.beagle.widget.layout.NavigationBarItem
@@ -69,18 +67,15 @@ object TextScreenBuilder : ScreenBuilder {
         text: String,
         styleId: String? = null,
         appearanceColor: String? = null
-    ) =
-        Text(text = text, styleId = styleId)
-            .applyStyle(Style(
-                    margin = EdgeValue(
-                        top = 16.unitReal(),
-                        left = 16.unitReal(),
-                        right = 16.unitReal()
-                    )
-                )
-            ).applyStyle(
-                style = Style(
-                    backgroundColor = appearanceColor
-                )
+    ) = Text(text = text, styleId = styleId)
+        .applyStyle(
+            style = Style(
+                margin = EdgeValue(
+                    top = 16.unitReal(),
+                    left = 16.unitReal(),
+                    right = 16.unitReal()
+                ),
+                backgroundColor = appearanceColor
             )
+        )
 }

--- a/common/extended-schema/src/main/kotlin/br/com/zup/beagle/ext/WidgetExtensions.kt
+++ b/common/extended-schema/src/main/kotlin/br/com/zup/beagle/ext/WidgetExtensions.kt
@@ -34,8 +34,7 @@ fun <T : Widget> T.setId(id: String) = this.apply { this.id = id }
  *
  * @return the current widget
  */
-fun <T : Widget> T.applyFlex(flex: Flex) = this.apply {
-    this.style = (this.style ?: Style()).copy(flex = flex) }
+fun <T : Widget> T.applyFlex(flex: Flex) = this.apply { this.style = (this.style ?: Style()).copy(flex = flex) }
 
 /**
  * Apply the appearance.
@@ -45,7 +44,7 @@ fun <T : Widget> T.applyFlex(flex: Flex) = this.apply {
  * @return the current widget
  */
 fun <T : Widget> T.applyStyle(style: Style) = this.apply {
-    this.style = style.copy(flex = this.style?.flex)
+    this.style = if (style.flex != null) style else style.copy(flex = this.style?.flex)
 }
 
 /**

--- a/common/extended-schema/src/main/kotlin/br/com/zup/beagle/ext/WidgetExtensions.kt
+++ b/common/extended-schema/src/main/kotlin/br/com/zup/beagle/ext/WidgetExtensions.kt
@@ -44,7 +44,9 @@ fun <T : Widget> T.applyFlex(flex: Flex) = this.apply {
  *
  * @return the current widget
  */
-fun <T : Widget> T.applyStyle(style: Style) = this.apply { this.style = style }
+fun <T : Widget> T.applyStyle(style: Style) = this.apply {
+    this.style = style.copy(flex = this.style?.flex ?: Flex())
+}
 
 /**
  * Apply the accessibility .

--- a/common/extended-schema/src/main/kotlin/br/com/zup/beagle/ext/WidgetExtensions.kt
+++ b/common/extended-schema/src/main/kotlin/br/com/zup/beagle/ext/WidgetExtensions.kt
@@ -45,7 +45,7 @@ fun <T : Widget> T.applyFlex(flex: Flex) = this.apply {
  * @return the current widget
  */
 fun <T : Widget> T.applyStyle(style: Style) = this.apply {
-    this.style = style.copy(flex = this.style?.flex ?: Flex())
+    this.style = style.copy(flex = this.style?.flex)
 }
 
 /**

--- a/common/extended-schema/src/test/kotlin/br/com/zup/beagle/ext/UnitValueExtensionsTest.kt
+++ b/common/extended-schema/src/test/kotlin/br/com/zup/beagle/ext/UnitValueExtensionsTest.kt
@@ -20,7 +20,7 @@ import br.com.zup.beagle.widget.core.UnitType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-class BeagleExtensions {
+class UnitValueExtensionsTest {
 
     @Test
     fun unitReal_should_return_a_UnitValue_with_100_double_REAL() {

--- a/common/extended-schema/src/test/kotlin/br/com/zup/beagle/ext/WidgetExtensionsTest.kt
+++ b/common/extended-schema/src/test/kotlin/br/com/zup/beagle/ext/WidgetExtensionsTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.ext
+
+import br.com.zup.beagle.core.Accessibility
+import br.com.zup.beagle.core.Style
+import br.com.zup.beagle.widget.Widget
+import br.com.zup.beagle.widget.core.Flex
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class TestWidget : Widget()
+
+class WidgetExtensionsTest {
+
+    @Test
+    fun `setId should set Id to the caller`() {
+        // Given
+        val widget = TestWidget()
+        val id = "id"
+
+        // When
+        widget.setId(id)
+
+        // Then
+        assertEquals(id, widget.id)
+    }
+
+    @Test
+    fun `applyFlex should set Flex to the caller and use existing Style object`() {
+        // Given
+        val widget = TestWidget()
+        val style = Style(backgroundColor = "backgroundColor")
+        widget.style = style
+        val flex = Flex(grow = 1.0)
+
+        // When
+        widget.applyFlex(flex)
+
+        // Then
+        assertEquals(style.backgroundColor, widget.style?.backgroundColor)
+        assertEquals(flex.grow, widget.style?.flex?.grow)
+    }
+
+    @Test
+    fun `applyFlex should set Flex to the caller even there is no Style object`() {
+        // Given
+        val widget = TestWidget()
+        val flex = Flex(grow = 1.0)
+
+        // When
+        widget.applyFlex(flex)
+
+        // Then
+        assertEquals(flex.grow, widget.style?.flex?.grow)
+    }
+
+
+    @Test
+    fun `applyStyle should set Style to the caller and use his Flex if exists`() {
+        // Given
+        val widget = TestWidget()
+        val style = Style(flex = Flex(grow = 1.0))
+
+        // When
+        widget.applyStyle(style)
+
+        // Then
+        assertEquals(style.flex?.grow, widget.style?.flex?.grow)
+    }
+
+    @Test
+    fun `applyStyle should set Style to the caller and use widgets Flex if exists`() {
+        // Given
+        val widget = TestWidget()
+        widget.applyFlex(Flex(grow = 1.0))
+        val style = Style()
+
+        // When
+        widget.applyStyle(style)
+
+        // Then
+        assertEquals(style.flex?.grow, widget.style?.flex?.grow)
+    }
+
+    @Test
+    fun `applyAccessibility should set Accessibility to the caller`() {
+        // Given
+        val widget = TestWidget()
+        val accessibility = Accessibility(accessible = false, accessibilityLabel = "accessibility")
+
+        // When
+        widget.applyAccessibility(accessibility)
+
+        // Then
+        assertEquals(accessibility, widget.accessibility)
+    }
+}


### PR DESCRIPTION
## Description

This PR corrects a behavior that a widget received a flex object and another style in a certain order, the previously informed flex was ignored.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/