### PR TITLE
fix: context lose its data when screen rotates

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -37,10 +37,12 @@ internal class ContextDataManager(
     private val contexts: MutableMap<String, ContextBinding> = mutableMapOf()
 
     fun addContext(contextData: ContextData) {
-        contexts[contextData.id] = ContextBinding(
-            bindings = mutableSetOf(),
-            context = contextData
-        )
+        if (contexts[contextData.id] == null) {
+            contexts[contextData.id] = ContextBinding(
+                bindings = mutableSetOf(),
+                context = contextData
+            )
+        }
     }
 
     fun getContextsFromBind(binding: Bind.Expression<*>): List<ContextData> {

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -95,9 +95,6 @@ class ContextDataManagerTest {
         contexts = contextDataManager.getPrivateField("contexts")
 
         contexts.clear()
-
-        val contextData = ContextData(CONTEXT_ID, model)
-        contexts[CONTEXT_ID] = ContextBinding(contextData, mutableSetOf(bindModel))
     }
 
     @After
@@ -125,7 +122,6 @@ class ContextDataManagerTest {
         // Given
         val contextData1 = ContextData(CONTEXT_ID, true)
         val contextData2 = ContextData(CONTEXT_ID, false)
-        contexts.clear()
 
         // When
         contextDataManager.addContext(contextData1)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -121,6 +121,21 @@ class ContextDataManagerTest {
     }
 
     @Test
+    fun addContext_should_not_add_new_context_when_context_already_exists() {
+        // Given
+        val contextData1 = ContextData(CONTEXT_ID, true)
+        val contextData2 = ContextData(CONTEXT_ID, false)
+        contexts.clear()
+
+        // When
+        contextDataManager.addContext(contextData1)
+        contextDataManager.addContext(contextData2)
+
+        // Then
+        assertEquals(contexts[CONTEXT_ID]?.context, contextData1)
+    }
+
+    @Test
     fun addBindingToContext_should_add_binding_to_context_on_stack() {
         // Given
         val bind = Bind.Expression("@{$CONTEXT_ID[0]}", type = Boolean::class.java)


### PR DESCRIPTION
## Description
Every time the screen rotation occur, the current context is replaced and consequently the data itself is loss

## Related Issues

Fixes #465 

## Tests

Create a unit test case to not replace the current context.