### PR TITLE
fix: navigation inside PageView

### DIFF
--- a/iOS/Sources/Beagle/Sources/Components/Page+Renderable/PageView+Renderable.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Page+Renderable/PageView+Renderable.swift
@@ -33,7 +33,8 @@ extension PageView: ServerDrivenComponent {
 
         let view = PageViewUIComponent(
             model: .init(pages: pagesControllers),
-            indicatorView: indicatorView
+            indicatorView: indicatorView,
+            controller: renderer.controller
         )
         
         view.style.setup(Style(flex: Flex(grow: 1.0)))

--- a/iOS/Sources/Beagle/Sources/Components/Page+Renderable/PageViewUIComponent.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Page+Renderable/PageViewUIComponent.swift
@@ -50,7 +50,8 @@ class PageViewUIComponent: UIView {
 
     init(
         model: Model,
-        indicatorView: PageIndicatorUIView?
+        indicatorView: PageIndicatorUIView?,
+        controller: BeagleController
     ) {
         self.model = model
         self.indicatorView = indicatorView
@@ -58,7 +59,7 @@ class PageViewUIComponent: UIView {
         
         self.indicatorView?.outputReceiver = self
 
-        setupLayout()
+        setupLayout(controller: controller)
         updateView()
     }
 
@@ -69,22 +70,24 @@ class PageViewUIComponent: UIView {
 
     // MARK: - Subviews
 
-    private(set) lazy var pageViewController: UIPageViewController = {
-        let pager = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
-        guard let firstPage = model.pages[safe: 0] else { return pager }
-        pager.setViewControllers(
-            [firstPage], direction: .forward, animated: true, completion: nil
-        )
-        pager.dataSource = self
-        pager.delegate = self
-        return pager
-    }()
+    private(set) var pageViewController = UIPageViewController(
+        transitionStyle: .scroll,
+        navigationOrientation: .horizontal
+    )
     
-    private func setupLayout() {
-        let pager: UIView = pageViewController.view
+    private func setupLayout(controller: BeagleController) {
+        controller.addChild(pageViewController)
+        addSubview(pageViewController.view)
+        pageViewController.didMove(toParent: controller)
         
-        pager.style.setup(Style(flex: Flex().grow(1)))
-        addSubview(pager)
+        if let firstPage = model.pages.first {
+            pageViewController.setViewControllers(
+                [firstPage], direction: .forward, animated: false
+            )
+        }
+        pageViewController.dataSource = self
+        pageViewController.delegate = self
+        pageViewController.view.style.setup(Style(flex: Flex().grow(1)))
         
         if let indicator = indicatorView as? UIView {
             indicator.style.setup(Style(size: Size().height(40), margin: EdgeValue().top(10)))

--- a/iOS/Sources/Beagle/Sources/Components/Page+Renderable/Tests/PageViewTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Page+Renderable/Tests/PageViewTests.swift
@@ -64,5 +64,17 @@ class PageViewTests: XCTestCase {
         let screen = Beagle.screen(.declarative(pageView.toScreen()))
         assertSnapshotImage(screen)
     }
+    
+    func test_PageViewChildShouldNotCreateNewNavigationController() {
+        let navigation = BeagleNavigationController()
+        let controller = BeagleScreenViewController(ComponentDummy())
+        navigation.viewControllers = [controller]
+        
+        let pageView = PageView(children: [ComponentDummy()], pageIndicator: nil)
+        let view = pageView.toView(renderer: controller.renderer)
+        let page = (view as? PageViewUIComponent)?.pageViewController.viewControllers?.first
+        
+        XCTAssertEqual(page?.navigationController, navigation)
+    }
 
 }

--- a/iOS/Sources/Beagle/Sources/Components/Page+Renderable/Tests/PageViewUIComponentTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Page+Renderable/Tests/PageViewUIComponentTests.swift
@@ -22,7 +22,8 @@ class PageViewUIComponentTests: XCTestCase {
 
     private lazy var pageView = PageViewUIComponent(
         model: .init(pages: pages),
-        indicatorView: PageIndicatorUIComponent(selectedColor: nil, unselectedColor: nil)
+        indicatorView: PageIndicatorUIComponent(selectedColor: nil, unselectedColor: nil),
+        controller: BeagleControllerStub()
     )
 
     private lazy var pages: [BeagleScreenViewController] = [

--- a/iOS/Sources/Beagle/Sources/Components/TabBar+Renderable/TabView.swift
+++ b/iOS/Sources/Beagle/Sources/Components/TabBar+Renderable/TabView.swift
@@ -21,7 +21,7 @@ extension TabView: ServerDrivenComponent {
 
     public func toView(renderer: BeagleRenderer) -> UIView {
         let model = TabViewUIComponent.Model(tabIndex: 0, tabViewItems: children)
-        let tabView = TabViewUIComponent(model: model)
+        let tabView = TabViewUIComponent(model: model, controller: renderer.controller)
 
         // TODO: use style in BeagleRenderer
         if let styleId = styleId {

--- a/iOS/Sources/Beagle/Sources/Components/TabBar+Renderable/TabViewUIComponent.swift
+++ b/iOS/Sources/Beagle/Sources/Components/TabBar+Renderable/TabViewUIComponent.swift
@@ -78,23 +78,26 @@ final class TabViewUIComponent: UIView {
         return view
     }()
     
-    lazy var contentView: PageViewUIComponent = {
-        let pages = model.tabViewItems.map {
-            BeagleScreenViewController(
-                viewModel: .init(screenType: .declarative($0.child.toScreen()))
-            )
-        }
-        let view = PageViewUIComponent(model: .init(pages: pages), indicatorView: nil)
+    static func contentView(items: [TabItem], controller: BeagleController) -> PageViewUIComponent {
+        let pages = items.map { BeagleScreenViewController($0.child) }
+        let view = PageViewUIComponent(
+            model: .init(pages: pages),
+            indicatorView: nil,
+            controller: controller
+        )
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.pageViewDelegate = self
         return view
-    }()
+    }
+    
+    var contentView: PageViewUIComponent
     
     // MARK: - Initialization
     init(
-        model: Model
+        model: Model,
+        controller: BeagleController
     ) {
         self.model = model
+        self.contentView = Self.contentView(items: model.tabViewItems, controller: controller)
         super.init(frame: .zero)
         setupViews()
     }
@@ -105,6 +108,8 @@ final class TabViewUIComponent: UIView {
     }
     
     private func setupViews() {
+        contentView.pageViewDelegate = self
+        
         addSubview(collectionView)
         collectionView.anchor(top: topAnchor, left: leftAnchor, right: rightAnchor)
         collectionView.heightAnchor.constraint(lessThanOrEqualToConstant: 65).isActive = true

--- a/iOS/Sources/Beagle/Sources/Components/TabBar+Renderable/Tests/TabViewUIComponentTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/TabBar+Renderable/Tests/TabViewUIComponentTests.swift
@@ -40,7 +40,7 @@ final class TabViewUIComponentTests: XCTestCase {
     
     private lazy var model = TabViewUIComponent.Model(tabIndex: 0, tabViewItems: component.children)
 
-    private lazy var sut = TabViewUIComponent(model: model)
+    private lazy var sut = TabViewUIComponent(model: model, controller: BeagleControllerStub())
 
     private func makeScreen(_ component: ServerDrivenComponent) -> BeagleScreenViewController {
         return Beagle.screen(.declarative(component.toScreen()))
@@ -97,7 +97,8 @@ final class TabViewUIComponentTests: XCTestCase {
         
         let pageView = PageViewUIComponent(
             model: .init(pages: pages),
-            indicatorView: PageIndicatorUIComponent(selectedColor: "", unselectedColor: "")
+            indicatorView: PageIndicatorUIComponent(selectedColor: "", unselectedColor: ""),
+            controller: BeagleControllerStub()
         )
         
         // When

--- a/iOS/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
+++ b/iOS/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
@@ -50,7 +50,7 @@ public class BeagleScreenViewController: BeagleController {
     
     // MARK: - Initialization
     
-    public convenience init(_ component: ServerDrivenComponent) {
+    public convenience init(_ component: RawComponent) {
         self.init(.declarative(component.toScreen()))
     }
     
@@ -141,7 +141,7 @@ public class BeagleScreenViewController: BeagleController {
     }
     
     private func updateNavigationBar(animated: Bool) {
-        guard let screen = screen else { return }
+        guard parent is BeagleNavigationController, let screen = screen else { return }
         let screenNavigationBar = screen.navigationBar
         let hideNavBar = screenNavigationBar == nil
         navigationController?.setNavigationBarHidden(hideNavBar, animated: animated)

--- a/iOS/Sources/Beagle/Sources/Theme/ThemeTests.swift
+++ b/iOS/Sources/Beagle/Sources/Theme/ThemeTests.swift
@@ -108,7 +108,10 @@ final class ThemeTests: XCTestCase {
         let backgroundColor: UIColor = .clear
         let indicatorColor: UIColor = .blue
         let tabItem = TabItem(title: "Tab 1", child: Text("Tab content"))
-        let view = TabViewUIComponent(model: TabViewUIComponent.Model(tabIndex: 0, tabViewItems: [tabItem, tabItem]))
+        let view = TabViewUIComponent(
+            model: TabViewUIComponent.Model(tabIndex: 0, tabViewItems: [tabItem, tabItem]),
+            controller: BeagleControllerStub()
+        )
         
         // When
         view |> BeagleStyle.tabView(backgroundColor: backgroundColor, indicatorColor: indicatorColor)


### PR DESCRIPTION
## Description

The `UIPageViewController` created by the `PageView` were not added as child of the `BeagleController`, making the `navigationController` not available to the `UIPageViewController` children.
It resulted in each page creating a navigation controller for its own.

## Related Issues

Fix #444 

## Tests

I added the following tests:

`PageViewTests.test_PageViewChildShouldNotCreateNewNavigationController`

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/