### PR TITLE
fix: coexisting cache filters with CORS

### DIFF
--- a/backend/framework/src/main/kotlin/br/com/zup/beagle/constants/CorsConstants.kt
+++ b/backend/framework/src/main/kotlin/br/com/zup/beagle/constants/CorsConstants.kt
@@ -14,16 +14,9 @@
  * limitations under the License.
  */
 
-package br.com.zup.beagle.sample.spring.config
+package br.com.zup.beagle.constants
 
-import br.com.zup.beagle.constants.BEAGLE_EXPOSED_HEADERS
-import org.springframework.context.annotation.Configuration
-import org.springframework.web.servlet.config.annotation.CorsRegistry
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import br.com.zup.beagle.cache.BeagleCacheHandler
+import br.com.zup.beagle.platform.BeaglePlatformUtil
 
-@Configuration
-open class CorsConfig : WebMvcConfigurer {
-    override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/**").exposedHeaders(*BEAGLE_EXPOSED_HEADERS)
-    }
-}
+val BEAGLE_EXPOSED_HEADERS = arrayOf(BeagleCacheHandler.CACHE_HEADER)

--- a/backend/sample/micronaut/src/main/resources/application.properties
+++ b/backend/sample/micronaut/src/main/resources/application.properties
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 jackson.serializationInclusion=NON_NULL
 jackson.serialization.indentOutput=true
 beagle.cache.endpoint.exclude=/image
 micronaut.router.static-resources.*.paths=classpath:static
+micronaut.server.cors.enabled=true
+micronaut.server.cors.configurations.all.exposedHeaders=beagle-hash,beagle-platform

--- a/backend/sample/micronaut/src/main/resources/application.properties
+++ b/backend/sample/micronaut/src/main/resources/application.properties
@@ -19,4 +19,4 @@ jackson.serialization.indentOutput=true
 beagle.cache.endpoint.exclude=/image
 micronaut.router.static-resources.*.paths=classpath:static
 micronaut.server.cors.enabled=true
-micronaut.server.cors.configurations.all.exposedHeaders=beagle-hash,beagle-platform
+micronaut.server.cors.configurations.beagle.exposedHeaders=beagle-hash

--- a/backend/sample/spring/src/main/kotlin/br/com/zup/beagle/sample/spring/config/CorsConfig.kt
+++ b/backend/sample/spring/src/main/kotlin/br/com/zup/beagle/sample/spring/config/CorsConfig.kt
@@ -16,6 +16,8 @@
 
 package br.com.zup.beagle.sample.spring.config
 
+import br.com.zup.beagle.cache.BeagleCacheHandler
+import br.com.zup.beagle.platform.BeaglePlatformUtil
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry
@@ -33,6 +35,7 @@ open class CorsConfig {
                     .allowedOrigins("*")
                     .allowedMethods("*")
                     .allowedHeaders("*")
+                    .exposedHeaders(BeagleCacheHandler.CACHE_HEADER, BeaglePlatformUtil.BEAGLE_PLATFORM_HEADER)
             }
         }
     }

--- a/backend/sample/spring/src/main/kotlin/br/com/zup/beagle/sample/spring/config/CorsConfig.kt
+++ b/backend/sample/spring/src/main/kotlin/br/com/zup/beagle/sample/spring/config/CorsConfig.kt
@@ -18,26 +18,14 @@ package br.com.zup.beagle.sample.spring.config
 
 import br.com.zup.beagle.cache.BeagleCacheHandler
 import br.com.zup.beagle.platform.BeaglePlatformUtil
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-open class CorsConfig {
-
-    @Bean
-    open fun corsConfigurer(): WebMvcConfigurer? {
-        return object : WebMvcConfigurer {
-            override fun addCorsMappings(registry: CorsRegistry) {
-                registry
-                    .addMapping("/**")
-                    .allowedOrigins("*")
-                    .allowedMethods("*")
-                    .allowedHeaders("*")
-                    .exposedHeaders(BeagleCacheHandler.CACHE_HEADER, BeaglePlatformUtil.BEAGLE_PLATFORM_HEADER)
-            }
-        }
+open class CorsConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .exposedHeaders(BeagleCacheHandler.CACHE_HEADER, BeaglePlatformUtil.BEAGLE_PLATFORM_HEADER)
     }
-
 }

--- a/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
+++ b/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
@@ -23,6 +23,7 @@ import br.com.zup.beagle.constants.BEAGLE_CACHE_INCLUDES
 import br.com.zup.beagle.platform.BeaglePlatformUtil
 import io.micronaut.context.annotation.Requirements
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponseFactory
 import io.micronaut.http.MutableHttpResponse
@@ -32,7 +33,7 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
 
-@Filter("\${$BEAGLE_CACHE_INCLUDES:/**}")
+@Filter(value = ["\${$BEAGLE_CACHE_INCLUDES:/**}"], methods = [HttpMethod.GET])
 @Requirements(
     Requires(classes = [BeagleCacheHandler::class]),
     Requires(property = BEAGLE_CACHE_ENABLED, value = "true", defaultValue = "true")

--- a/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
+++ b/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
@@ -23,7 +23,6 @@ import br.com.zup.beagle.constants.BEAGLE_CACHE_INCLUDES
 import br.com.zup.beagle.platform.BeaglePlatformUtil
 import io.micronaut.context.annotation.Requirements
 import io.micronaut.context.annotation.Requires
-import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponseFactory
 import io.micronaut.http.MutableHttpResponse
@@ -33,10 +32,7 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
 
-@Filter(
-    value = ["\${$BEAGLE_CACHE_INCLUDES:/**}"],
-    methods = [HttpMethod.DELETE, HttpMethod.GET, HttpMethod.PATCH, HttpMethod.POST, HttpMethod.PUT]
-)
+@Filter("\${$BEAGLE_CACHE_INCLUDES:/**}")
 @Requirements(
     Requires(classes = [BeagleCacheHandler::class]),
     Requires(property = BEAGLE_CACHE_ENABLED, value = "true", defaultValue = "true")

--- a/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
+++ b/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
@@ -23,6 +23,7 @@ import br.com.zup.beagle.constants.BEAGLE_CACHE_INCLUDES
 import br.com.zup.beagle.platform.BeaglePlatformUtil
 import io.micronaut.context.annotation.Requirements
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponseFactory
 import io.micronaut.http.MutableHttpResponse
@@ -32,7 +33,10 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
 
-@Filter("\${$BEAGLE_CACHE_INCLUDES:/**}")
+@Filter(
+    value = ["\${$BEAGLE_CACHE_INCLUDES:/**}"],
+    methods = [HttpMethod.DELETE, HttpMethod.GET, HttpMethod.PATCH, HttpMethod.POST, HttpMethod.PUT]
+)
 @Requirements(
     Requires(classes = [BeagleCacheHandler::class]),
     Requires(property = BEAGLE_CACHE_ENABLED, value = "true", defaultValue = "true")

--- a/backend/starters/beagle-spring-starter/src/main/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilter.kt
+++ b/backend/starters/beagle-spring-starter/src/main/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilter.kt
@@ -21,6 +21,7 @@ import br.com.zup.beagle.cache.RestCacheHandler
 import br.com.zup.beagle.platform.BeaglePlatformUtil
 import org.springframework.http.HttpMethod
 import org.springframework.web.util.ContentCachingResponseWrapper
+import java.util.*
 import javax.servlet.Filter
 import javax.servlet.FilterChain
 import javax.servlet.ServletRequest
@@ -31,7 +32,7 @@ import javax.servlet.http.HttpServletResponse
 class BeagleCacheFilter(private val cacheHandler: BeagleCacheHandler) : Filter {
     override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
         if (chain != null && request is HttpServletRequest && response is HttpServletResponse) {
-            if (request.method == HttpMethod.OPTIONS.name) chain.doFilter(request, response)
+            if (request.method.toUpperCase(Locale.ROOT) == HttpMethod.OPTIONS.name) chain.doFilter(request, response)
             else this.cacheHandler.handleCache(
                 endpoint = request.requestURI,
                 receivedHash = request.getHeader(BeagleCacheHandler.CACHE_HEADER),

--- a/backend/starters/beagle-spring-starter/src/main/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilter.kt
+++ b/backend/starters/beagle-spring-starter/src/main/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilter.kt
@@ -19,6 +19,7 @@ package br.com.zup.beagle.spring.filter
 import br.com.zup.beagle.cache.BeagleCacheHandler
 import br.com.zup.beagle.cache.RestCacheHandler
 import br.com.zup.beagle.platform.BeaglePlatformUtil
+import org.springframework.http.HttpMethod
 import org.springframework.web.util.ContentCachingResponseWrapper
 import javax.servlet.Filter
 import javax.servlet.FilterChain
@@ -30,7 +31,8 @@ import javax.servlet.http.HttpServletResponse
 class BeagleCacheFilter(private val cacheHandler: BeagleCacheHandler) : Filter {
     override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
         if (chain != null && request is HttpServletRequest && response is HttpServletResponse) {
-            this.cacheHandler.handleCache(
+            if (request.method == HttpMethod.OPTIONS.name) chain.doFilter(request, response)
+            else this.cacheHandler.handleCache(
                 endpoint = request.requestURI,
                 receivedHash = request.getHeader(BeagleCacheHandler.CACHE_HEADER),
                 currentPlatform = request.getHeader(BeaglePlatformUtil.BEAGLE_PLATFORM_HEADER),

--- a/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilterTest.kt
+++ b/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilterTest.kt
@@ -21,7 +21,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verifyAll
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpMethod
 import org.springframework.web.util.ContentCachingResponseWrapper
 import javax.servlet.FilterChain
 import javax.servlet.ServletRequest
@@ -32,6 +31,8 @@ import javax.servlet.http.HttpServletResponse
 internal class BeagleCacheFilterTest {
     companion object {
         const val STRING = "test"
+        const val OPTIONS = "options"
+        const val GET = "get"
     }
 
     @Test
@@ -43,7 +44,7 @@ internal class BeagleCacheFilterTest {
 
         every { request.requestURI } returns STRING
         every { request.getHeader(any()) } returns STRING
-        every { request.method } returns HttpMethod.OPTIONS.name
+        every { request.method } returns OPTIONS
 
         BeagleCacheFilter(cacheHandler).doFilter(request, response, chain)
 
@@ -60,7 +61,7 @@ internal class BeagleCacheFilterTest {
 
         every { request.requestURI } returns STRING
         every { request.getHeader(any()) } returns STRING
-        every { request.method } returns HttpMethod.GET.name
+        every { request.method } returns GET
         every {
             cacheHandler.handleCache<ContentCachingResponseWrapper>(any(), any(), any(), any(), any())
         } returns wrapper

--- a/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilterTest.kt
+++ b/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilterTest.kt
@@ -31,28 +31,12 @@ import javax.servlet.http.HttpServletResponse
 internal class BeagleCacheFilterTest {
     companion object {
         const val STRING = "test"
-        const val OPTIONS = "options"
         const val GET = "get"
+        const val OPTIONS = "options"
     }
 
     @Test
-    fun `doFilter when all parameters are valid and request method is OPTION`() {
-        val cacheHandler = mockk<BeagleCacheHandler>()
-        val request = mockk<HttpServletRequest>()
-        val response = mockk<HttpServletResponse>()
-        val chain = mockk<FilterChain>(relaxUnitFun = true)
-
-        every { request.requestURI } returns STRING
-        every { request.getHeader(any()) } returns STRING
-        every { request.method } returns OPTIONS
-
-        BeagleCacheFilter(cacheHandler).doFilter(request, response, chain)
-
-        verifyAll { chain.doFilter(request, response) }
-    }
-
-    @Test
-    fun `doFilter when all parameters are valid and request method is not OPTION`() {
+    fun `doFilter when all parameters are valid and request method is GET`() {
         val cacheHandler = mockk<BeagleCacheHandler>()
         val request = mockk<HttpServletRequest>()
         val response = mockk<HttpServletResponse>()
@@ -70,6 +54,22 @@ internal class BeagleCacheFilterTest {
 
         verifyAll { cacheHandler.handleCache(STRING, STRING, STRING, any(), any()) }
         verifyAll { wrapper.copyBodyToResponse() }
+    }
+
+    @Test
+    fun `doFilter when all parameters are valid and request method is not GET`() {
+        val cacheHandler = mockk<BeagleCacheHandler>()
+        val request = mockk<HttpServletRequest>()
+        val response = mockk<HttpServletResponse>()
+        val chain = mockk<FilterChain>(relaxUnitFun = true)
+
+        every { request.requestURI } returns STRING
+        every { request.getHeader(any()) } returns STRING
+        every { request.method } returns OPTIONS
+
+        BeagleCacheFilter(cacheHandler).doFilter(request, response, chain)
+
+        verifyAll { chain.doFilter(request, response) }
     }
 
     @Test

--- a/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilterTest.kt
+++ b/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/filter/BeagleCacheFilterTest.kt
@@ -21,6 +21,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verifyAll
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
 import org.springframework.web.util.ContentCachingResponseWrapper
 import javax.servlet.FilterChain
 import javax.servlet.ServletRequest
@@ -34,7 +35,23 @@ internal class BeagleCacheFilterTest {
     }
 
     @Test
-    fun `doFilter when all parameters are valid`() {
+    fun `doFilter when all parameters are valid and request method is OPTION`() {
+        val cacheHandler = mockk<BeagleCacheHandler>()
+        val request = mockk<HttpServletRequest>()
+        val response = mockk<HttpServletResponse>()
+        val chain = mockk<FilterChain>(relaxUnitFun = true)
+
+        every { request.requestURI } returns STRING
+        every { request.getHeader(any()) } returns STRING
+        every { request.method } returns HttpMethod.OPTIONS.name
+
+        BeagleCacheFilter(cacheHandler).doFilter(request, response, chain)
+
+        verifyAll { chain.doFilter(request, response) }
+    }
+
+    @Test
+    fun `doFilter when all parameters are valid and request method is not OPTION`() {
         val cacheHandler = mockk<BeagleCacheHandler>()
         val request = mockk<HttpServletRequest>()
         val response = mockk<HttpServletResponse>()
@@ -43,6 +60,7 @@ internal class BeagleCacheFilterTest {
 
         every { request.requestURI } returns STRING
         every { request.getHeader(any()) } returns STRING
+        every { request.method } returns HttpMethod.GET.name
         every {
             cacheHandler.handleCache<ContentCachingResponseWrapper>(any(), any(), any(), any(), any())
         } returns wrapper


### PR DESCRIPTION
## Description

Exposed our custom headers in Spring sample BFF's CORS configuration. 
Only caching the HTTP `GET` method, since the mechanism is not suited for others.
Configured CORS in Micronaut sample BFF.

## Related Issues

Fixes #482.

## Tests

I updated Spring starter's `BeagleCacheFilterTest` with scenarios for the HTTP methods `GET` and non-`GET`.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/