### PR TITLE
fix: Implicit context for data type that is not string and removed de…

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/action/SetContext.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/action/SetContext.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.android.action
 
 import br.com.zup.beagle.android.annotation.ContextDataValue
+import br.com.zup.beagle.android.logger.BeagleLoggerProxy
 import br.com.zup.beagle.android.utils.evaluateExpression
 import br.com.zup.beagle.android.utils.generateViewModelInstance
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
@@ -37,12 +38,18 @@ data class SetContext(
 
     override fun execute(rootView: RootView) {
         val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
-        viewModel.updateContext(toInternalSetContext(rootView))
+        try {
+            val value = toInternalSetContext(rootView)
+            viewModel.updateContext(value)
+        } catch (ex: Exception) {
+            BeagleLoggerProxy.warning(ex.message ?: "")
+        }
     }
 
     private fun toInternalSetContext(rootView: RootView) = SetContextInternal(
         contextId = this.contextId,
-        value = evaluateExpression(rootView, this.value.toString()) ?: "",
+        value = evaluateExpression(rootView, this.value.toString()) ?:
+            throw IllegalStateException("SetContext with id=${this.contextId} evaluated to null"),
         path = this.path
     )
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
@@ -104,7 +104,7 @@ data class TextInput(
                     rootView,
                     onChange,
                     "onChange",
-                    newText.toString()
+                    mapOf("value" to newText.toString())
                 )
             }
         }
@@ -122,7 +122,7 @@ data class TextInput(
                         rootView,
                         onFocus,
                         "onFocus",
-                        this.text.toString()
+                        mapOf("value" to this.text.toString())
                     )
                 }
             } else {
@@ -131,7 +131,7 @@ data class TextInput(
                         rootView,
                         onBlur,
                         "onBlur",
-                        this.text.toString()
+                        mapOf("value" to this.text.toString())
                     )
                 }
             }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
@@ -37,6 +37,8 @@ import br.com.zup.beagle.widget.core.TextInputType.EMAIL
 import br.com.zup.beagle.widget.core.TextInputType.NUMBER
 import br.com.zup.beagle.widget.core.TextInputType.PASSWORD
 
+private const val VALUE_KEY = "value"
+
 data class TextInput(
     val value: Bind<String>? = null,
     val placeholder: Bind<String>? = null,
@@ -104,7 +106,7 @@ data class TextInput(
                     rootView,
                     onChange,
                     "onChange",
-                    mapOf("value" to newText.toString())
+                    mapOf(VALUE_KEY to newText.toString())
                 )
             }
         }
@@ -122,7 +124,7 @@ data class TextInput(
                         rootView,
                         onFocus,
                         "onFocus",
-                        mapOf("value" to this.text.toString())
+                        mapOf(VALUE_KEY to this.text.toString())
                     )
                 }
             } else {
@@ -131,7 +133,7 @@ data class TextInput(
                         rootView,
                         onBlur,
                         "onBlur",
-                        mapOf("value" to this.text.toString())
+                        mapOf(VALUE_KEY to this.text.toString())
                     )
                 }
             }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/form/Form.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/form/Form.kt
@@ -40,7 +40,6 @@ import br.com.zup.beagle.android.view.ServerDrivenState
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.WidgetView
 import br.com.zup.beagle.core.ServerDrivenComponent
-import br.com.zup.beagle.widget.Widget
 
 data class Form(
     val child: ServerDrivenComponent,

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextActionExecutor.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextActionExecutor.kt
@@ -17,14 +17,9 @@
 package br.com.zup.beagle.android.context
 
 import br.com.zup.beagle.android.action.Action
-import br.com.zup.beagle.android.data.serializer.BeagleMoshi
 import br.com.zup.beagle.android.utils.generateViewModelInstance
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import br.com.zup.beagle.android.widget.RootView
-import org.json.JSONArray
-import org.json.JSONObject
-
-private const val DEFAULT_KEY_NAME = "value"
 
 internal class ContextActionExecutor {
 
@@ -54,22 +49,8 @@ internal class ContextActionExecutor {
         val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
         val contextData = ContextData(
             id = eventName,
-            value = parseToJSONObject(eventValue)
-        )
+            value = eventValue
+        ).normalize()
         viewModel.addImplicitContext(contextData, sender, actions)
-    }
-
-    private fun parseToJSONObject(value: Any): Any {
-        return if (value is String || value is Number || value is Boolean) {
-            JSONObject().apply {
-                put(DEFAULT_KEY_NAME, value)
-            }
-        } else {
-            if (value is Collection<*>) {
-                JSONArray(value)
-            } else {
-                JSONObject(BeagleMoshi.moshi.adapter<Any>(value::class.java).toJson(value))
-            }
-        }
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataExtensions.kt
@@ -26,7 +26,7 @@ import org.json.JSONObject
  * to a JSONArray or JSONObject.
  */
 internal fun ContextData.normalize(): ContextData {
-    return if (value is String || value is Number || value is Boolean || value is JSONArray || value is JSONObject) {
+    return if (isValueNormalized()) {
         this
     } else {
         val newValue = BeagleMoshi.moshi.adapter(Any::class.java).toJson(value) ?: ""
@@ -37,4 +37,8 @@ internal fun ContextData.normalize(): ContextData {
         }
         ContextData(this.id, normalizedValue)
     }
+}
+
+private fun ContextData.isValueNormalized(): Boolean {
+    return value is String || value is Number || value is Boolean || value is JSONArray || value is JSONObject
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataExtensions.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.context
+
+import br.com.zup.beagle.android.data.serializer.BeagleMoshi
+import org.json.JSONArray
+import org.json.JSONObject
+
+/*
+ * This function should be used in cases where user created the context implicit or explicit
+ * because if user pass a map, list or any kind of object, this should be normalized
+ * to a JSONArray or JSONObject.
+ */
+internal fun ContextData.normalize(): ContextData {
+    return if (value is String || value is Number || value is Boolean || value is JSONArray || value is JSONObject) {
+        this
+    } else {
+        val newValue = BeagleMoshi.moshi.adapter(Any::class.java).toJson(value) ?: ""
+        val normalizedValue: Any = when {
+            newValue.startsWith("{") -> JSONObject(newValue)
+            newValue.startsWith("[") -> JSONArray(newValue)
+            else -> newValue
+        }
+        ContextData(this.id, normalizedValue)
+    }
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -40,7 +40,7 @@ internal class ContextDataManager(
         if (contexts[contextData.id] == null) {
             contexts[contextData.id] = ContextBinding(
                 bindings = mutableSetOf(),
-                context = contextData
+                context = contextData.normalize()
             )
         }
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataValueResolver.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataValueResolver.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.context
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal class ContextDataValueResolver {
+
+    fun parse(value: Any?): Any? {
+        return when (value) {
+            is Collection<*> -> JSONArray(value)
+            is Map<*, *> -> JSONObject(value)
+            else -> value
+        }
+    }
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/ContextDataAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/ContextDataAdapterFactory.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.android.data.serializer.adapter
 
 import br.com.zup.beagle.android.annotation.ContextDataValue
+import br.com.zup.beagle.android.context.ContextDataValueResolver
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
@@ -44,24 +45,13 @@ internal class ContextDataAdapterFactory : JsonAdapter.Factory {
 }
 
 internal class AnyToJsonObjectAdapter(
-    private val adapter: JsonAdapter<Any>
+    private val adapter: JsonAdapter<Any>,
+    private val contextDataValueResolver: ContextDataValueResolver = ContextDataValueResolver()
 ) : JsonAdapter<Any>() {
 
     override fun fromJson(reader: JsonReader): Any? {
-        val type = reader.peek()
         val value = reader.readJsonValue()
-
-        return when (type) {
-            JsonReader.Token.BEGIN_OBJECT -> {
-                JSONObject(value as Map<String, Any>)
-            }
-            JsonReader.Token.BEGIN_ARRAY -> {
-                JSONArray(value as Collection<Any>)
-            }
-            else -> {
-                value
-            }
-        }
+        return contextDataValueResolver.parse(value)
     }
 
     override fun toJson(writer: JsonWriter, value: Any?) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/logger/BeagleLoggerProxy.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/logger/BeagleLoggerProxy.kt
@@ -20,7 +20,7 @@ import br.com.zup.beagle.android.setup.BeagleEnvironment
 
 internal object BeagleLoggerProxy : BeagleLogger {
 
-    private val logger: BeagleLogger = BeagleLoggerFactory().make()
+    private val logger: BeagleLogger by lazy { BeagleLoggerFactory().make() }
 
     override fun warning(message: String) = runIfEnable{
         logger.warning(message)

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
@@ -20,12 +20,12 @@ import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.expressionOf
 import br.com.zup.beagle.android.context.ContextActionExecutor
+import br.com.zup.beagle.android.context.ContextDataValueResolver
 import br.com.zup.beagle.android.logger.BeagleMessageLogs
 import br.com.zup.beagle.android.widget.RootView
-import org.json.JSONArray
-import org.json.JSONObject
 
 internal var contextActionExecutor = ContextActionExecutor()
+internal var contextDataValueResolver = ContextDataValueResolver()
 
 /**
  * Execute a list of actions and create the implicit context with eventName and eventValue (optional).
@@ -78,12 +78,8 @@ internal fun Action.evaluateExpression(
     expressionData: String
 ): Any? {
     return try {
-        val value = expressionOf<String>(expressionData).evaluateForAction(rootView, this) ?: ""
-        when {
-            value.startsWith("{") -> JSONObject(value)
-            value.startsWith("[") -> JSONArray(value)
-            else -> value
-        }
+        val value = expressionOf<Any>(expressionData).evaluateForAction(rootView, this)
+        contextDataValueResolver.parse(value)
     } catch (ex: Exception) {
         BeagleMessageLogs.errorWhileTryingToEvaluateBinding(ex)
         null

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/BaseTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/BaseTest.kt
@@ -37,6 +37,8 @@ abstract class BaseTest {
 
         mockkObject(BeagleEnvironment)
         every { BeagleEnvironment.beagleSdk } returns beagleSdk
+        every { beagleSdk.registeredWidgets() } returns listOf()
+        every { beagleSdk.registeredActions() } returns listOf()
     }
 
     @After

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/action/SetContextTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/action/SetContextTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.action
+
+import androidx.appcompat.app.AppCompatActivity
+import br.com.zup.beagle.android.engine.renderer.ActivityRootView
+import br.com.zup.beagle.android.logger.BeagleLoggerProxy
+import br.com.zup.beagle.android.testutil.RandomData
+import br.com.zup.beagle.android.utils.ViewModelProviderFactory
+import br.com.zup.beagle.android.utils.evaluateExpression
+import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class SetContextTest {
+
+    private val viewModel = mockk<ScreenContextViewModel>()
+    private val rootView = mockk<ActivityRootView> {
+        every { activity } returns mockk()
+    }
+
+    @Before
+    internal fun setUp() {
+        mockkObject(ViewModelProviderFactory)
+        mockkObject(BeagleLoggerProxy)
+        mockkStatic("br.com.zup.beagle.android.utils.ActionExtensionsKt")
+
+        every {
+            ViewModelProviderFactory.of(any<AppCompatActivity>())[ScreenContextViewModel::class.java]
+        } returns viewModel
+    }
+
+    @Test
+    fun execute_should_call_viewModel_updateContext() {
+        // Given
+        val evaluated = RandomData.string()
+        val setContext = SetContext(
+            contextId = RandomData.string(),
+            value = ""
+        )
+        val updateContext = slot<SetContextInternal>()
+        every { setContext.evaluateExpression(any(), any()) } returns evaluated
+        every { viewModel.updateContext(capture(updateContext)) } just Runs
+
+        // When
+        setContext.execute(rootView)
+
+        // Then
+        assertEquals(setContext.contextId, updateContext.captured.contextId)
+        assertEquals(evaluated, updateContext.captured.value)
+    }
+
+    @Test
+    fun execute_should_not_call_viewModel_updateContext_when_evaluate_returns_null() {
+        // Given
+        val setContext = SetContext(
+            contextId = RandomData.string(),
+            value = ""
+        )
+        every { setContext.evaluateExpression(any(), any()) } returns null
+        every { BeagleLoggerProxy.warning(any()) } just Runs
+
+        // When
+        setContext.execute(rootView)
+
+        // Then
+        verify(exactly = 0) { viewModel.updateContext(any()) }
+        verify { BeagleLoggerProxy.warning("SetContext with id=${setContext.contextId} evaluated to null") }
+    }
+}

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextActionExecutorTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextActionExecutorTest.kt
@@ -99,7 +99,7 @@ class ContextActionExecutorTest : BaseTest() {
 
         // Then
         assertEquals(eventId, contextDataSlot.captured.id)
-        assertEquals("{\"value\":\"$value\"}", contextDataSlot.captured.value.toString())
+        assertEquals(value, contextDataSlot.captured.value.toString())
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataExtensionsKtTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.context
+
+import br.com.zup.beagle.android.BaseTest
+import br.com.zup.beagle.android.testutil.RandomData
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+private data class Test(val a: String)
+
+internal class ContextDataExtensionsKtTest : BaseTest() {
+
+    @Test
+    fun normalize_should_return_the_actual_contextData_when_value_type_is_double() {
+        // Given
+        val contextData = ContextData(
+            id = RandomData.string(),
+            value = RandomData.double()
+        )
+
+        // When
+        val normalized = contextData.normalize()
+
+        // Then
+        assertEquals(normalized, contextData)
+    }
+
+    @Test
+    fun normalize_should_return_the_actual_contextData_when_value_type_is_string() {
+        // Given
+        val contextData = ContextData(
+            id = RandomData.string(),
+            value = RandomData.string()
+        )
+
+        // When
+        val normalized = contextData.normalize()
+
+        // Then
+        assertEquals(normalized, contextData)
+    }
+
+    @Test
+    fun normalize_should_return_the_actual_contextData_when_value_type_is_boolean() {
+        // Given
+        val contextData = ContextData(
+            id = RandomData.string(),
+            value = RandomData.boolean()
+        )
+
+        // When
+        val normalized = contextData.normalize()
+
+        // Then
+        assertEquals(normalized, contextData)
+    }
+
+    @Test
+    fun normalize_should_return_the_actual_contextData_when_value_type_is_JSONArray() {
+        // Given
+        val contextData = ContextData(
+            id = RandomData.string(),
+            value = JSONArray()
+        )
+
+        // When
+        val normalized = contextData.normalize()
+
+        // Then
+        assertEquals(normalized, contextData)
+    }
+
+    @Test
+    fun normalize_should_return_the_actual_contextData_when_value_type_is_JSONObject() {
+        // Given
+        val contextData = ContextData(
+            id = RandomData.string(),
+            value = JSONObject()
+        )
+
+        // When
+        val normalized = contextData.normalize()
+
+        // Then
+        assertEquals(normalized, contextData)
+    }
+
+    @Test
+    fun normalize_should_return_new_contextData_when_value_type_is_list() {
+        // Given
+        val contextData = ContextData(
+            id = RandomData.string(),
+            value = emptyList<ContextData>()
+        )
+
+        // When
+        val normalized = contextData.normalize()
+
+        // Then
+        assertNotEquals(normalized, contextData)
+        assertTrue(normalized.value is JSONArray)
+    }
+
+    @Test
+    fun normalize_should_return_new_contextData_when_value_type_is_object() {
+        // Given
+        val contextData = ContextData(
+            id = RandomData.string(),
+            value = Test("")
+        )
+
+        // When
+        val normalized = contextData.normalize()
+
+        // Then
+        assertNotEquals(normalized, contextData)
+        assertTrue(normalized.value is JSONObject)
+    }
+}

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -16,6 +16,7 @@
 
 package br.com.zup.beagle.android.context
 
+import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.action.SetContextInternal
 import br.com.zup.beagle.android.jsonpath.JsonCreateTree
 import br.com.zup.beagle.android.jsonpath.JsonPathFinder
@@ -46,7 +47,7 @@ import kotlin.test.assertTrue
 
 private val CONTEXT_ID = RandomData.string()
 
-class ContextDataManagerTest {
+class ContextDataManagerTest : BaseTest() {
 
     private lateinit var contextDataManager: ContextDataManager
 
@@ -70,9 +71,8 @@ class ContextDataManagerTest {
     @MockK
     private lateinit var model: ComponentModel
 
-    @Before
-    fun setUp() {
-        MockKAnnotations.init(this)
+    override fun setUp() {
+        super.setUp()
 
         every { bindModel.type } returns ComponentModel::class.java
         every { bindModel.value } returns "@{$CONTEXT_ID}"
@@ -95,11 +95,6 @@ class ContextDataManagerTest {
         contexts = contextDataManager.getPrivateField("contexts")
 
         contexts.clear()
-    }
-
-    @After
-    fun tearDown() {
-        unmockkAll()
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataValueResolverTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataValueResolverTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.context
+
+import br.com.zup.beagle.android.testutil.RandomData
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class ContextDataValueResolverTest {
+
+    private val contextDataValueResolver = ContextDataValueResolver()
+
+    @Test
+    fun parse_should_return_a_JSONArray_when_given_a_list() {
+        // Given
+        val value = emptyList<String>()
+
+        // When
+        val parsedValue = contextDataValueResolver.parse(value)
+
+        // Then
+        assertTrue(parsedValue is JSONArray)
+    }
+
+    @Test
+    fun parse_should_return_a_JSONObject_when_given_a_map() {
+        // Given
+        val value = emptyMap<String, Any>()
+
+        // When
+        val parsedValue = contextDataValueResolver.parse(value)
+
+        // Then
+        assertTrue(parsedValue is JSONObject)
+    }
+
+    @Test
+    fun parse_should_return_a_JSONObject_when_given_a_primitive() {
+        // Given
+        val value = RandomData.string()
+
+        // When
+        val parsedValue = contextDataValueResolver.parse(value)
+
+        // Then
+        assertTrue(parsedValue is String)
+        assertEquals(value, parsedValue)
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes three bugs:

1 - Every time the `handleEvent` is called and its a primitive, Beagle were creating an JSON Object with `value` as key of this primitive.
Ex.: Given this code 
```kotlin
val newText = "a"
handleEvent(rootView, onChange,  "onChange", newText.toString())
```
The context value will be:
contextId = "onChange"
context value= 
```json
{
  "value": "a"
}
```

But assuming this `value` as key is dangerous and could generate unexpected behaviour.

Now the context for the same example above is:
contextId = "onChange"
context value = "a"

2 - Our context were not handling local declarative
3 - SetContext and SendRequest as expecting only string as return values.

## Tests

Created unit tests.