### PR TITLE
fix: CacheManager normalize headers before use

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/cache/CacheManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/cache/CacheManager.kt
@@ -104,15 +104,20 @@ internal class CacheManager(
         return if (responseData.statusCode == 304 && beagleCache != null) {
             beagleCache.json
         } else {
+            val headers = normalizeHeaders(responseData.headers)
             return String(responseData.data).apply {
-                val beagleHash = responseData.headers[BEAGLE_HASH]
+                val beagleHash = headers[BEAGLE_HASH]
                 if (isEnabled() && beagleHash != null) {
                     persistCacheDataOnDisk(url, this, beagleHash)
-                    val cacheControl = responseData.headers[CACHE_CONTROL_HEADER]
+                    val cacheControl = headers[CACHE_CONTROL_HEADER]
                     persistCacheOnMemory(url, this, beagleHash, cacheControl)
                 }
             }
         }
+    }
+
+    private fun normalizeHeaders(headers: Map<String, String>): Map<String, String> {
+        return headers.mapKeys { it.key.toLowerCase() }
     }
 
     private fun persistCacheDataOnDisk(url: String, responseBody: String, beagleHash: String) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/cache/CacheManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/cache/CacheManager.kt
@@ -22,6 +22,7 @@ import br.com.zup.beagle.android.store.StoreHandler
 import br.com.zup.beagle.android.store.StoreHandlerFactory
 import br.com.zup.beagle.android.store.StoreType
 import br.com.zup.beagle.android.utils.nanoTimeInSeconds
+import br.com.zup.beagle.android.utils.toLowerKeys
 import br.com.zup.beagle.android.view.ScreenRequest
 import java.lang.NumberFormatException
 
@@ -104,7 +105,7 @@ internal class CacheManager(
         return if (responseData.statusCode == 304 && beagleCache != null) {
             beagleCache.json
         } else {
-            val headers = normalizeHeaders(responseData.headers)
+            val headers = responseData.headers.toLowerKeys()
             return String(responseData.data).apply {
                 val beagleHash = headers[BEAGLE_HASH]
                 if (isEnabled() && beagleHash != null) {
@@ -114,10 +115,6 @@ internal class CacheManager(
                 }
             }
         }
-    }
-
-    private fun normalizeHeaders(headers: Map<String, String>): Map<String, String> {
-        return headers.mapKeys { it.key.toLowerCase() }
     }
 
     private fun persistCacheDataOnDisk(url: String, responseBody: String, beagleHash: String) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/MapExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/MapExtensions.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.utils
+
+fun <K> Map<String, K>.toLowerKeys() = this.mapKeys { it.key.toLowerCase() }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/cache/CacheManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/cache/CacheManagerTest.kt
@@ -281,7 +281,8 @@ class CacheManagerTest {
     @Test
     fun handleResponseData_should_not_call_store_cache_if_beagleCache_header_is_not_present() {
         // Given
-        every { responseData.headers[BEAGLE_HASH] } returns null
+        val headers = mapOf<String, String>()
+        every { responseData.headers } returns headers
 
         // When
         cacheManager.handleResponseData(URL, null, responseData)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/MapExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/MapExtensionsKtTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.utils
+
+import br.com.zup.beagle.android.testutil.RandomData
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class MapExtensionsKtTest {
+
+    @Test
+    fun toLowerKeys_should_return_map_keys_as_lowerCase() {
+        // Given
+        val headers = mapOf(
+            "aaa" to RandomData.string(),
+            "AsA" to RandomData.string(),
+            "BBB" to RandomData.string()
+        )
+
+        // When
+        val keysLower = headers.toLowerKeys()
+
+        // Then
+        val keys = keysLower.keys.toList()
+        assertEquals("aaa", keys[0])
+        assertEquals("asa", keys[1])
+        assertEquals("bbb", keys[2])
+    }
+}


### PR DESCRIPTION
## Description

Inside CacheManager every header were not using case sensitive for header names.

## Related Issues

Fixes: #479 

## Tests

Created unit tests to the function that normalize headers map.