### PR TITLE
fix: Undefined actions to not crash when trying to deserialize

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/action/UndefinedAction.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/action/UndefinedAction.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.action
+
+import br.com.zup.beagle.android.widget.RootView
+
+internal class UndefinedAction : Action {
+    override fun execute(rootView: RootView) {}
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/ActionJsonAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/ActionJsonAdapterFactory.kt
@@ -25,6 +25,7 @@ import br.com.zup.beagle.android.action.FormValidation
 import br.com.zup.beagle.android.action.Navigate
 import br.com.zup.beagle.android.action.SendRequest
 import br.com.zup.beagle.android.action.SetContext
+import br.com.zup.beagle.android.action.UndefinedAction
 import br.com.zup.beagle.android.data.serializer.PolymorphicJsonAdapterFactory
 import java.util.Locale
 
@@ -35,6 +36,8 @@ internal object ActionJsonAdapterFactory {
 
     fun make(factory: PolymorphicJsonAdapterFactory<Action>): PolymorphicJsonAdapterFactory<Action> {
         return factory
+            .withDefaultValue(UndefinedAction())
+            .withSubtype(UndefinedAction::class.java, createNamespaceFor<UndefinedAction>())
             .withSubtype(FormRemoteAction::class.java, createNamespaceFor<FormRemoteAction>())
             .withSubtype(FormLocalAction::class.java, createNamespaceFor<FormLocalAction>())
             .withSubtype(FormValidation::class.java, createNamespaceFor<FormValidation>())

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
@@ -25,6 +25,7 @@ import br.com.zup.beagle.android.action.FormMethodType
 import br.com.zup.beagle.android.action.FormRemoteAction
 import br.com.zup.beagle.android.action.FormValidation
 import br.com.zup.beagle.android.action.Navigate
+import br.com.zup.beagle.android.action.UndefinedAction
 import br.com.zup.beagle.android.components.Button
 import br.com.zup.beagle.android.components.Image
 import br.com.zup.beagle.android.components.PathType
@@ -493,6 +494,37 @@ class BeagleMoshiTest : BaseTest() {
         // Then
         assertNotNull(actual)
         assertTrue(actual is FormValidation)
+    }
+
+    @Test
+    fun make_should_return_moshi_to_deserialize_a_UndefinedAction() {
+        // Given
+        val json = makeUndefinedActionJson()
+
+        // When
+        val actual = moshi.adapter(Action::class.java).fromJson(json)
+
+        // Then
+        assertNotNull(actual)
+        assertTrue(actual is UndefinedAction)
+    }
+
+    @Test
+    fun make_should_return_moshi_to_serialize_a_UndefinedAction() {
+        // Given
+        val component = Button(
+            text = "",
+            onPress = listOf(
+                UndefinedAction()
+            )
+        )
+
+        // When
+        val actual = moshi.adapter(ServerDrivenComponent::class.java).toJson(component)
+
+        // Then
+        val expected = """{"_beagleComponent_":"beagle:button","text":"","onPress":[{"_beagleAction_":"beagle:undefinedaction"}]}"""
+        assertEquals(expected, actual)
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
@@ -280,6 +280,12 @@ fun makeUndefinedComponentJson() = """
     }
 """
 
+fun makeUndefinedActionJson() = """
+    {
+        "_beagleAction_": "custom:new"
+    }
+"""
+
 fun makeInternalObject() = """{"value1": "hello", "value2": 123}"""
 
 fun makeBindComponent() = """


### PR DESCRIPTION
## Description

When an unregistered action is found on JSON, actually the application is crashing.
I created the UndefinedAction to be replaced when this kind of JSON is found.

## Related Issues

Fixes: #477 

## Tests

Created unit test scenarios for this case.