### PR TITLE
fix: UndefinedWidget was not working for InputWidget and PageIndicato…

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/widget/UndefinedWidget.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/widget/UndefinedWidget.kt
@@ -19,11 +19,14 @@ package br.com.zup.beagle.android.widget
 import android.annotation.SuppressLint
 import android.graphics.Color
 import android.view.View
+import br.com.zup.beagle.android.components.form.InputWidget
+import br.com.zup.beagle.android.components.page.PageIndicatorComponent
+import br.com.zup.beagle.android.components.page.PageIndicatorOutput
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.setup.Environment
 import br.com.zup.beagle.android.view.ViewFactory
 
-internal class UndefinedWidget : WidgetView() {
+internal class UndefinedWidget : InputWidget(), PageIndicatorComponent {
 
     private val viewFactory: ViewFactory = ViewFactory()
 
@@ -39,4 +42,14 @@ internal class UndefinedWidget : WidgetView() {
             viewFactory.makeView(rootView.getContext())
         }
     }
+
+    override fun getValue(): Any { return "" }
+
+    override fun onErrorMessage(message: String) {}
+
+    override fun setCount(pages: Int) {}
+
+    override fun onItemUpdated(newIndex: Int) {}
+
+    override fun initPageView(pageIndicatorOutput: PageIndicatorOutput) {}
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
@@ -642,6 +642,38 @@ class BeagleMoshiTest : BaseTest() {
     }
 
     @Test
+    fun make_should_return_moshi_to_serialize_a_UndefinedComponent_of_type_InputWidget() {
+        // Given
+        val component = FormInput(
+            name = RandomData.string(),
+            child = UndefinedWidget()
+        )
+
+        // When
+        val jsonComponent =
+            moshi.adapter(ServerDrivenComponent::class.java).toJson(component)
+
+        // Then
+        assertNotNull(JSONObject(jsonComponent))
+    }
+
+    @Test
+    fun make_should_return_moshi_to_serialize_a_UndefinedComponent_of_type_PageIndicatorComponent() {
+        // Given
+        val component = PageView(
+            children = listOf(),
+            pageIndicator = UndefinedWidget()
+        )
+
+        // When
+        val jsonComponent =
+            moshi.adapter(ServerDrivenComponent::class.java).toJson(component)
+
+        // Then
+        assertNotNull(JSONObject(jsonComponent))
+    }
+
+    @Test
     fun moshi_should_deserialize_bindComponent() {
         // Given
         val jsonComponent = makeBindComponent()


### PR DESCRIPTION
## Description
When Beagle Android receives a JSON that the expected type is `InputWidget` or `PageIndicatorComponent`, our deserializator cannot transform it to a UndefinedWidget` because it does not inherit from these types.


## Related Issues

Fix: #450 

## Tests

Created more tests case to catch this kind of errors.