### PR TITLE
fix: cancel image request 

### DIFF
--- a/iOS/Sources/Beagle/Sources/Components/Image+Renderable/Tests/ImageTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Image+Renderable/Tests/ImageTests.swift
@@ -64,11 +64,11 @@ class ImageTests: XCTestCase {
         //Given
         let image = Image("@{img.path}")
         let dependency = BeagleDependencies()
-        let container = Container(children: [image])
-        let controller = BeagleScreenViewController(viewModel: .init(screenType:.declarative(container.toScreen()), dependencies: dependency))
         let data = Data()
         let repository = RepositoryStub(imageResult: .success(data))
         dependency.repository = repository
+        let container = Container(children: [image])
+        let controller = BeagleScreenViewController(viewModel: .init(screenType:.declarative(container.toScreen()), dependencies: dependency))
         let action = SetContext(contextId: "img", path: "path", value: ["_beagleImagePath_": "local", "mobileId": "shuttle"])
         
         //When

--- a/iOS/Sources/Beagle/Sources/Components/Image+Renderable/Tests/ImageTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Image+Renderable/Tests/ImageTests.swift
@@ -21,10 +21,6 @@ import BeagleSchema
 
 class ImageTests: XCTestCase {
     
-    struct Dependencies: DependencyRepository {
-        let repository: Repository
-    }
-
     var dependencies: BeagleDependencies {
         // swiftlint:disable implicit_getter
         get {
@@ -64,8 +60,7 @@ class ImageTests: XCTestCase {
         //Given
         let image = Image("@{img.path}")
         let dependency = BeagleDependencies()
-        let data = Data()
-        let repository = RepositoryStub(imageResult: .success(data))
+        let repository = RepositoryStub(imageResult: .success(Data()))
         dependency.repository = repository
         let container = Container(children: [image])
         let controller = BeagleScreenViewController(viewModel: .init(screenType:.declarative(container.toScreen()), dependencies: dependency))


### PR DESCRIPTION
## Description
The remote image was not canceling the current image request when the value of the expression is changed.
We now store the request token for the current image request and cancel that request when there is a change in the image path expression.

## Related Issues #425 

## Tests
I added the following test to beagle Core:
ImageTests - test_cancelRequestImageRemote

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
