### PR TITLE
fix: adjust crash when use component Textinput with a default value

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
@@ -85,7 +85,7 @@ data class TextInput(
     private lateinit var textInputView: EditText
 
     @Transient
-    private lateinit var textWatcher: TextWatcher
+    private var textWatcher: TextWatcher? = null
 
     override fun buildView(rootView: RootView): View = viewFactory.makeInputText(rootView.getContext()).apply {
         textInputView = this


### PR DESCRIPTION
## Description
Adjust crash when use component Textinput with a default value

## Related Issues

fixes #530 

## Tests

I opened the Sample app and click in disabled form input to check the behaviour continues works.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/