### PR TITLE
fix: remove internal keyword

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/exception/BeagleApiException.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/exception/BeagleApiException.kt
@@ -18,7 +18,7 @@ package br.com.zup.beagle.android.exception
 
 import br.com.zup.beagle.android.networking.ResponseData
 
-internal data class BeagleApiException(
+data class BeagleApiException(
     val responseData: ResponseData,
     override val message: String = responseData.toString()
 ) : BeagleException(message)


### PR DESCRIPTION
## Description

Removed the `internal` keyword.

## Related Issues

#547
