### PR TITLE
fix: minSdk 23+ crash

### DIFF
--- a/android/beagle/build.gradle
+++ b/android/beagle/build.gradle
@@ -68,6 +68,7 @@ dependencies {
 
     implementation GeneralLibraries.yoga
     implementation GeneralLibraries.soLoader
+    implementation GeneralLibraries.jni
 
     implementation GoogleLibraries.materialDesign
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -85,6 +85,8 @@ object Versions {
 
     const val yoga = "1.16.0"
 
+    const val jni = "0.0.2"
+
     const val okHttp = "4.5.0"
 
     const val kotlinTest = "1.3.50"
@@ -151,6 +153,9 @@ object GeneralLibraries {
     const val soLoader = "com.facebook.soloader:soloader:${Versions.soLoader}"
 
     const val yoga = "com.facebook.yoga.android:yoga-layout:${Versions.yoga}"
+
+    const val jni = "com.facebook.fbjni:fbjni:${Versions.jni}"
+
 
     const val jacksonKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${Versions.jacksonKotlin}"
 


### PR DESCRIPTION
## Description

This issue was happen because for minSdk 23+ is necessary import a facebook lib named jni, to solve, I just import this one

## Related Issues

#540 

## Tests

I added the following tests:

No test was added

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*