### PR TITLE
fix: renamed deploy to CI/CD in labeler settings

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,7 +12,7 @@ iOS: iOS/**
 
 schema: schema/**
 
-deploy:
+CI/CD:
     - danger/**
     - fastlane/**
     - .github/**


### PR DESCRIPTION
## Description

Updated the name of the old deploy label to its new name CI/CD, because the bot was labeling with the old name.

## Related Issues

None.

## Tests

The fixing commit triggers the labeler, testing that it uses the correct label.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/