### PR TITLE
feat: updated backend cache defaults

### DIFF
--- a/backend/framework/src/main/kotlin/br/com/zup/beagle/cache/BeagleCacheHandler.kt
+++ b/backend/framework/src/main/kotlin/br/com/zup/beagle/cache/BeagleCacheHandler.kt
@@ -19,7 +19,6 @@ package br.com.zup.beagle.cache
 import com.google.common.hash.Hashing
 import java.net.HttpURLConnection
 import java.nio.charset.Charset
-import java.util.regex.Pattern
 
 class BeagleCacheHandler(excludeEndpoints: List<String> = listOf()) {
     companion object {
@@ -27,22 +26,22 @@ class BeagleCacheHandler(excludeEndpoints: List<String> = listOf()) {
     }
 
     private val endpointHashMap = mutableMapOf<String, String>()
-    private val excludePatterns = excludeEndpoints.filter { it.isNotEmpty() }.map(Pattern::compile)
+    private val excludePatterns = excludeEndpoints.filter { it.isNotEmpty() }.map(::Regex)
 
     private fun generateHashForJson(json: String) =
         Hashing.sha512().hashString(json, Charset.defaultCharset()).toString()
 
-    private fun getCacheKey(endpoint: String, currentPlatform: String?) = currentPlatform?.plus("_")?.plus(endpoint)
-        ?: endpoint
+    private fun getCacheKey(endpoint: String, currentPlatform: String?) =
+        currentPlatform?.plus("_")?.plus(endpoint) ?: endpoint
 
     internal fun isEndpointInExcludedPatterns(endpoint: String) =
-        this.excludePatterns.any { it.matcher(endpoint).find() }
+        this.excludePatterns.any { it matches endpoint }
 
-    internal fun isHashUpToDate(endpoint: String, currentPlatform: String?, hash: String)
-        = this.endpointHashMap[getCacheKey(endpoint, currentPlatform)] == hash
+    internal fun isHashUpToDate(endpoint: String, currentPlatform: String?, hash: String) =
+        this.endpointHashMap[this.getCacheKey(endpoint, currentPlatform)] == hash
 
     internal fun generateAndAddHash(endpoint: String, currentPlatform: String?, json: String) =
-        this.endpointHashMap.computeIfAbsent(getCacheKey(endpoint, currentPlatform)) {
+        this.endpointHashMap.computeIfAbsent(this.getCacheKey(endpoint, currentPlatform)) {
             this.generateHashForJson(json)
         }
 

--- a/backend/framework/src/test/kotlin/br/com/zup/beagle/cache/BeagleCacheHandlerTest.kt
+++ b/backend/framework/src/test/kotlin/br/com/zup/beagle/cache/BeagleCacheHandlerTest.kt
@@ -32,7 +32,7 @@ import kotlin.test.assertTrue
 
 internal class BeagleCacheHandlerTest {
 
-    private val excludedEndpoints = listOf("/ima*")
+    private val excludedEndpoints = listOf("/ima.*")
 
     companion object {
         private const val HOME_ENDPOINT = "/home"

--- a/backend/framework/src/test/kotlin/br/com/zup/beagle/cache/BeagleCacheHandlerTest.kt
+++ b/backend/framework/src/test/kotlin/br/com/zup/beagle/cache/BeagleCacheHandlerTest.kt
@@ -32,7 +32,8 @@ import kotlin.test.assertTrue
 
 internal class BeagleCacheHandlerTest {
 
-    private val excludedEndpoints = listOf("/ima.*")
+    private val allEndpoints = listOf("/.*")
+    private val imageEndpoints = listOf("/image", "/image2")
 
     companion object {
         private const val HOME_ENDPOINT = "/home"
@@ -43,30 +44,49 @@ internal class BeagleCacheHandlerTest {
     }
 
     @Test
-    fun cacheHandler_should_return_true_for_checkEndpointForExcludedPatterns() {
+    fun `cacheHandler should return true for isEndpointExcluded for image endpoint when all included and images excluded`() {
         assertTrue {
-            BeagleCacheHandler(excludedEndpoints).isEndpointInExcludedPatterns(IMAGE_ENDPOINT)
+            BeagleCacheHandler(excludeEndpoints = imageEndpoints, includeEndpoints = allEndpoints)
+                .isEndpointExcluded(IMAGE_ENDPOINT)
         }
     }
 
     @Test
-    fun cacheHandler_should_return_false_for_checkEndpointForExcludedPatterns() {
+    fun `cacheHandler should return false for isEndpointExcluded for home endpoint when all included and images excluded`() {
         assertFalse {
-            BeagleCacheHandler(excludedEndpoints).isEndpointInExcludedPatterns(HOME_ENDPOINT)
+            BeagleCacheHandler(excludeEndpoints = imageEndpoints, includeEndpoints = allEndpoints)
+                .isEndpointExcluded(HOME_ENDPOINT)
         }
     }
 
     @Test
-    fun cacheHandler_should_return_same_hash_for_button_object_when_call_generateAndAddHash() {
-        assertEquals(BeagleCacheHandler().generateAndAddHash(
-            endpoint = HOME_ENDPOINT,
-            currentPlatform = BeaglePlatform.ALL.name,
-            json = BUTTON_JSON
-        ), BUTTON_JSON_HASH)
+    fun `cacheHandler should return false for isEndpointExcluded for image endpoint when images included`() {
+        assertFalse {
+            BeagleCacheHandler(includeEndpoints = imageEndpoints).isEndpointExcluded(IMAGE_ENDPOINT)
+        }
     }
 
     @Test
-    fun cacheHandler_should_return_true_for_verifyIfHashIsUpToDate() {
+    fun `cacheHandler should return true for isEndpointExcluded for home endpoint when images included`() {
+        assertTrue {
+            BeagleCacheHandler(includeEndpoints = imageEndpoints).isEndpointExcluded(HOME_ENDPOINT)
+        }
+    }
+
+    @Test
+    fun `cacheHandler should return same hash for button object when call generateAndAddHash`() {
+        assertEquals(
+            BeagleCacheHandler().generateAndAddHash(
+                endpoint = HOME_ENDPOINT,
+                currentPlatform = BeaglePlatform.ALL.name,
+                json = BUTTON_JSON
+            ),
+            BUTTON_JSON_HASH
+        )
+    }
+
+    @Test
+    fun `cacheHandler should return true for isHashIsUpToDate`() {
         val cacheHandler = BeagleCacheHandler()
         cacheHandler.generateAndAddHash(
             endpoint = HOME_ENDPOINT,
@@ -83,7 +103,7 @@ internal class BeagleCacheHandlerTest {
     }
 
     @Test
-    fun cacheHandler_should_return_false_for_verifyIfHashIsUpToDate() {
+    fun `cacheHandler should return false for isHashIsUpToDate`() {
         val cacheHandler = BeagleCacheHandler()
         val cacheHandler2 = BeagleCacheHandler()
         cacheHandler.generateAndAddHash(
@@ -108,19 +128,22 @@ internal class BeagleCacheHandlerTest {
     }
 
     @Test
-    fun test_handleCache_when_excluded_endpoint() {
-        testHandleCache(endpoint = IMAGE_ENDPOINT) {
-            verifySequence { it.callController(Response.START) }
-        }
+    fun `Test handleCache when endpoint is excluded`() {
+        testHandleCache(endpoint = IMAGE_ENDPOINT) { verifySequence { it.callController(Response.START) } }
     }
 
     @Test
-    fun test_handleCache_when_no_previous_cache() {
+    fun `Test handleCache when endpoint is not included`() {
+        testHandleCache(endpoint = "") { verifySequence { it.callController(Response.START) } }
+    }
+
+    @Test
+    fun `Test handleCache when no previous cache`() {
         testHandleCache(endpoint = HOME_ENDPOINT, verify = this::verifySentResponse)
     }
 
     @Test
-    fun test_handleCache_when_previous_cache_is_outdated() {
+    fun `Test handleCache when previous cache is outdated`() {
         testHandleCache(
             endpoint = HOME_ENDPOINT,
             hash = "",
@@ -130,7 +153,7 @@ internal class BeagleCacheHandlerTest {
     }
 
     @Test
-    fun test_handleCache_when_previous_cache_is_up_to_date() {
+    fun `Test handleCache when previous cache is up to date`() {
         testHandleCache(endpoint = HOME_ENDPOINT, hash = BUTTON_JSON_HASH, prepare = this::preparePreviousCache) {
             verifySequence {
                 it.addStatus(Response.START, HttpURLConnection.HTTP_NOT_MODIFIED)
@@ -146,14 +169,13 @@ internal class BeagleCacheHandlerTest {
         verify: (RestCacheHandler<Response>) -> Unit
     ) {
         val restCache = mockk<RestCacheHandler<Response>>()
-        val cacheHandler = BeagleCacheHandler(excludedEndpoints)
-        val response = BUTTON_JSON
+        val cacheHandler = BeagleCacheHandler(excludeEndpoints = imageEndpoints, includeEndpoints = allEndpoints)
 
         prepare(cacheHandler)
         every { restCache.callController(any()) } returns Response.CONTROLLER
         every { restCache.addHashHeader(any(), any()) } returns Response.HEADER
         every { restCache.addStatus(any(), any()) } returns Response.STATUS
-        every { restCache.getBody(any()) } returns response
+        every { restCache.getBody(any()) } returns BUTTON_JSON
 
         cacheHandler.handleCache(
             endpoint = endpoint,

--- a/backend/sample/micronaut/src/main/resources/application.properties
+++ b/backend/sample/micronaut/src/main/resources/application.properties
@@ -15,6 +15,7 @@
 #
 
 beagle.cache.endpoint.include=/**
+beagle.cache.endpoint.exclude=/html/.*,/images/.*
 jackson.serializationInclusion=NON_NULL
 jackson.serialization.indentOutput=true
 micronaut.router.static-resources.*.paths=classpath:static

--- a/backend/sample/micronaut/src/main/resources/application.properties
+++ b/backend/sample/micronaut/src/main/resources/application.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-beagle.cache.endpoint.include=/**
+beagle.cache.endpoint.include=/.*
 beagle.cache.endpoint.exclude=/html/.*,/images/.*
 jackson.serializationInclusion=NON_NULL
 jackson.serialization.indentOutput=true

--- a/backend/sample/micronaut/src/main/resources/application.properties
+++ b/backend/sample/micronaut/src/main/resources/application.properties
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
+beagle.cache.endpoint.include=/**
 jackson.serializationInclusion=NON_NULL
 jackson.serialization.indentOutput=true
-beagle.cache.endpoint.exclude=/image
 micronaut.router.static-resources.*.paths=classpath:static
 micronaut.server.cors.enabled=true
 micronaut.server.cors.configurations.beagle.exposedHeaders=beagle-hash

--- a/backend/sample/spring/src/main/resources/application.properties
+++ b/backend/sample/spring/src/main/resources/application.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-beagle.cache.endpoint.include=/*
+beagle.cache.endpoint.include=/.*
 beagle.cache.endpoint.exclude=/html/.*,/images/.*
 spring.jackson.default-property-inclusion=NON_NULL
 spring.jackson.serialization.indent-output=true

--- a/backend/sample/spring/src/main/resources/application.properties
+++ b/backend/sample/spring/src/main/resources/application.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-beagle.cache.endpoint.exclude=/image
+beagle.cache.endpoint.include=/*
 spring.jackson.default-property-inclusion=NON_NULL
 spring.jackson.serialization.indent-output=true

--- a/backend/sample/spring/src/main/resources/application.properties
+++ b/backend/sample/spring/src/main/resources/application.properties
@@ -15,5 +15,6 @@
 #
 
 beagle.cache.endpoint.include=/*
+beagle.cache.endpoint.exclude=/html/.*,/images/.*
 spring.jackson.default-property-inclusion=NON_NULL
 spring.jackson.serialization.indent-output=true

--- a/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/configuration/BeagleCacheConfiguration.kt
+++ b/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/configuration/BeagleCacheConfiguration.kt
@@ -18,12 +18,16 @@ package br.com.zup.beagle.micronaut.configuration
 
 import br.com.zup.beagle.cache.BeagleCacheHandler
 import br.com.zup.beagle.constants.BEAGLE_CACHE_EXCLUDES
+import br.com.zup.beagle.constants.BEAGLE_CACHE_INCLUDES
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Value
 import javax.inject.Singleton
 
 @Factory
-class BeagleCacheConfiguration(@Value("\${$BEAGLE_CACHE_EXCLUDES:}") private val excludeEndpoints: List<String>) {
+class BeagleCacheConfiguration(
+    @Value("\${$BEAGLE_CACHE_INCLUDES:}") private val includeEndpoints: List<String>,
+    @Value("\${$BEAGLE_CACHE_EXCLUDES:}") private val excludeEndpoints: List<String>
+) {
     @Singleton
-    fun beagleCacheHandler() = BeagleCacheHandler(this.excludeEndpoints)
+    fun beagleCacheHandler() = BeagleCacheHandler(this.excludeEndpoints, this.includeEndpoints)
 }

--- a/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
+++ b/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
@@ -33,7 +33,7 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
 
-@Filter(value = ["\${$BEAGLE_CACHE_INCLUDES:/**}"], methods = [HttpMethod.GET])
+@Filter(value = ["\${$BEAGLE_CACHE_INCLUDES:}"], methods = [HttpMethod.GET])
 @Requirements(
     Requires(classes = [BeagleCacheHandler::class]),
     Requires(property = BEAGLE_CACHE_ENABLED, value = "true", defaultValue = "true")

--- a/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
+++ b/backend/starters/beagle-micronaut-starter/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeagleCacheFilter.kt
@@ -33,7 +33,7 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
 
-@Filter(value = ["\${$BEAGLE_CACHE_INCLUDES:}"], methods = [HttpMethod.GET])
+@Filter(value = ["/**"], methods = [HttpMethod.GET])
 @Requirements(
     Requires(classes = [BeagleCacheHandler::class]),
     Requires(property = BEAGLE_CACHE_ENABLED, value = "true", defaultValue = "true")

--- a/backend/starters/beagle-micronaut-starter/src/test/kotlin/br/com/zup/beagle/micronaut/Extensions.kt
+++ b/backend/starters/beagle-micronaut-starter/src/test/kotlin/br/com/zup/beagle/micronaut/Extensions.kt
@@ -18,5 +18,12 @@ package br.com.zup.beagle.micronaut
 
 import io.micronaut.context.ApplicationContext
 import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
 
 fun ApplicationContext.containsBeans(vararg beans: KClass<*>) = beans.all { this.containsBean(it.java) }
+
+fun Any.getProperty(name: String) = this::class.memberProperties.find { it.name == name }?.let {
+    it.isAccessible = true
+    it.getter.call(this)
+}!!

--- a/backend/starters/beagle-spring-starter/src/main/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfiguration.kt
+++ b/backend/starters/beagle-spring-starter/src/main/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfiguration.kt
@@ -32,16 +32,13 @@ import org.springframework.context.annotation.Configuration
 @ConditionalOnClass(value = [BeagleCacheFilter::class, BeagleCacheHandler::class])
 @ConditionalOnProperty(value = [BEAGLE_CACHE_ENABLED], matchIfMissing = true, havingValue = "true")
 open class BeagleCacheAutoConfiguration(
-    @Value("\${$BEAGLE_CACHE_INCLUDES: }") private val includeEndpointList: List<String>,
+    @Value("\${$BEAGLE_CACHE_INCLUDES:}") private val includeEndpointList: List<String>,
     @Value("\${$BEAGLE_CACHE_EXCLUDES:}") private val excludeEndpointList: List<String>
 ) {
     @Bean
     open fun beagleCachingFilter(cacheHandler: BeagleCacheHandler) =
-        FilterRegistrationBean<BeagleCacheFilter>().also {
-            it.filter = BeagleCacheFilter(cacheHandler)
-            it.urlPatterns = this.includeEndpointList
-        }
+        FilterRegistrationBean<BeagleCacheFilter>().also { it.filter = BeagleCacheFilter(cacheHandler) }
 
     @Bean
-    open fun beagleCacheHandler() = BeagleCacheHandler(this.excludeEndpointList)
+    open fun beagleCacheHandler() = BeagleCacheHandler(this.excludeEndpointList, this.includeEndpointList)
 }

--- a/backend/starters/beagle-spring-starter/src/main/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfiguration.kt
+++ b/backend/starters/beagle-spring-starter/src/main/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfiguration.kt
@@ -32,14 +32,14 @@ import org.springframework.context.annotation.Configuration
 @ConditionalOnClass(value = [BeagleCacheFilter::class, BeagleCacheHandler::class])
 @ConditionalOnProperty(value = [BEAGLE_CACHE_ENABLED], matchIfMissing = true, havingValue = "true")
 open class BeagleCacheAutoConfiguration(
-    @Value("\${$BEAGLE_CACHE_INCLUDES:*}") private val includeEndpointList: List<String>,
+    @Value("\${$BEAGLE_CACHE_INCLUDES: }") private val includeEndpointList: List<String>,
     @Value("\${$BEAGLE_CACHE_EXCLUDES:}") private val excludeEndpointList: List<String>
 ) {
     @Bean
     open fun beagleCachingFilter(cacheHandler: BeagleCacheHandler) =
         FilterRegistrationBean<BeagleCacheFilter>().also {
             it.filter = BeagleCacheFilter(cacheHandler)
-            it.addUrlPatterns(*this.includeEndpointList.toTypedArray())
+            it.urlPatterns = this.includeEndpointList
         }
 
     @Bean

--- a/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfigurationTest.kt
+++ b/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfigurationTest.kt
@@ -31,7 +31,6 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean
 import kotlin.test.assertTrue
 
 internal class BeagleCacheAutoConfigurationTest {
-
     private val contextRunner by lazy {
         ApplicationContextRunner().withConfiguration(AutoConfigurations.of(BeagleCacheAutoConfiguration::class.java))
     }
@@ -41,14 +40,14 @@ internal class BeagleCacheAutoConfigurationTest {
     private val excludesField = "excludeEndpointList"
 
     @Test
-    fun beagleCacheAutoConfiguration_must_not_be_present_with_enabled_property_false() {
+    fun `beagleCacheAutoConfiguration must not be present with enabled property false`() {
         this.contextRunner.withPropertyValues("$BEAGLE_CACHE_ENABLED=false").run {
             validateCacheFilter(it, true)
         }
     }
 
     @Test
-    fun beagleCacheAutoConfiguration_must_be_present_with_enabled_property_true_or_absent() {
+    fun `beagleCacheAutoConfiguration must be present with enabled property true or absent`() {
         this.contextRunner.withPropertyValues("$BEAGLE_CACHE_ENABLED=true").run {
             validateCacheFilter(it)
         }
@@ -58,7 +57,7 @@ internal class BeagleCacheAutoConfigurationTest {
     }
 
     @Test
-    fun beagleCacheAutoConfiguration_must_not_be_present_without_required_classes() {
+    fun `beagleCacheAutoConfiguration must not be present without required classes`() {
         val filterClassLoader = FilteredClassLoader(BeagleCacheFilter::class.java, BeagleCacheHandler::class.java)
         this.contextRunner.withClassLoader(filterClassLoader).run {
             validateCacheFilter(it, true)
@@ -66,26 +65,31 @@ internal class BeagleCacheAutoConfigurationTest {
     }
 
     @Test
-    fun beagleCacheAutoConfiguration_must_be_present_with_default_value_for_properties() {
+    fun `beagleCacheAutoConfiguration must be present with default value for properties`() {
         this.contextRunner.run {
             validateCacheFilter(it)
             assertThat(it).getBean(BeagleCacheAutoConfiguration::class.java)
-                .hasFieldOrPropertyWithValue(this.includesField, listOf(" "))
+                .hasFieldOrPropertyWithValue(this.includesField, listOf(""))
                 .hasFieldOrPropertyWithValue(this.excludesField, listOf(""))
         }
     }
 
     @Test
-    fun cacheFilter_must_be_present_and_match_url_pattern() {
-        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_INCLUDES=/te*").run {
+    fun `beagleCacheAutoConfiguration must be present with test value for include property`() {
+        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_INCLUDES=/test").run {
             validateCacheFilter(it)
-            val cacheFilter = (it.getBean(this.cacheFilterBeanName) as FilterRegistrationBean<*>)
-            assertTrue { cacheFilter.urlPatterns.map(::Regex).any { regex -> regex.containsMatchIn("/text") } }
         }
     }
 
     @Test
-    fun beagleCacheAutoConfiguration_must_fail_to_start_with_invalid_excludes_property() {
+    fun `beagleCacheAutoConfiguration must be present with test value for exclude property`() {
+        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_EXCLUDES=/test").run {
+            validateCacheFilter(it)
+        }
+    }
+
+    @Test
+    fun `beagleCacheAutoConfiguration must fail to start with invalid excludes property`() {
         this.contextRunner.withPropertyValues("$BEAGLE_CACHE_EXCLUDES=?").run {
             assertThat(it).hasFailed()
         }

--- a/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfigurationTest.kt
+++ b/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfigurationTest.kt
@@ -31,6 +31,11 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean
 import kotlin.test.assertTrue
 
 internal class BeagleCacheAutoConfigurationTest {
+    companion object {
+        private val BLANK_LIST = listOf("")
+        private val SOME_LIST = listOf("test")
+    }
+
     private val contextRunner by lazy {
         ApplicationContextRunner().withConfiguration(AutoConfigurations.of(BeagleCacheAutoConfiguration::class.java))
     }
@@ -69,30 +74,53 @@ internal class BeagleCacheAutoConfigurationTest {
         this.contextRunner.run {
             validateCacheFilter(it)
             assertThat(it).getBean(BeagleCacheAutoConfiguration::class.java)
-                .hasFieldOrPropertyWithValue(this.includesField, listOf(""))
-                .hasFieldOrPropertyWithValue(this.excludesField, listOf(""))
+                .hasFieldOrPropertyWithValue(this.includesField, BLANK_LIST)
+                .hasFieldOrPropertyWithValue(this.excludesField, BLANK_LIST)
         }
     }
 
     @Test
-    fun `beagleCacheAutoConfiguration must be present with test value for include property`() {
-        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_INCLUDES=/test").run {
+    fun `beagleCacheAutoConfiguration must be present with test values for include property`() {
+        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_INCLUDES=${SOME_LIST.joinToString(",")}").run {
             validateCacheFilter(it)
+            assertThat(it).getBean(BeagleCacheAutoConfiguration::class.java)
+                .hasFieldOrPropertyWithValue(this.includesField, SOME_LIST)
+                .hasFieldOrPropertyWithValue(this.excludesField, BLANK_LIST)
         }
     }
 
     @Test
-    fun `beagleCacheAutoConfiguration must be present with test value for exclude property`() {
-        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_EXCLUDES=/test").run {
+    fun `beagleCacheAutoConfiguration must be present with test values for exclude property`() {
+        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_EXCLUDES=${SOME_LIST.joinToString(",")}").run {
             validateCacheFilter(it)
+            assertThat(it).getBean(BeagleCacheAutoConfiguration::class.java)
+                .hasFieldOrPropertyWithValue(this.includesField, BLANK_LIST)
+                .hasFieldOrPropertyWithValue(this.excludesField, SOME_LIST)
         }
     }
 
     @Test
-    fun `beagleCacheAutoConfiguration must fail to start with invalid excludes property`() {
-        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_EXCLUDES=?").run {
-            assertThat(it).hasFailed()
+    fun `beagleCacheAutoConfiguration must be present with test values for include and exclude property`() {
+        this.contextRunner.withPropertyValues(
+            "$BEAGLE_CACHE_INCLUDES=${SOME_LIST.joinToString(",")}",
+            "$BEAGLE_CACHE_EXCLUDES=${SOME_LIST.joinToString(",")}"
+        ).run {
+            validateCacheFilter(it)
+            assertThat(it).getBean(BeagleCacheAutoConfiguration::class.java)
+                .hasFieldOrPropertyWithValue(this.includesField, SOME_LIST)
+                .hasFieldOrPropertyWithValue(this.excludesField, SOME_LIST)
         }
+    }
+
+
+    @Test
+    fun `beagleCacheAutoConfiguration must fail to start with invalid exclude property`() {
+        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_EXCLUDES=?").run { assertThat(it).hasFailed() }
+    }
+
+    @Test
+    fun `beagleCacheAutoConfiguration must fail to start with invalid include property`() {
+        this.contextRunner.withPropertyValues("$BEAGLE_CACHE_INCLUDES=?").run { assertThat(it).hasFailed() }
     }
 
     private fun validateCacheFilter(context: AssertableApplicationContext, toNotExists: Boolean = false) {

--- a/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfigurationTest.kt
+++ b/backend/starters/beagle-spring-starter/src/test/kotlin/br/com/zup/beagle/spring/configuration/BeagleCacheAutoConfigurationTest.kt
@@ -28,9 +28,7 @@ import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.boot.web.servlet.FilterRegistrationBean
-import java.util.regex.Pattern
 import kotlin.test.assertTrue
-
 
 internal class BeagleCacheAutoConfigurationTest {
 
@@ -71,8 +69,9 @@ internal class BeagleCacheAutoConfigurationTest {
     fun beagleCacheAutoConfiguration_must_be_present_with_default_value_for_properties() {
         this.contextRunner.run {
             validateCacheFilter(it)
-            assertThat(it).getBean(BeagleCacheAutoConfiguration::class.java).hasFieldOrPropertyWithValue(this.includesField, listOf("*"))
-            assertThat(it).getBean(BeagleCacheAutoConfiguration::class.java).hasFieldOrPropertyWithValue(this.excludesField, listOf(""))
+            assertThat(it).getBean(BeagleCacheAutoConfiguration::class.java)
+                .hasFieldOrPropertyWithValue(this.includesField, listOf(" "))
+                .hasFieldOrPropertyWithValue(this.excludesField, listOf(""))
         }
     }
 
@@ -81,11 +80,7 @@ internal class BeagleCacheAutoConfigurationTest {
         this.contextRunner.withPropertyValues("$BEAGLE_CACHE_INCLUDES=/te*").run {
             validateCacheFilter(it)
             val cacheFilter = (it.getBean(this.cacheFilterBeanName) as FilterRegistrationBean<*>)
-            assertTrue {
-                cacheFilter.urlPatterns.map(Pattern::compile).any { pattern ->
-                    pattern.matcher("/text").find()
-                }
-            }
+            assertTrue { cacheFilter.urlPatterns.map(::Regex).any { regex -> regex.containsMatchIn("/text") } }
         }
     }
 


### PR DESCRIPTION
## Description

Updated the default value of each starter's included endpoints to be empty.

## Related Issues

Closes #446.

## Tests

I updated the starter's test to consider the new defaults.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [X] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/

BREAKING CHANGE: `beagle.cache.endpoint.include` default is no endpoints now, not all of them, and now uses Kotlin's `Regex` syntax, regardless of framework