### PR TITLE
fix: Context evaluation for values that is not string

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
@@ -47,7 +47,7 @@ internal class ContextDataEvaluation(
         val expressions = bind.value.getExpressions()
 
         return when {
-            !bind.value.startsWith("@") || expressions.size > 1 -> {
+            bind.type.typeCanHandleMultipleExpressions() -> {
                 contextsData.forEach { contextData ->
                     expressions.filter { it.getContextId() == contextData.id }.forEach { expression ->
                         evaluateExpressionsForContext(contextData, expression, bind)
@@ -62,6 +62,10 @@ internal class ContextDataEvaluation(
                 null
             }
         }
+    }
+
+    private fun <T> Class<T>.typeCanHandleMultipleExpressions(): Boolean {
+        return this == String::class.java || this == Object::class.java
     }
 
     private fun evaluateExpressionsForContext(

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
@@ -47,7 +47,7 @@ internal class ContextDataEvaluation(
         val expressions = bind.value.getExpressions()
 
         return when {
-            bind.type.typeCanHandleMultipleExpressions() -> {
+            bind.type == String::class.java -> {
                 contextsData.forEach { contextData ->
                     expressions.filter { it.getContextId() == contextData.id }.forEach { expression ->
                         evaluateExpressionsForContext(contextData, expression, bind)
@@ -62,10 +62,6 @@ internal class ContextDataEvaluation(
                 null
             }
         }
-    }
-
-    private fun <T> Class<T>.typeCanHandleMultipleExpressions(): Boolean {
-        return this == String::class.java || this == Object::class.java
     }
 
     private fun evaluateExpressionsForContext(

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
@@ -47,7 +47,7 @@ internal class ContextDataEvaluation(
         val expressions = bind.value.getExpressions()
 
         return when {
-            bind.type == String::class.java -> {
+            !bind.value.startsWith("@") || expressions.size > 1 -> {
                 contextsData.forEach { contextData ->
                     expressions.filter { it.getContextId() == contextData.id }.forEach { expression ->
                         evaluateExpressionsForContext(contextData, expression, bind)

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataExtensions.kt
@@ -30,12 +30,16 @@ internal fun ContextData.normalize(): ContextData {
         this
     } else {
         val newValue = BeagleMoshi.moshi.adapter(Any::class.java).toJson(value) ?: ""
-        val normalizedValue: Any = when {
-            newValue.startsWith("{") -> JSONObject(newValue)
-            newValue.startsWith("[") -> JSONArray(newValue)
-            else -> newValue
-        }
+        val normalizedValue = newValue.normalizeContextValue()
         ContextData(this.id, normalizedValue)
+    }
+}
+
+internal fun String.normalizeContextValue(): Any {
+    return when {
+        this.startsWith("{") -> JSONObject(this)
+        this.startsWith("[") -> JSONArray(this)
+        else -> this
     }
 }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
@@ -91,7 +91,7 @@ internal fun Action.evaluateExpression(
         return if (data is JSONObject || data is JSONArray || data.isExpression()) {
             val value = expressionOf<Any>(data.toString()).evaluateForAction(rootView, this)
             if (value is String) {
-                return value.normalizeContextValue()
+                value.normalizeContextValue()
             } else {
                 value
             }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
@@ -23,6 +23,7 @@ import br.com.zup.beagle.android.context.expressionOf
 import br.com.zup.beagle.android.context.ContextActionExecutor
 import br.com.zup.beagle.android.context.ContextDataValueResolver
 import br.com.zup.beagle.android.context.isExpression
+import br.com.zup.beagle.android.context.normalizeContextValue
 import br.com.zup.beagle.android.data.serializer.BeagleMoshi
 import br.com.zup.beagle.android.logger.BeagleMessageLogs
 import br.com.zup.beagle.android.widget.RootView
@@ -88,13 +89,12 @@ internal fun Action.evaluateExpression(
 ): Any? {
     return try {
         return if (data is JSONObject || data is JSONArray || data.isExpression()) {
-            val value = expressionOf<String>(data.toString()).evaluateForAction(rootView, this)
-            val actualValue = if (data is String) {
-                value
+            val value = expressionOf<Any>(data.toString()).evaluateForAction(rootView, this)
+            if (value is String) {
+                return value.normalizeContextValue()
             } else {
-                BeagleMoshi.moshi.adapter(Any::class.java).fromJson(value)
+                value
             }
-            contextDataValueResolver.parse(actualValue)
         } else {
             data
         }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
@@ -93,7 +93,7 @@ internal fun Action.evaluateExpression(
             if (value is String) {
                 value.normalizeContextValue()
             } else {
-                value
+                contextDataValueResolver.parse(value)
             }
         } else {
             data

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ActionExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ActionExtensionsKtTest.kt
@@ -32,6 +32,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ActionExtensionsKtTest : BaseTest() {
 
@@ -74,6 +75,28 @@ class ActionExtensionsKtTest : BaseTest() {
 
         // Then
         val expected = "Hello hello and hello"
+        assertEquals(expected, actualValue)
+    }
+
+    @Test
+    fun evaluateExpression_should_evaluate_bind_of_type_String_with_multiple_expressions_starting_wih_expression() {
+        // Given
+        val bind = expressionOf<String>("@{context1} and @{context2}")
+        val contextValue = "hello"
+        viewModel.addContext(ContextData(
+            id = "context1",
+            value = contextValue
+        ))
+        viewModel.addContext(ContextData(
+            id = "context2",
+            value = contextValue
+        ))
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, bind)
+
+        // Then
+        val expected = "hello and hello"
         assertEquals(expected, actualValue)
     }
 
@@ -154,7 +177,58 @@ class ActionExtensionsKtTest : BaseTest() {
     }
 
     @Test
-    fun evaluateExpression_should_return_expression_result() {
+    fun evaluateExpression_should_evaluate_expression_of_type_int() {
+        // Given
+        val contextValue = 0
+        viewModel.addContext(ContextData(
+            id = "context",
+            value = contextValue
+        ))
+        val value = "@{context}"
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, value)
+
+        // Then
+        assertEquals(contextValue, actualValue as Int)
+    }
+
+    @Test
+    fun evaluateExpression_should_evaluate_expression_of_type_double() {
+        // Given
+        val contextValue = 1.0
+        viewModel.addContext(ContextData(
+            id = "context",
+            value = contextValue
+        ))
+        val value = "@{context}"
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, value)
+
+        // Then
+        assertEquals(contextValue, actualValue as Double)
+    }
+
+    @Test
+    fun evaluateExpression_should_evaluate_expression_of_type_boolean() {
+        // Given
+        val contextValue = true
+        viewModel.addContext(ContextData(
+            id = "context",
+            value = contextValue
+        ))
+        val value = "@{context}"
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, value)
+
+        // Then
+        assertEquals(contextValue, actualValue as Boolean)
+    }
+
+    @Test
+    fun evaluateExpression_should_evaluate_expression_of_type_string() {
         // Given
         val contextValue = "hello"
         viewModel.addContext(ContextData(
@@ -186,6 +260,7 @@ class ActionExtensionsKtTest : BaseTest() {
         val actualValue = action.evaluateExpression(rootView, value)
 
         // Then
+        assertTrue(actualValue is JSONArray)
         assertEquals("""["$contextValue"]""", actualValue.toString())
     }
 
@@ -210,6 +285,7 @@ class ActionExtensionsKtTest : BaseTest() {
         val actualValue = action.evaluateExpression(rootView, value)
 
         // Then
+        assertTrue(actualValue is JSONArray)
         assertEquals("""["$contextValue","$contextValue"]""", actualValue.toString())
     }
 
@@ -229,6 +305,7 @@ class ActionExtensionsKtTest : BaseTest() {
         val actualValue = action.evaluateExpression(rootView, value)
 
         // Then
+        assertTrue(actualValue is JSONObject)
         assertEquals("""{"value":"$contextValue"}""", actualValue.toString())
     }
 
@@ -253,6 +330,7 @@ class ActionExtensionsKtTest : BaseTest() {
         val actualValue = action.evaluateExpression(rootView, value)
 
         // Then
+        assertTrue(actualValue is JSONObject)
         assertEquals("""{"value2":"$contextValue","value1":"$contextValue"}""", actualValue.toString())
     }
 
@@ -278,5 +356,20 @@ class ActionExtensionsKtTest : BaseTest() {
         // Then
         val expected = "Hello $explicitContextValue and $implicitContextValue"
         assertEquals(expected, actualValue)
+    }
+
+    @Test
+    fun evaluateExpression_should_return_evaluated_primitive_value_from_implicit_context() {
+        // Given
+        val secondAction = mockk<Action>(relaxed = true)
+        val bind = expressionOf<Int>("@{onChange}")
+        val implicitContextValue = 0
+        action.handleEvent(rootView, originView, secondAction, "onChange", implicitContextValue)
+
+        // When
+        val actualValue = secondAction.evaluateExpression(rootView, bind)
+
+        // Then
+        assertEquals(implicitContextValue, actualValue)
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ActionExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ActionExtensionsKtTest.kt
@@ -265,6 +265,25 @@ class ActionExtensionsKtTest : BaseTest() {
     }
 
     @Test
+    fun evaluateExpression_should_evaluate_JSONArray() {
+        // Given
+        val contextValue = JSONArray().apply {
+            put("hello")
+        }
+        viewModel.addContext(ContextData(
+            id = "context",
+            value = contextValue
+        ))
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, "@{context}")
+
+        // Then
+        assertTrue(actualValue is JSONArray)
+        assertEquals("""["hello"]""", actualValue.toString())
+    }
+
+    @Test
     fun evaluateExpression_should_return_JSONArray_evaluated_with_multiple_expressions() {
         // Given
         val contextValue = "hello"
@@ -307,6 +326,25 @@ class ActionExtensionsKtTest : BaseTest() {
         // Then
         assertTrue(actualValue is JSONObject)
         assertEquals("""{"value":"$contextValue"}""", actualValue.toString())
+    }
+
+    @Test
+    fun evaluateExpression_should_evaluate_JSONObject() {
+        // Given
+        val value = JSONObject().apply {
+            put("value", "hello")
+        }
+        viewModel.addContext(ContextData(
+            id = "context",
+            value = value
+        ))
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, "@{context}")
+
+        // Then
+        assertTrue(actualValue is JSONObject)
+        assertEquals("""{"value":"hello"}""", actualValue.toString())
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ActionExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ActionExtensionsKtTest.kt
@@ -32,6 +32,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ActionExtensionsKtTest : BaseTest() {
@@ -242,6 +243,24 @@ class ActionExtensionsKtTest : BaseTest() {
 
         // Then
         assertEquals(contextValue, actualValue)
+    }
+
+    @Test
+    fun evaluateExpression_should_return_JSON_string_evaluated() {
+        // Given
+        val contextValue = "hello"
+        viewModel.addContext(ContextData(
+            id = "context",
+            value = contextValue
+        ))
+        val value = """{"value": "@{context}""""
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, value)
+
+        // Then
+        val expected = """{"value": "$contextValue""""
+        assertEquals(expected, actualValue)
     }
 
     @Test


### PR DESCRIPTION
## Description

When attempting to Set a context value for a complex object (a list of Genre objects) the SetContext action is not able to serialize a JSON Object and It serializes a String instead

## Related Issues

#574 

## Tests

Create more unit test for this cases.