### PR TITLE
fix: clear bindings from destroyed views

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -46,6 +46,8 @@ internal class ContextDataManager(
                 bindings = mutableSetOf(),
                 context = contextData.normalize()
             )
+        } else {
+            contexts[contextData.id]?.bindings?.clear()
         }
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -127,6 +127,22 @@ class ContextDataManagerTest : BaseTest() {
     }
 
     @Test
+    fun addContext_should_clear_bindings_when_context_already_exists() {
+        // Given
+        val contextData1 = ContextData(CONTEXT_ID, true)
+        val bind = Bind.Expression("@{$CONTEXT_ID[0]}", type = Boolean::class.java)
+        val contextData2 = ContextData(CONTEXT_ID, false)
+
+        // When
+        contextDataManager.addContext(contextData1)
+        contextDataManager.addBindingToContext(bind)
+        contextDataManager.addContext(contextData2)
+
+        // Then
+        assertTrue {contexts[CONTEXT_ID]?.bindings?.isEmpty() ?: false}
+    }
+
+    @Test
     fun addBindingToContext_should_add_binding_to_context_on_stack() {
         // Given
         val bind = Bind.Expression("@{$CONTEXT_ID[0]}", type = Boolean::class.java)


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>

## Description

Clear bindings when rebuilding the screen.

## Related Issues

https://github.com/ZupIT/beagle/issues/583

## Tests

I added the following tests:

Added test to ensure that when adding a context that already exists in `ContextDataManager` all bindings related this context are removed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/