### PR TITLE
fix: custom components registering

### DIFF
--- a/iOS/Sources/Beagle/Sources/Setup/BeagleDependencies.swift
+++ b/iOS/Sources/Beagle/Sources/Setup/BeagleDependencies.swift
@@ -101,7 +101,7 @@ open class BeagleDependencies: BeagleDependenciesProtocol {
         self.isLoggingEnabled = true
         self.logger = BeagleLoggerProxy(logger: BeagleLoggerDefault(), dependencies: resolver)
 
-        self.decoder = BeagleSchema.DefaultDependencies().decoder
+        self.decoder = BeagleSchema.dependencies.decoder
         self.formDataStoreHandler = FormDataStoreHandler()
         self.windowManager = WindowManagerDefault()
         self.navigation = BeagleNavigator()

--- a/iOS/Sources/Beagle/Sources/Setup/Tests/BeagleSetupTests.swift
+++ b/iOS/Sources/Beagle/Sources/Setup/Tests/BeagleSetupTests.swift
@@ -22,6 +22,11 @@ import BeagleSchema
 final class BeagleSetupTests: XCTestCase {
     // swiftlint:disable discouraged_direct_init
 
+    override func setUp() {
+        super.setUp()
+        BeagleSchema.dependencies = DefaultDependencies()
+    }
+
     func testDefaultDependencies() {
         let dependencies = BeagleDependencies()
         dependencies.appBundle = Bundle()


### PR DESCRIPTION
## Description

*Beagle doesn't decode custom components when we don't initialize BeagleDependencies.*

## Related Issues

#455 

## Tests

I Updated `BeagleSetupTests`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
