### PR TITLE
feat: Add context binding evaluation cache

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -25,8 +25,8 @@ import br.com.zup.beagle.android.utils.getExpressions
 
 internal data class ContextBinding(
     val context: ContextData,
-    val bindings: MutableSet<Bind.Expression<*>>,
-    val cache: LruCache<String, Any?>
+    val bindings: MutableSet<Bind.Expression<*>> = mutableSetOf(),
+    val cache: LruCache<String, Any?> = LruCache(Integer.MAX_VALUE)
 ) {
     fun evaluateBindExpression(binding: Bind.Expression<*>): Any? {
         val expression = binding.value
@@ -53,9 +53,7 @@ internal class ContextDataManager(
     fun addContext(contextData: ContextData) {
         if (contexts[contextData.id] == null) {
             contexts[contextData.id] = ContextBinding(
-                bindings = mutableSetOf(),
-                context = contextData.normalize(),
-                cache = LruCache(10)
+                context = contextData.normalize()
             )
         } else {
             contexts[contextData.id]?.bindings?.clear()

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -31,6 +31,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.verify
 import org.json.JSONObject
@@ -134,7 +135,7 @@ class ContextDataManagerTest : BaseTest() {
         contextDataManager.addContext(contextData2)
 
         // Then
-        assertTrue {contexts[CONTEXT_ID]?.bindings?.isEmpty() ?: false}
+        assertTrue { contexts[CONTEXT_ID]?.bindings?.isEmpty() ?: false }
     }
 
     @Test
@@ -227,6 +228,27 @@ class ContextDataManagerTest : BaseTest() {
 
     @Test
     fun evaluateContextBindings_should_get_value_from_evaluation() {
+        // Given
+        val value = true
+        val contextData = ContextData(CONTEXT_ID, value)
+        contexts[CONTEXT_ID] = mockk<ContextBinding> {
+            every { context } returns contextData
+            every { bindings } returns mutableSetOf(bindModel)
+            every { cache } returns cacheMock
+        }
+
+        every { contexts[CONTEXT_ID]?.evaluateBindExpression(bindModel) } returns model
+
+
+        // When
+        contextDataManager.evaluateContexts()
+
+        // Then
+        verify { bindModel.notifyChange(model) }
+    }
+
+    @Test
+    fun evaluateContextBindings_should_cache_value_from_evaluation() {
         //Given
         val contextData = ContextData(CONTEXT_ID, model)
         val contextBinding = ContextBinding(

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataTreeHelperTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataTreeHelperTest.kt
@@ -16,6 +16,8 @@
 
 package br.com.zup.beagle.android.context
 
+import android.util.LruCache
+import androidx.core.util.lruCache
 import br.com.zup.beagle.android.action.SetContextInternal
 import br.com.zup.beagle.android.jsonpath.JsonCreateTree
 import br.com.zup.beagle.android.testutil.RandomData
@@ -37,7 +39,7 @@ class ContextDataTreeHelperTest {
     fun `should create a context with new json array tree`() {
         val contexts = mutableMapOf<String, ContextBinding>()
         val contextData = ContextData(CONTEXT_ID, true)
-        val contextBinding = ContextBinding(contextData, mutableSetOf())
+        val contextBinding = ContextBinding(contextData, mutableSetOf(), LruCache(1))
         contexts[contextData.id] = contextBinding
         val result = ContextDataTreeHelper().updateContextDataWithTree(
             contextBinding,
@@ -53,7 +55,7 @@ class ContextDataTreeHelperTest {
     fun `should create a context with new json object tree`() {
         val contexts = mutableMapOf<String, ContextBinding>()
         val contextData = ContextData(CONTEXT_ID, JSONArray())
-        val contextBinding = ContextBinding(contextData, mutableSetOf())
+        val contextBinding = ContextBinding(contextData, mutableSetOf(), LruCache(1))
         contexts[contextData.id] = contextBinding
         val result = ContextDataTreeHelper().updateContextDataWithTree(
             contextBinding,
@@ -69,7 +71,7 @@ class ContextDataTreeHelperTest {
     fun `should return the same context when the root tree is the same type`() {
         val contexts = mutableMapOf<String, ContextBinding>()
         val contextData = ContextData(CONTEXT_ID, JSONArray())
-        val contextBinding = ContextBinding(contextData, mutableSetOf())
+        val contextBinding = ContextBinding(contextData, mutableSetOf(), LruCache(1))
         contexts[contextData.id] = contextBinding
         val result = ContextDataTreeHelper().updateContextDataWithTree(
             contextBinding,


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>

## Description

Creates a cache for binding data evaluation in `ContextDataManager()`

## Related Issues

https://github.com/ZupIT/beagle/issues/535

## Tests

I added the following tests:

Ensure that `evaluateContextBindings` saves evaluated data to cache
Ensure that `updateContext` clears cached data

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/