### PR TITLE
fix: change event name of PageView

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/PageViewScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/PageViewScreen.swift
@@ -31,16 +31,16 @@ struct PageViewScreen: DeeplinkScreen {
             navigationBar: NavigationBar(title: "PageView"),
             child: Container(
                 children: [
-                    PageIndicator(numberOfPages: 4, currentPage: "@{context}"),
+                    PageIndicator(numberOfPages: 4, currentPage: "@{currentPage}"),
                     PageView(
                         children: Array(repeating: Page(), count: 4).map { $0.content },
                         pageIndicator: PageIndicator(),
-                        onPageChange: [SetContext(contextId: "context", value: "@{onChange}")],
-                        currentPage: "@{context}"
+                        onPageChange: [SetContext(contextId: "currentPage", value: "@{onPageChange}")],
+                        currentPage: "@{currentPage}"
                     )
                 ],
                 widgetProperties: WidgetProperties(style: Style(flex: Flex().grow(1))),
-                context: Context(id: "context", value: 3)
+                context: Context(id: "currentPage", value: 3)
             )
         )
     }

--- a/iOS/Sources/Beagle/Sources/Components/Page+Renderable/PageView+Renderable.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Page+Renderable/PageView+Renderable.swift
@@ -39,7 +39,7 @@ extension PageView: ServerDrivenComponent {
         
         if let actions = onPageChange {
             view.onPageChange = { page in
-                let context = Context(id: "onChange", value: .int(page))
+                let context = Context(id: "onPageChange", value: .int(page))
                 renderer.controller.execute(actions: actions, with: context, sender: view)
             }
         }


### PR DESCRIPTION
Change event name of PageView to be the same of web and android

## Description

*Page changing event of PageView must have the same name of the attribute `onPageChange`*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/