### PR TITLE
feat: cache iOS dependencies

### DIFF
--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -29,14 +29,10 @@ jobs:
                 uses: actions/cache@v2
                 env:
                     spm-cache-key: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
-                    # spm-path: iOS/.build
                     spm-path: ~/**/DerivedData
                 with:
                     path: ${{ env.spm-path }}
                     key: ${{ env.spm-cache-key }}
-                    # restore-keys: |
-                    #     ${{ env.spm-cache-key }}
-                    #     ${{ runner.os }}-spm-
 
             -   name: install swiftLint
                 run: brew install swiftlint

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -29,9 +29,8 @@ jobs:
                 uses: actions/cache@v2
                 env:
                     spm-cache-key: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
-                    spm-path: iOS/.build
-                    spm-path: iOS/SPM
-                    # spm-path: ~/**/DerivedData/**
+                    # spm-path: iOS/.build
+                    spm-path: ~/**/DerivedData
                 with:
                     path: ${{ env.spm-path }}
                     key: ${{ env.spm-cache-key }}

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -29,8 +29,8 @@ jobs:
                 uses: actions/cache@v2
                 env:
                     spm-cache-key: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
-                    # spm-path: iOS/.build
-                    spm-path: ~/**/DerivedData/**
+                    spm-path: iOS/.build
+                    # spm-path: ~/**/DerivedData/**
                 with:
                     path: ${{ env.spm-path }}
                     key: ${{ env.spm-cache-key }}

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -21,9 +21,18 @@ jobs:
                     fastlane-path: ~/.gem
                 with:
                     path: ${{ env.fastlane-path }}
-                    key: ${{ runner.os }}-spm-${{ hashFiles('iOS/Beagle.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+                    key: ${{ runner.os }}-build-${{ env.fastlane-cache-key }}-${{ hashFiles('Gemfile.lock') }}
             -   name: Install Fastlane
                 run: bundle config set path '~/.gem' && bundle install
+
+            -   name: Cache SPM dependencies
+                uses: actions/cache@v2
+                env:
+                    spm-cache-key: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
+                    spm-path: .build
+                with:
+                    path: ${{ env.spm-path }}
+                    key: ${{ env.spm-cache-key }}
 
             -   name: install Carthage
                 run: brew install carthage

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -34,9 +34,6 @@ jobs:
                     path: ${{ env.spm-path }}
                     key: ${{ env.spm-cache-key }}
 
-            -   name: install Carthage
-                run: brew install carthage
-
             -   name: install swiftLint
                 run: brew install swiftlint
 

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -29,10 +29,12 @@ jobs:
                 uses: actions/cache@v2
                 env:
                     spm-cache-key: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
-                    spm-path: .build
+                    spm-path: iOS/.build
                 with:
                     path: ${{ env.spm-path }}
                     key: ${{ env.spm-cache-key }}
+                    restore-keys: |
+                        ${{ runner.os }}-spm-
 
             -   name: install swiftLint
                 run: brew install swiftlint

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -27,12 +27,9 @@ jobs:
 
             -   name: Cache SPM dependencies
                 uses: actions/cache@v2
-                env:
-                    spm-cache-key: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
-                    spm-path: ~/**/DerivedData
                 with:
-                    path: ${{ env.spm-path }}
-                    key: ${{ env.spm-cache-key }}
+                    path: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
+                    key: ~/**/DerivedData
 
             -   name: install swiftLint
                 run: brew install swiftlint

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -29,11 +29,13 @@ jobs:
                 uses: actions/cache@v2
                 env:
                     spm-cache-key: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
-                    spm-path: iOS/.build
+                    # spm-path: iOS/.build
+                    spm-path: ~/**/DerivedData/**
                 with:
                     path: ${{ env.spm-path }}
                     key: ${{ env.spm-cache-key }}
                     restore-keys: |
+                        ${{ env.spm-cache-key }}
                         ${{ runner.os }}-spm-
 
             -   name: install swiftLint

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -21,7 +21,7 @@ jobs:
                     fastlane-path: ~/.gem
                 with:
                     path: ${{ env.fastlane-path }}
-                    key: ${{ runner.os }}-build-${{ env.fastlane-cache-key }}-${{ hashFiles('Gemfile.lock') }}
+                    key: ${{ runner.os }}-spm-${{ hashFiles('iOS/Beagle.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
             -   name: Install Fastlane
                 run: bundle config set path '~/.gem' && bundle install
 

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -30,13 +30,14 @@ jobs:
                 env:
                     spm-cache-key: ${{ runner.os }}-spm-${{ hashFiles('iOS/**/Package.resolved') }}
                     spm-path: iOS/.build
+                    spm-path: iOS/SPM
                     # spm-path: ~/**/DerivedData/**
                 with:
                     path: ${{ env.spm-path }}
                     key: ${{ env.spm-cache-key }}
-                    restore-keys: |
-                        ${{ env.spm-cache-key }}
-                        ${{ runner.os }}-spm-
+                    # restore-keys: |
+                    #     ${{ env.spm-cache-key }}
+                    #     ${{ runner.os }}-spm-
 
             -   name: install swiftLint
                 run: brew install swiftlint

--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
@@ -88,7 +88,7 @@ struct MainScreen: DeeplinkScreen {
     
     private func buildNavigationBar() -> NavigationBar {
         return NavigationBar(
-            title: "Beagle Demo"
+            title: "Beagle Demo1"
         )
     }
 

--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/MainScreen.swift
@@ -88,7 +88,7 @@ struct MainScreen: DeeplinkScreen {
     
     private func buildNavigationBar() -> NavigationBar {
         return NavigationBar(
-            title: "Beagle Demo1"
+            title: "Beagle Demo"
         )
     }
 


### PR DESCRIPTION
## Description

Changed the iOS PR check action in the CI to cache dependencies from SPM. The intension was to gain performance.
Also removed Carthage action because we don't use it as dependency manager anymore.

## Related Issues

#522 

## Tests

Tested by checking the time used to fetch dependencies and looking if the cache step could get data from cache folder.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/