### PR TITLE
fix: live preview android plugin dependency and navigation

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -23,6 +23,7 @@ import br.com.zup.beagle.android.components.utils.viewExtensionsViewFactory
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.engine.renderer.ActivityRootView
 import br.com.zup.beagle.android.engine.renderer.FragmentRootView
+import br.com.zup.beagle.android.view.BeagleFragment
 import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.android.view.custom.OnStateChanged
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
@@ -86,13 +87,14 @@ fun ViewGroup.renderScreen(fragment: Fragment, screenJson: String) {
     this.renderScreen(FragmentRootView(fragment), screenJson)
 }
 
-
-internal fun ViewGroup.renderScreen(rootView: RootView, screenJson: String){
-    removeAllViewsInLayout()
+internal fun ViewGroup.renderScreen(rootView: RootView, screenJson: String) {
     val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
     viewModel.clearContexts()
-    addView(beagleSerializerFactory.deserializeComponent(screenJson).toView(rootView))
-
+    val component = beagleSerializerFactory.deserializeComponent(screenJson)
+    (rootView.getContext() as AppCompatActivity)
+        .supportFragmentManager
+        .beginTransaction()
+        .replace(this.id, BeagleFragment.newInstance(component))
+        .addToBackStack(null)
+        .commit()
 }
-
-

--- a/android/buildSrc/src/main/kotlin/br/com/zup/beagle/Dependencies.kt
+++ b/android/buildSrc/src/main/kotlin/br/com/zup/beagle/Dependencies.kt
@@ -74,7 +74,8 @@ class Dependencies : Plugin<Project> {
 
         const val jni = "0.0.2"
 
-        const val okHttp = "4.5.0"
+        const val webSocket = "1.5.1"
+        const val simpleLogger = "1.7.25"
 
         const val kotlinTest = "1.3.50"
         const val kotlinCoroutinesTest = "1.3.1"
@@ -125,7 +126,8 @@ class Dependencies : Plugin<Project> {
 
         const val jni = "com.facebook.fbjni:fbjni:${Versions.jni}"
 
-        const val okHttp = "com.squareup.okhttp3:okhttp:${Versions.okHttp}"
+        const val webSocket = "org.java-websocket:Java-WebSocket:${Versions.webSocket}"
+        const val simpleLogger = "org.slf4j:slf4j-simple:${Versions.simpleLogger}"
 
         const val jsonObject = "org.json:json:${Versions.jsonObject}"
     }

--- a/android/preview/build.gradle
+++ b/android/preview/build.gradle
@@ -49,7 +49,8 @@ android {
 dependencies {
     implementation Dependencies.AndroidxLibraries.appcompat
     implementation Dependencies.GeneralLibraries.kotlin
-    implementation Dependencies.GeneralLibraries.okHttp
+    implementation Dependencies.GeneralLibraries.webSocket
+    implementation Dependencies.GeneralLibraries.simpleLogger
 
     implementation project(Dependencies.Modules.core)
 

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/MainActivity.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/MainActivity.kt
@@ -21,6 +21,9 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import br.com.zup.beagle.android.utils.dp
+import br.com.zup.beagle.android.view.BeagleActivity
+import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.sample.activities.NavigationBarActivity
 import br.com.zup.beagle.sample.constants.SAMPLE_ENDPOINT
 import br.com.zup.beagle.sample.fragment.ComposeComponentFragment
@@ -35,9 +38,6 @@ import br.com.zup.beagle.sample.fragment.ScrollViewFragment
 import br.com.zup.beagle.sample.fragment.TabViewFragment
 import br.com.zup.beagle.sample.fragment.TextInputFragment
 import br.com.zup.beagle.sample.fragment.WebViewFragment
-import br.com.zup.beagle.android.utils.dp
-import br.com.zup.beagle.android.view.BeagleActivity
-import br.com.zup.beagle.android.view.ScreenRequest
 
 class MainActivity : AppCompatActivity() {
 


### PR DESCRIPTION
## Description
This PR improves and corrects the behavior of the Android LivePreview plugin. Navigation in the plugin was fixed and the dependency used for websocket communication okHttp was replaced by java websocket, removing conflicts with Beagle's host projects.

## Related Issues
Fixes #430 and resolves #497 

## Tests
I added the following tests:
`beaglePreview_should_use_host_parameter_with_port`,
`beaglePreview_should_use_default_parameter_with_default_port`,
`onClose_should_call_onClose_only_with_remote_is_true`,
`onClose_should_not_call_onClose_when_remote_is_false`,
`onMessage_should_call_onMessage`,
`onError_should_call_onError`

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*