### PR TITLE
fix: fetch the screen before the navigation

### DIFF
--- a/iOS/Sources/Beagle/Sources/Navigation/Tests/BeagleNavigatorTests.swift
+++ b/iOS/Sources/Beagle/Sources/Navigation/Tests/BeagleNavigatorTests.swift
@@ -55,7 +55,9 @@ final class BeagleNavigatorTests: XCTestCase {
         // Given
         let windowMock = WindowMock()
         let windowManager = WindowManagerDumb(window: windowMock)
-        let dependencies = BeagleScreenDependencies(windowManager: windowManager)
+        let repository = RepositoryStub(componentResult: .success(ComponentDummy()))
+        let dependencies = BeagleScreenDependencies(repository: repository, windowManager: windowManager)
+        
         let sut = BeagleNavigator()
         let controller = BeagleControllerStub(dependencies: dependencies)
 
@@ -97,7 +99,10 @@ final class BeagleNavigatorTests: XCTestCase {
     private func swapViewTest(_ navigate: Navigate) {
         let sut = BeagleNavigator()
         let firstViewController = UIViewController()
-        let secondViewController = BeagleControllerStub()
+        
+        let repository = RepositoryStub(componentResult: .success(ComponentDummy()))
+        let dependencies = BeagleScreenDependencies(repository: repository)
+        let secondViewController = BeagleControllerStub(dependencies: dependencies)
         let navigation = BeagleNavigationController()
         navigation.viewControllers = [firstViewController, secondViewController]
         
@@ -117,7 +122,9 @@ final class BeagleNavigatorTests: XCTestCase {
     
     private func addViewTest(_ navigate: Navigate) {
         let sut = BeagleNavigator()
-        let firstViewController = BeagleControllerStub()
+        let repository = RepositoryStub(componentResult: .success(ComponentDummy()))
+        let dependencies = BeagleScreenDependencies(repository: repository)
+        let firstViewController = BeagleControllerStub(dependencies: dependencies)
         let navigation = BeagleNavigationController(rootViewController: firstViewController)
         
         sut.navigate(action: navigate, controller: firstViewController)
@@ -258,7 +265,9 @@ final class BeagleNavigatorTests: XCTestCase {
     
     private func pushStackTest(_ navigate: Navigate) {
         let sut = BeagleNavigator()
-        let navigationSpy = BeagleControllerNavigationSpy()
+        let repository = RepositoryStub(componentResult: .success(ComponentDummy()))
+        let dependencies = BeagleScreenDependencies(repository: repository)
+        let navigationSpy = BeagleControllerNavigationSpy(dependencies: dependencies)
         
         sut.navigate(action: navigate, controller: navigationSpy)
         

--- a/iOS/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
+++ b/iOS/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
@@ -50,6 +50,19 @@ public class BeagleScreenViewController: BeagleController {
     
     // MARK: - Initialization
     
+    @discardableResult
+    static func remote(
+        _ remote: ScreenType.Remote,
+        dependencies: BeagleDependenciesProtocol,
+        completion: @escaping (Result<BeagleScreenViewController, Request.Error>) -> Void
+    ) -> RequestToken? {
+        return BeagleScreenViewModel.remote(remote, dependencies: dependencies) {
+            completion($0.map { viewModel in
+                return self.init(viewModel: viewModel)
+            })
+        }
+    }
+    
     public convenience init(_ component: RawComponent) {
         self.init(.declarative(component.toScreen()))
     }


### PR DESCRIPTION
## Description
When navigating to a remote screen Beagle presents a blank screen while the screen is loading.
This PR changes the navigation to fetch screen before navigate, avoiding the blank screen.

## Related Issues

Part of #585

## Tests

Navigation tests updated.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/