### PR TITLE
fix: added test platform settings in Micronaut starter

### DIFF
--- a/backend/starters/micronaut/build.gradle
+++ b/backend/starters/micronaut/build.gradle
@@ -43,4 +43,8 @@ tasks.withType(JavaCompile) {
     ]
 }
 
+test {
+    useJUnitPlatform()
+}
+
 apply from: rootProject.file('../maven-publish.gradle')


### PR DESCRIPTION
## Description

Fixed test execution of Micronaut stater, adding missing configuration of test platform in its `build.gradle`.

## Related Issues

None.

## Tests

This PR's verification.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.