### PR TITLE
fix: wrong context data evaluate

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
@@ -16,7 +16,6 @@
 
 package br.com.zup.beagle.android.context
 
-import br.com.zup.beagle.android.context.ValueHandler.treatValue
 import br.com.zup.beagle.android.data.serializer.BeagleMoshi
 import br.com.zup.beagle.android.jsonpath.JsonPathFinder
 import br.com.zup.beagle.android.logger.BeagleMessageLogs
@@ -108,7 +107,7 @@ internal class ContextDataEvaluation(
         return if (path != contextData.id) {
             findValue(contextData, path)
         } else {
-            ValueHandler.treatValue(contextData.value, type)
+            ContextValueHandler.treatValue(contextData.value, type)
         }
     }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
@@ -16,6 +16,7 @@
 
 package br.com.zup.beagle.android.context
 
+import br.com.zup.beagle.android.context.ValueHandler.treatValue
 import br.com.zup.beagle.android.data.serializer.BeagleMoshi
 import br.com.zup.beagle.android.jsonpath.JsonPathFinder
 import br.com.zup.beagle.android.logger.BeagleMessageLogs
@@ -24,6 +25,7 @@ import br.com.zup.beagle.android.utils.getExpressions
 import com.squareup.moshi.Moshi
 import org.json.JSONArray
 import org.json.JSONObject
+import java.lang.reflect.Type
 
 internal class ContextDataEvaluation(
     private val jsonPathFinder: JsonPathFinder = JsonPathFinder(),
@@ -102,38 +104,12 @@ internal class ContextDataEvaluation(
         null
     }
 
-    private fun getValue(contextData: ContextData, path: String, type: Class<*>): Any? {
+    private fun getValue(contextData: ContextData, path: String, type: Type): Any? {
         return if (path != contextData.id) {
             findValue(contextData, path)
         } else {
-            treatValue(contextData.value, type)
+            ValueHandler.treatValue(contextData.value, type)
         }
-    }
-
-    //this function is necessary because MOSHI return every number as double
-    // to fix this, this function made due conversion
-    private fun treatValue(value: Any, type: Class<*>): Any {
-        var treatedValue = value
-        if (value is Double) {
-            if (typeIsInt(type))
-                treatedValue = valueToInt(value)
-            else if (typeIsFloat(type))
-                treatedValue = valueToFloat(value)
-        }
-        return treatedValue
-    }
-
-    private fun typeIsInt(type: Class<*>) = type == Integer::class.java
-
-    private fun typeIsFloat(type: Class<*>) = type == Float::class.java
-
-
-    private fun valueToInt(value: Double): Int {
-        return value.toInt()
-    }
-
-    private fun valueToFloat(value: Double): Float {
-        return value.toFloat()
     }
 
     private fun findValue(contextData: ContextData, path: String): Any? {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextValueHandler.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextValueHandler.kt
@@ -20,7 +20,7 @@ import java.lang.reflect.Type
 
 //this object is necessary because MOSHI return every number as double
 // to fix this, this function made due conversion
-internal object ValueHandler {
+internal object ContextValueHandler {
 
     fun treatValue(value: Any, type: Type): Any {
         var treatedValue = value

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ValueHandler.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ValueHandler.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.context
+
+import java.lang.reflect.Type
+
+//this object is necessary because MOSHI return every number as double
+// to fix this, this function made due conversion
+object ValueHandler {
+
+    fun treatValue(value: Any, type: Type): Any {
+        var treatedValue = value
+        if (value is Double) {
+            if (typeIsInt(type))
+                treatedValue = value.toInt()
+            else if (typeIsFloat(type))
+                treatedValue = value.toFloat()
+        }
+        return treatedValue
+    }
+
+    private fun typeIsInt(type: Type) = type == Integer::class.java
+
+    private fun typeIsFloat(type: Type) = type == Float::class.java
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ValueHandler.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ValueHandler.kt
@@ -20,7 +20,7 @@ import java.lang.reflect.Type
 
 //this object is necessary because MOSHI return every number as double
 // to fix this, this function made due conversion
-object ValueHandler {
+internal object ValueHandler {
 
     fun treatValue(value: Any, type: Type): Any {
         var treatedValue = value

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
@@ -257,11 +257,11 @@ internal class ContextDataEvaluationTest {
 
         //WHEN
         val result = contextDataEvaluation.evaluateBindExpression(
-            contextData = ContextData("context", 0.0),
+            contextData = ContextData("context", RandomData.double()),
             bind = bind
         )
         //THEN
-        assertEquals(0, result)
+        assert(result is Integer)
     }
 
     @Test
@@ -272,11 +272,11 @@ internal class ContextDataEvaluationTest {
 
         //WHEN
         val result = contextDataEvaluation.evaluateBindExpression(
-            contextData = ContextData("context", 0.0),
+            contextData = ContextData("context", RandomData.double()),
             bind = bind
         )
         //THEN
-        assertEquals(0f, result)
+        assert(result is Float)
     }
 
     @Test
@@ -287,11 +287,11 @@ internal class ContextDataEvaluationTest {
 
         //WHEN
         val result = contextDataEvaluation.evaluateBindExpression(
-            contextData = ContextData("context", 0.0),
+            contextData = ContextData("context", RandomData.double()),
             bind = bind
         )
         //THEN
-        assertEquals(0.0, result)
+        assert(result is Double)
     }
 
     private fun <T>commonMock() : Bind.Expression<T> {

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
@@ -21,14 +21,9 @@ import br.com.zup.beagle.android.jsonpath.JsonPathFinder
 import br.com.zup.beagle.android.logger.BeagleMessageLogs
 import br.com.zup.beagle.android.mockdata.ComponentModel
 import br.com.zup.beagle.android.testutil.RandomData
+import br.com.zup.beagle.android.utils.getExpressions
 import com.squareup.moshi.Moshi
-import io.mockk.Runs
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.unmockkAll
-import io.mockk.verify
+import io.mockk.*
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
@@ -252,6 +247,60 @@ internal class ContextDataEvaluationTest {
         // Then
         assertNull(value)
         verify(exactly = once()) { BeagleMessageLogs.errorWhenExpressionEvaluateNullValue(any()) }
+    }
+
+    @Test
+    fun evaluateExpressionsForContext_should_set_binding_evaluatedExpressions_value_with_int_when_bind_type_is_int() {
+        //GIVEN
+        val bind = commonMock<Integer>()
+        every { bind.type } returns Integer::class.java
+
+        //WHEN
+        val result = contextDataEvaluation.evaluateBindExpression(
+            contextData = ContextData("context", 0.0),
+            bind = bind
+        )
+        //THEN
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun evaluateExpressionsForContext_should_set_binding_evaluatedExpressions_value_with_float_when_bind_type_is_float() {
+        //GIVEN
+        val bind = commonMock<Float>()
+        every { bind.type } returns Float::class.java
+
+        //WHEN
+        val result = contextDataEvaluation.evaluateBindExpression(
+            contextData = ContextData("context", 0.0),
+            bind = bind
+        )
+        //THEN
+        assertEquals(0f, result)
+    }
+
+    @Test
+    fun evaluateExpressionsForContext_should_set_binding_evaluatedExpressions_value_with_double_when_bind_type_is_double() {
+        //GIVEN
+        val bind = commonMock<Double>()
+        every { bind.type } returns Double::class.java
+
+        //WHEN
+        val result = contextDataEvaluation.evaluateBindExpression(
+            contextData = ContextData("context", 0.0),
+            bind = bind
+        )
+        //THEN
+        assertEquals(0.0, result)
+    }
+
+    private fun <T>commonMock() : Bind.Expression<T> {
+        mockkStatic("br.com.zup.beagle.android.utils.StringExtensionsKt")
+        val value = "@{context}"
+        val bind: Bind.Expression<T> = mockk(relaxed = true)
+        every { bind.value } returns value
+        every { value.getExpressions() } returns listOf("context")
+        return bind
     }
 
 }


### PR DESCRIPTION
## Description

When will evaluateExpression, after get the value of ContextData the value is treated to cast to the specific type

## Related Issues
#622 

## Tests

I added the following tests:
evaluateExpressionsForContext_should_set_binding_evaluatedExpressions_value_with_int_when_bind_type_is_int
evaluateExpressionsForContext_should_set_binding_evaluatedExpressions_value_with_float_when_bind_type_is_float
evaluateExpressionsForContext_should_set_binding_evaluatedExpressions_value_with_double_when_bind_type_is_double

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/