### PR TITLE
fix: Android context cache

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -31,7 +31,10 @@ internal data class ContextBinding(
     fun evaluateBindExpression(binding: Bind.Expression<*>): Any? {
         val expression = binding.value
         if (cache[expression] == null) {
-            cache.put(expression, ContextDataEvaluation().evaluateBindExpression(context, binding))
+            val value = ContextDataEvaluation().evaluateBindExpression(context, binding)
+            if(value != null) {
+                cache.put(expression, value)
+            }
         }
 
         return cache.get(expression)


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>

## Description

Avoid caching null values. `LruCache` doesn't allow caching null values.

## Related Issues

https://github.com/ZupIT/beagle/issues/628


## Tests

I added the following tests:

No tests added

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/