### PR TITLE
feat: set possibility of escape expressions

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/ViewExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/ViewExtensions.kt
@@ -18,6 +18,7 @@ package br.com.zup.beagle.android.components.utils
 
 import android.content.Context
 import android.graphics.drawable.GradientDrawable
+import android.os.Build
 import android.util.TypedValue
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -46,6 +47,9 @@ internal fun View.applyStyle(component: ServerDrivenComponent) {
             applyCornerRadius(it)
         } else {
             styleManagerFactory.applyStyleComponent(component = it, view = this)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            elevation = 1.6f
         }
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/ViewExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/ViewExtensions.kt
@@ -48,9 +48,6 @@ internal fun View.applyStyle(component: ServerDrivenComponent) {
         } else {
             styleManagerFactory.applyStyleComponent(component = it, view = this)
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            elevation = 1.6f
-        }
     }
 }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/ViewExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/ViewExtensions.kt
@@ -18,7 +18,6 @@ package br.com.zup.beagle.android.components.utils
 
 import android.content.Context
 import android.graphics.drawable.GradientDrawable
-import android.os.Build
 import android.util.TypedValue
 import android.view.View
 import android.view.inputmethod.InputMethodManager

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
@@ -74,7 +74,7 @@ internal class ContextDataEvaluation(
 
     private fun evaluateMultipleExpressions(bind: Bind.Expression<*>): Any? {
         val regex = "(?<=\\})".toRegex()
-        val text = bind.value.split(regex).joinToString("") {
+        return bind.value.split(regex).joinToString("") {
             val slash = "(\\\\*)@".toRegex().find(it)?.groups?.get(1)?.value?.length ?: 0
             if (!it.matches(".*\\\\@.*".toRegex()) || slash % 2 == 0) {
                 val key = "\\{([^\\{]*)\\}".toRegex().find(it)?.groups?.get(1)?.value
@@ -89,7 +89,6 @@ internal class ContextDataEvaluation(
             .replace("\\\\", "\\")
             .replace("\\@", "@")
 
-        return if (text.isEmpty()) null else text
     }
 
     private fun evaluateExpression(contextData: ContextData, bind: Bind.Expression<*>, expression: String): Any? {

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
@@ -206,7 +206,7 @@ internal class ContextDataEvaluationTest {
     }
 
     @Test
-    fun evaluateAllContext_should_return_null_in_expressions_with_null_bind_value_in_string_type() {
+    fun evaluateAllContext_should_return_empty_in_expressions_with_null_bind_value_in_string_type() {
         // Given
         val bind = expressionOf<String>("@{$CONTEXT_ID.exp1}")
         every { jsonPathFinder.find(any(), any()) } returns null
@@ -215,8 +215,7 @@ internal class ContextDataEvaluationTest {
         val value = contextDataEvaluation.evaluateBindExpression(CONTEXT_DATA, bind)
 
         // Then
-        assertNull(value)
-        verify(exactly = once()) { BeagleMessageLogs.errorWhenExpressionEvaluateNullValue(any()) }
+        assertEquals("", value)
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
@@ -79,7 +79,7 @@ internal class ContextDataEvaluationTest {
     }
 
     @Test
-    fun evaluateContextBindings_should_get_value_from_context_and_deserialize_JSONOBject() {
+    fun evaluateContextBindings_should_get_value_from_context_and_deserialize_JSONObject() {
         // Given
         val jsonObject = mockk<JSONObject>()
         every { jsonPathFinder.find(any(), any()) } returns jsonObject
@@ -294,7 +294,21 @@ internal class ContextDataEvaluationTest {
         assert(result is Double)
     }
 
-    private fun <T>commonMock() : Bind.Expression<T> {
+    @Test
+    fun evaluateAllContext_with_escaping_expressions_should_return_expected_values() {
+        createEscapeBindingMockCases().forEach { mockCase ->
+            // Given
+            val bind = expressionOf<String>(mockCase.value)
+
+            // When
+            val value = contextDataEvaluation.evaluateBindExpression(mockCase.contextData, bind)
+
+            // Then
+            assertEquals(mockCase.expected, value)
+        }
+    }
+
+    private fun <T> commonMock(): Bind.Expression<T> {
         mockkStatic("br.com.zup.beagle.android.utils.StringExtensionsKt")
         val value = "@{context}"
         val bind: Bind.Expression<T> = mockk(relaxed = true)
@@ -303,4 +317,24 @@ internal class ContextDataEvaluationTest {
         return bind
     }
 
+    private fun createEscapeBindingMockCases(): List<EscapingTestCases> = listOf(
+        EscapingTestCases("@{context}", "value"),
+        EscapingTestCases("@{context} test", "value test"),
+        EscapingTestCases("test @{context}", "test value"),
+        EscapingTestCases("test \\@{context}", "test @{context}"),
+        EscapingTestCases("test \\\\@{context}", "test \\value"),
+        EscapingTestCases("test \\\\\\@{context}", "test \\@{context}"),
+        EscapingTestCases("test \\\\\\\\@{context}", "test \\\\value"),
+        EscapingTestCases("test \\\\\\\\\\@{context}", "test \\\\@{context}"),
+        EscapingTestCases(
+            "This is a @{context} of \\ expression \\@{context}",
+            "This is a value of \\ expression @{context}"
+        )
+    )
+
+    data class EscapingTestCases(
+        val value: String,
+        val expected: String,
+        val contextData: ContextData = ContextData("context", "value")
+    )
 }


### PR DESCRIPTION
## Description

Set the possibility to escape the context expressions of JSON

## Related Issues

https://github.com/ZupIT/beagle/issues/536

## Tests

I added the following tests:

evaluateAllContext_with_escaping_expressions_should_return_expected_values at ContextDataEvaluationTest

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/