### PR TITLE
fix: beagle components fetch and deserialization was taking place on …

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/engine/renderer/RootView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/engine/renderer/RootView.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModelStoreOwner
 import br.com.zup.beagle.android.widget.RootView
 
 class FragmentRootView(
@@ -28,6 +29,8 @@ class FragmentRootView(
     override fun getContext(): Context = fragment.requireContext()
 
     override fun getLifecycleOwner(): LifecycleOwner = fragment.viewLifecycleOwner
+
+    override fun getViewModelStoreOwner(): ViewModelStoreOwner = fragment
 }
 
 class ActivityRootView(
@@ -36,4 +39,6 @@ class ActivityRootView(
     override fun getContext(): Context = activity
 
     override fun getLifecycleOwner(): LifecycleOwner = activity
+
+    override fun getViewModelStoreOwner(): ViewModelStoreOwner = activity
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpClientDefault.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpClientDefault.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.android.networking
 
 import br.com.zup.beagle.android.exception.BeagleApiException
+import br.com.zup.beagle.android.utils.CoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Job
@@ -31,7 +32,7 @@ typealias OnError = (responseData: ResponseData) -> Unit
 internal class HttpClientDefault : HttpClient, CoroutineScope {
 
     private val job = Job()
-    override val coroutineContext = job + IO
+    override val coroutineContext = job + CoroutineDispatchers.IO
 
     override fun execute(
         request: RequestData,

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/RootViewExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/RootViewExtensions.kt
@@ -16,28 +16,10 @@
 
 package br.com.zup.beagle.android.utils
 
-import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import br.com.zup.beagle.android.engine.renderer.ActivityRootView
-import br.com.zup.beagle.android.engine.renderer.FragmentRootView
 import br.com.zup.beagle.android.widget.RootView
 
 internal inline fun <reified T : ViewModel> RootView.generateViewModelInstance(): T {
-    return when (this) {
-        is ActivityRootView -> {
-            val activity = this.activity
-            ViewModelProviderFactory.of(activity).get(T::class.java)
-        }
-        else -> {
-            val fragment = (this as FragmentRootView).fragment
-            ViewModelProviderFactory.of(fragment).get(T::class.java)
-        }
-    }
-}
-
-internal object ViewModelProviderFactory {
-    fun of(fragment: Fragment) = ViewModelProvider(fragment)
-    fun of(activity: AppCompatActivity) = ViewModelProvider(activity)
+    return ViewModelProvider(this.getViewModelStoreOwner()).get(T::class.java)
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/widget/RootView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/widget/RootView.kt
@@ -18,8 +18,10 @@ package br.com.zup.beagle.android.widget
 
 import android.content.Context
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModelStoreOwner
 
 interface RootView {
     fun getContext(): Context
     fun getLifecycleOwner(): LifecycleOwner
+    fun getViewModelStoreOwner(): ViewModelStoreOwner
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/BaseTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/BaseTest.kt
@@ -18,13 +18,14 @@ package br.com.zup.beagle.android
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.android.engine.renderer.ActivityRootView
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.setup.BeagleSdk
-import br.com.zup.beagle.android.utils.ViewModelProviderFactory
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.junit.After
@@ -40,7 +41,6 @@ abstract class BaseTest {
         MockKAnnotations.init(this)
 
         mockkObject(BeagleEnvironment)
-        mockkObject(ViewModelProviderFactory)
 
         every { rootView.activity } returns mockk()
         every { BeagleEnvironment.beagleSdk } returns beagleSdk
@@ -55,6 +55,7 @@ abstract class BaseTest {
     }
 
     protected fun prepareViewModelMock(viewModel: ViewModel) {
-        every { ViewModelProviderFactory.of(any<AppCompatActivity>())[viewModel::class.java] } returns viewModel
+        mockkConstructor(ViewModelProvider::class)
+        every { anyConstructed<ViewModelProvider>().get(viewModel::class.java) } returns viewModel
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/action/SendRequestTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/action/SendRequestTest.kt
@@ -17,24 +17,23 @@
 package br.com.zup.beagle.android.action
 
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.android.context.ContextData
+import br.com.zup.beagle.android.context.valueOf
 import br.com.zup.beagle.android.engine.renderer.ActivityRootView
 import br.com.zup.beagle.android.extensions.once
-import br.com.zup.beagle.android.view.viewmodel.ActionRequestViewModel
-import br.com.zup.beagle.android.view.viewmodel.Response
-import br.com.zup.beagle.android.context.valueOf
-import br.com.zup.beagle.android.utils.ViewModelProviderFactory
 import br.com.zup.beagle.android.utils.evaluateExpression
 import br.com.zup.beagle.android.utils.handleEvent
+import br.com.zup.beagle.android.view.viewmodel.ActionRequestViewModel
+import br.com.zup.beagle.android.view.viewmodel.Response
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
+import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
@@ -61,13 +60,8 @@ class SendRequestTest {
 
     @Before
     fun setUp() {
-        mockkObject(ViewModelProviderFactory)
-
-        every {
-            ViewModelProviderFactory
-                .of(any<AppCompatActivity>())
-                .get(ActionRequestViewModel::class.java)
-        } returns viewModel
+        mockkConstructor(ViewModelProvider::class)
+        every { anyConstructed<ViewModelProvider>().get(ActionRequestViewModel::class.java) } returns viewModel
 
         mockkStatic("br.com.zup.beagle.android.utils.ActionExtensionsKt")
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/action/SetContextTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/action/SetContextTest.kt
@@ -17,17 +17,17 @@
 package br.com.zup.beagle.android.action
 
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.android.engine.renderer.ActivityRootView
 import br.com.zup.beagle.android.logger.BeagleLoggerProxy
 import br.com.zup.beagle.android.testutil.RandomData
-import br.com.zup.beagle.android.utils.ViewModelProviderFactory
 import br.com.zup.beagle.android.utils.evaluateExpression
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
@@ -41,18 +41,17 @@ internal class SetContextTest {
     private val viewModel = mockk<ScreenContextViewModel>()
     private val view = mockk<View>()
     private val rootView = mockk<ActivityRootView> {
-        every { activity } returns mockk()
+        every { activity } returns mockk(relaxed = true)
+        every { getViewModelStoreOwner() } returns activity
     }
 
     @Before
     internal fun setUp() {
-        mockkObject(ViewModelProviderFactory)
         mockkObject(BeagleLoggerProxy)
         mockkStatic("br.com.zup.beagle.android.utils.ActionExtensionsKt")
 
-        every {
-            ViewModelProviderFactory.of(any<AppCompatActivity>())[ScreenContextViewModel::class.java]
-        } returns viewModel
+        mockkConstructor(ViewModelProvider::class)
+        every { anyConstructed<ViewModelProvider>().get(ScreenContextViewModel::class.java) } returns viewModel
     }
 
     @Test
@@ -84,6 +83,7 @@ internal class SetContextTest {
         )
         every { setContext.evaluateExpression(any(), view, any<Any>()) } returns null
         every { BeagleLoggerProxy.warning(any()) } just Runs
+
 
         // When
         setContext.execute(rootView, view)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
@@ -33,7 +33,6 @@ import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.setup.DesignSystem
 import br.com.zup.beagle.android.testutil.RandomData
-import br.com.zup.beagle.android.utils.ViewModelProviderFactory
 import br.com.zup.beagle.android.utils.loadView
 import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.android.view.ViewFactory
@@ -65,10 +64,10 @@ class ViewExtensionsKtTest : BaseTest() {
     @MockK(relaxUnitFun = true, relaxed = true)
     private lateinit var viewModel : ScreenContextViewModel
 
-    @MockK
+    @RelaxedMockK
     private lateinit var fragment: Fragment
 
-    @MockK
+    @RelaxedMockK
     private lateinit var activity: AppCompatActivity
 
     @MockK
@@ -95,12 +94,10 @@ class ViewExtensionsKtTest : BaseTest() {
         super.setUp()
 
         mockkStatic(TextViewCompat::class)
-        mockkObject(ViewModelProviderFactory)
 
         viewExtensionsViewFactory = viewFactory
 
-        every { ViewModelProviderFactory.of(any<Fragment>())[ScreenContextViewModel::class.java] } returns viewModel
-        every { ViewModelProviderFactory.of(any<AppCompatActivity>())[ScreenContextViewModel::class.java] } returns viewModel
+        prepareViewModelMock(viewModel)
         every { viewFactory.makeBeagleView(any()) } returns beagleView
         every { viewFactory.makeView(any()) } returns beagleView
         every { viewGroup.addView(capture(viewSlot)) } just Runs

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextActionExecutorTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextActionExecutorTest.kt
@@ -17,29 +17,21 @@
 package br.com.zup.beagle.android.context
 
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.action.Action
-import br.com.zup.beagle.android.components.layout.Container
-import br.com.zup.beagle.android.data.serializer.BeagleMoshi
-import br.com.zup.beagle.android.engine.renderer.ActivityRootView
 import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.testutil.RandomData
-import br.com.zup.beagle.android.utils.ViewModelProviderFactory
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.slot
-import io.mockk.unmockkAll
 import io.mockk.verify
 import io.mockk.verifySequence
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Test
-
 import kotlin.test.assertEquals
 
 data class PersonTest(val name: String)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextComponentHandlerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextComponentHandlerTest.kt
@@ -18,14 +18,16 @@ package br.com.zup.beagle.android.context
 
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
+import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.engine.renderer.ActivityRootView
-import br.com.zup.beagle.android.utils.ViewModelProviderFactory
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
@@ -45,11 +47,11 @@ class ContextComponentHandlerTest {
     fun setUp() {
         contextComponentHandler = ContextComponentHandler()
 
-        mockkObject(ViewModelProviderFactory)
+        every { rootView.activity } returns mockk(relaxed = true)
+        every { rootView.getViewModelStoreOwner() } returns rootView.activity
+        mockkConstructor(ViewModelProvider::class)
+        every { anyConstructed<ViewModelProvider>().get(ScreenContextViewModel::class.java) } returns viewModel
 
-        every { rootView.activity } returns mockk()
-        every { ViewModelProviderFactory.of(any<AppCompatActivity>())
-            .get(ScreenContextViewModel::class.java) } returns viewModel
     }
 
     @After

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/WidgetExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/WidgetExtensionsKtTest.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.android.utils
 
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.components.layout.NavigationBar
 import br.com.zup.beagle.android.components.layout.Screen
@@ -31,6 +32,7 @@ import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.core.Style
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.verifySequence
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -77,9 +79,10 @@ class WidgetExtensionsKtTest : BaseTest() {
         // Given
         val viewModelMock = mockk<ScreenContextViewModel>(relaxed = true)
         val beagleFlexView = mockk<BeagleFlexView>(relaxed = true)
-        every {
-            ViewModelProviderFactory.of(any<AppCompatActivity>())[ScreenContextViewModel::class.java]
-        } returns viewModelMock
+
+        mockkConstructor(ViewModelProvider::class)
+        every { anyConstructed<ViewModelProvider>().get(ScreenContextViewModel::class.java) } returns viewModelMock
+
         every { viewFactory.makeBeagleFlexView(any()) } returns beagleFlexView
         every { rootView.getContext() } returns mockk()
 


### PR DESCRIPTION
…the main thread

Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>

## Description

The goal of this PR is to change `BeagleViewModel::fetchComponent` and `BeagleViewModel::fetchForCache` dispatchers. This class was doing internet requests and heavy data processing in main thread leading to Garbage Collector triggering several times.

The selected approach to solving this problem was to inject the desired dispatcher in `BeagleViewModel`. This approach was used due to two main reasons:

- Reinforce Open/Closed SOLID principle, making the class more closed to changes.
- Reduce code smell. According to The official Android Developers publication on Medium (https://medium.com/androiddevelopers/testing-two-consecutive-livedata-emissions-in-coroutines-5680b693cbf8) “As a good practice, always inject Dispatchers to those classes that use them. You shouldn’t use the predefined Dispatchers that come with the coroutines library (e.g. Dispatchers.IO) in your classes directly since it makes testing more difficult, pass them as a dependency.”

## Related Issues

https://github.com/ZupIT/beagle/issues/419

## Tests

The following test classes were updated:

BeagleViewModelTest - Updated to use a TestCoroutineDispatcher

ActionExtensionsKtTest
ContextActionExecutorTest
ContextComponentHandlerTest
PreFetchHelperTest
SendRequestTest
SetContextTest
ViewExtensionsKtTest
WidgetExtensionsKtTest

Above classes updated due changes to RootViewExtensions.kt

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/