### PR TITLE
fix: ContextPathResolver - Evaluate expression with variable string name value was the same as context id.

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextPathResolver.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextPathResolver.kt
@@ -28,13 +28,13 @@ class ContextPathResolver {
 
     private fun removeContextFromPath(contextId: String, path: String): String {
         var newPath = path
-        val contextIdFormatted ="$contextId."
+        val contextIdFormatted = "$contextId."
 
-        if (contextId == path) {
-            throw JsonPathUtils.createInvalidPathException(path)
-        } else if(path.startsWith(contextIdFormatted)){
-            newPath = path.replaceFirst(contextIdFormatted, "")
-        }
+        if (newPath.startsWith(contextIdFormatted)) {
+            newPath = newPath.replaceFirst(contextIdFormatted, "")
+        } else if (newPath.isEmpty()) {
+                throw JsonPathUtils.createInvalidPathException(path)
+            }
         return newPath
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextPathResolver.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextPathResolver.kt
@@ -27,14 +27,14 @@ class ContextPathResolver {
     }
 
     private fun removeContextFromPath(contextId: String, path: String): String {
-        val newPath = path.replace(contextId, "")
+        var newPath = path
+        val contextIdFormatted ="$contextId."
 
         if (newPath.isEmpty()) {
             throw JsonPathUtils.createInvalidPathException(path)
-        } else if (newPath.startsWith(".")) {
-            return newPath.replaceFirst(".", "")
+        } else if(path.startsWith(contextIdFormatted)){
+            newPath = path.replaceFirst(contextIdFormatted, "")
         }
-
         return newPath
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextPathResolver.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextPathResolver.kt
@@ -30,7 +30,7 @@ class ContextPathResolver {
         var newPath = path
         val contextIdFormatted ="$contextId."
 
-        if (newPath.isEmpty()) {
+        if (contextId == path) {
             throw JsonPathUtils.createInvalidPathException(path)
         } else if(path.startsWith(contextIdFormatted)){
             newPath = path.replaceFirst(contextIdFormatted, "")

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextPathResolverTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextPathResolverTest.kt
@@ -71,4 +71,17 @@ class ContextPathResolverTest {
         assertEquals("b", keys.poll())
         assertEquals(0, keys.size)
     }
+
+    @Test
+    fun it_should_not_remove_a_partial_string_value_from_path_that_equals_the_context_id_string_value(){
+        //Given
+        val contextId = RandomData.string()
+        val path = contextId+RandomData.string()
+
+        //When
+        val keys = contextPathResolver.getKeysFromPath(contextId, path)
+
+        //Then
+        assertEquals(path, keys[0])
+    }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextPathResolverTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextPathResolverTest.kt
@@ -53,7 +53,7 @@ class ContextPathResolverTest {
         assertFails {
             contextPathResolver.getKeysFromPath(
                 CONTEXT_ID,
-                CONTEXT_ID
+                ""
             )
         }
     }


### PR DESCRIPTION
## Description

The context Path Resolver class was removing any string value inside a path that matches the context ID String value and not just the value for ID.
Example. If a context ID is set as : user and a path shared the same value partially, like userName , it would remove the user part and attempt to set values or evaluate expression considering "Name" as a biding key.

## Related Issues
https://github.com/ZupIT/beagle/issues/670

## Tests

I added the following tests:

it_should_not_remove_a_partial_string_value_from_path_that_equals_the_context_id_string_value

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/