### PR TITLE
fix: Remove internal keyword

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
@@ -144,7 +144,7 @@ fun ServerDrivenComponent.toView(activity: AppCompatActivity) = this.toView(Acti
  */
 fun ServerDrivenComponent.toView(fragment: Fragment) = this.toView(FragmentRootView(fragment))
 
-internal fun ServerDrivenComponent.toView(rootView: RootView): View {
+fun ServerDrivenComponent.toView(rootView: RootView): View {
     val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
     viewModel.resetIds()
     return viewFactory.makeBeagleFlexView(rootView.getContext()).apply {


### PR DESCRIPTION
## Description

The `.toView` function that receives the rootView parameter is internal, which makes it necessary to use a cast for fragment or activity when it is called a custom component, this PR remove `internal` keyword.

## Related Issues

#672

## Tests

No tests were included

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
