### PR TITLE
fix: Android LoadView

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -60,8 +60,8 @@ private fun loadView(
     val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
     viewModel.resetIds()
     val view = viewExtensionsViewFactory.makeBeagleView(viewGroup.context).apply {
-        loadView(rootView, screenRequest)
         stateChangedListener = listener
+        loadView(rootView, screenRequest)
     }
     view.loadCompletedListener = {
         viewGroup.addView(view)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
@@ -122,8 +122,8 @@ class ViewExtensionsKtTest : BaseTest() {
         verifySequence {
             viewModel.resetIds()
             viewFactory.makeBeagleView(activity)
-            beagleView.loadView(any<FragmentRootView>(), screenRequest)
             beagleView.stateChangedListener = any()
+            beagleView.loadView(any<FragmentRootView>(), screenRequest)
             beagleView.loadCompletedListener = any()
         }
     }


### PR DESCRIPTION
## Description

set first the listener to make sure that the listener variable is not null when the loadView method is called
  val view = viewExtensionsViewFactory.makeBeagleView(viewGroup.context).apply {
        stateChangedListener = listener
        loadView(rootView, screenRequest)
    }

## Related Issues

https://github.com/ZupIT/beagle/issues/666

## Tests

No tests were included
The sequence also was changed from test method loadView_should_create_BeagleView_and_call_loadView_with_fragment.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [X] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->

[DCO]: https://developercertificate.org/