### PR TITLE
fix: android webview without defined size

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/WebView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/WebView.kt
@@ -21,8 +21,11 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.http.SslError
 import android.view.View
-import android.webkit.*
+import android.webkit.SslErrorHandler
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.valueOf
 import br.com.zup.beagle.android.utils.observeBindChanges

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/WebView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/WebView.kt
@@ -21,11 +21,8 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.http.SslError
 import android.view.View
-import android.webkit.SslErrorHandler
-import android.webkit.WebResourceError
-import android.webkit.WebResourceRequest
+import android.webkit.*
 import android.webkit.WebView
-import android.webkit.WebViewClient
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.valueOf
 import br.com.zup.beagle.android.utils.observeBindChanges
@@ -51,7 +48,7 @@ data class WebView(
         webView.webViewClient = BeagleWebViewClient(webView.context)
         webView.settings.javaScriptEnabled = true
         observeBindChanges(rootView, webView, url) {
-            it?.let{ webView.loadUrl(it) }
+            it?.let { webView.loadUrl(it) }
         }
         return webView
     }
@@ -60,6 +57,7 @@ data class WebView(
 
         override fun onPageFinished(view: WebView?, url: String?) {
             notify(loading = false)
+            view?.requestLayout()
         }
 
         override fun onPageStarted(
@@ -84,7 +82,7 @@ data class WebView(
             error: WebResourceError?
         ) {
             val throwable = Error("$error")
-            notify(state = ServerDrivenState.WebViewError(throwable){ view?.reload() })
+            notify(state = ServerDrivenState.WebViewError(throwable) { view?.reload() })
         }
 
         fun notify(loading: Boolean) {
@@ -95,4 +93,5 @@ data class WebView(
             (context as? BeagleActivity)?.onServerDrivenContainerStateChanged(state)
         }
     }
+
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/YogaLayout.java
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/YogaLayout.java
@@ -200,12 +200,6 @@ public class YogaLayout extends ViewGroup {
         invalidate();
     }
 
-    public void setViewHeight(View view, int height) {
-        if (mYogaNodes.containsKey(view)) {
-            mYogaNodes.get(view).setHeight(height);
-        }
-    }
-
     private void removeViewFromYogaTree(View view, boolean inLayout) {
         final YogaNode node = mYogaNodes.get(view);
         if (node == null) {

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/WebViewTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/WebViewTest.kt
@@ -77,10 +77,11 @@ class WebViewTest : BaseComponentTest() {
         val webViewClient = createMockedWebViewClient(stateSlot)
 
         // When
-        webViewClient.onPageFinished(null, null)
+        webViewClient.onPageFinished(webView, null)
 
         // Then
         assertFalse((stateSlot.captured as ServerDrivenState.Loading).loading)
+        verify(exactly = once()) { webView.requestLayout() }
     }
 
     @Test

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/WebViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/WebViewFragment.kt
@@ -21,15 +21,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import br.com.zup.beagle.ext.applyFlex
-import br.com.zup.beagle.ext.unitPercent
-import br.com.zup.beagle.android.utils.toView
-import br.com.zup.beagle.core.Style
-import br.com.zup.beagle.ext.applyStyle
-import br.com.zup.beagle.widget.core.Flex
-import br.com.zup.beagle.widget.core.Size
 import br.com.zup.beagle.android.components.WebView
 import br.com.zup.beagle.android.components.layout.Screen
+import br.com.zup.beagle.android.utils.toView
 
 class WebViewFragment : Fragment() {
 
@@ -40,13 +34,6 @@ class WebViewFragment : Fragment() {
         val declarative = Screen(
             child = WebView(
                 url = "https://zup.com.br"
-            ).applyStyle(
-                Style(
-                    size = Size(
-                        width = 100.unitPercent(),
-                        height = 100.unitPercent()
-                    )
-                )
             )
         )
         return declarative.toView(this)


### PR DESCRIPTION
Signed-off-by: jenifer-mathias <jenifer.santos@zup.com.br>

## Description

This PR corrects a behavior of WebView on Android in which it did not set its own size if the user did not enter a size.

## Related Issues

fix #645 

## Tests

I added the following tests:

`webViewClient_should_notify_when_page_stops_loading`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/