### PR TITLE
fix: ios component registering

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/AppDelegate.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/AppDelegate.swift
@@ -49,9 +49,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         dependencies.isLoggingEnabled = true
         dependencies.navigationControllerType = CustomBeagleNavigationController.self
         
-        Beagle.dependencies = dependencies
+        registerCustomComponents(in: dependencies)
         
-        registerCustomComponents()
+        Beagle.dependencies = dependencies
         
         let rootViewController = MainScreen().screenController()
         window?.rootViewController = rootViewController
@@ -59,10 +59,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
     
-    private func registerCustomComponents() {
-        Beagle.registerCustomComponent("DSCollection", componentType: DSCollection.self)
-        Beagle.registerCustomComponent("SampleTextField", componentType: DemoTextField.self)
-        Beagle.registerCustomComponent("MyComponent", componentType: MyComponent.self)
-        Beagle.registerCustomAction("CustomConsoleLogAction", actionType: CustomConsoleLogAction.self)
+    private func registerCustomComponents(in dependencies: BeagleDependencies) {
+        dependencies.decoder.register(component: DSCollection.self)
+        dependencies.decoder.register(component: MyComponent.self)
+        dependencies.decoder.register(action: CustomConsoleLogAction.self)
+        dependencies.decoder.register(component: DemoTextField.self, for: "SampleTextField")
     }
 }

--- a/iOS/Example/BeagleDemo/BeagleDemo/AppDelegate.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/AppDelegate.swift
@@ -63,6 +63,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         dependencies.decoder.register(component: DSCollection.self)
         dependencies.decoder.register(component: MyComponent.self)
         dependencies.decoder.register(action: CustomConsoleLogAction.self)
-        dependencies.decoder.register(component: DemoTextField.self, for: "SampleTextField")
+        dependencies.decoder.register(component: DemoTextField.self, named: "SampleTextField")
     }
 }

--- a/iOS/Schema/Sources/Decoding/ComponentDecoder.swift
+++ b/iOS/Schema/Sources/Decoding/ComponentDecoder.swift
@@ -19,8 +19,12 @@ import Foundation
 public protocol ComponentDecoding {
     typealias Error = ComponentDecodingError
     
-    func register<T: RawComponent>(_ type: T.Type, for typeName: String)
-    func register<A: RawAction>(_ type: A.Type, for typeName: String)
+    func register<T: RawComponent>(component type: T.Type)
+    func register<A: RawAction>(action type: A.Type)
+    
+    func register<T: RawComponent>(component type: T.Type, for typeName: String)
+    func register<A: RawAction>(action type: A.Type, for typeName: String)
+    
     func componentType(forType type: String) -> Decodable.Type?
     func actionType(forType type: String) -> Decodable.Type?
     func decodeComponent(from data: Data) throws -> RawComponent
@@ -51,11 +55,23 @@ final public class ComponentDecoder: ComponentDecoding {
         registerDefaultTypes()
     }
     
-    public func register<T: RawComponent>(_ type: T.Type, for typeName: String) {
+    // MARK: - ComponentDecoding
+    
+    public func register<T: RawComponent>(component type: T.Type) {
+        let componentTypeName = String(describing: T.self)
+        registerComponent(type, key: key(name: componentTypeName, namespace: .custom))
+    }
+    
+    public func register<A: RawAction>(action type: A.Type) {
+        let actionTypeName = String(describing: A.self)
+        registerAction(type, key: key(name: actionTypeName, namespace: .custom))
+    }
+    
+    public func register<T: RawComponent>(component type: T.Type, for typeName: String) {
         registerComponent(type, key: key(name: typeName, namespace: .custom))
     }
     
-    public func register<A: RawAction>(_ type: A.Type, for typeName: String) {
+    public func register<A: RawAction>(action type: A.Type, for typeName: String) {
         registerAction(type, key: key(name: typeName, namespace: .custom))
     }
     

--- a/iOS/Schema/Sources/Decoding/ComponentDecoder.swift
+++ b/iOS/Schema/Sources/Decoding/ComponentDecoder.swift
@@ -22,8 +22,8 @@ public protocol ComponentDecoding {
     func register<T: RawComponent>(component type: T.Type)
     func register<A: RawAction>(action type: A.Type)
     
-    func register<T: RawComponent>(component type: T.Type, for typeName: String)
-    func register<A: RawAction>(action type: A.Type, for typeName: String)
+    func register<T: RawComponent>(component type: T.Type, named: String)
+    func register<A: RawAction>(action type: A.Type, named: String)
     
     func componentType(forType type: String) -> Decodable.Type?
     func actionType(forType type: String) -> Decodable.Type?
@@ -67,12 +67,12 @@ final public class ComponentDecoder: ComponentDecoding {
         registerAction(type, key: key(name: actionTypeName, namespace: .custom))
     }
     
-    public func register<T: RawComponent>(component type: T.Type, for typeName: String) {
-        registerComponent(type, key: key(name: typeName, namespace: .custom))
+    public func register<T: RawComponent>(component type: T.Type, named: String) {
+        registerComponent(type, key: key(name: named, namespace: .custom))
     }
     
-    public func register<A: RawAction>(action type: A.Type, for typeName: String) {
-        registerAction(type, key: key(name: typeName, namespace: .custom))
+    public func register<A: RawAction>(action type: A.Type, named: String) {
+        registerAction(type, key: key(name: named, namespace: .custom))
     }
     
     public func componentType(forType type: String) -> Decodable.Type? {

--- a/iOS/Schema/Sources/Decoding/Tests/ComponentDecoderTests.swift
+++ b/iOS/Schema/Sources/Decoding/Tests/ComponentDecoderTests.swift
@@ -56,7 +56,7 @@ public final class ComponentDecoderTests: XCTestCase {
         let sut = ComponentDecoder()
 
         // When
-        sut.register(component: NewComponent.self, for: "NewCustomComponent")
+        sut.register(component: NewComponent.self, named: "NewCustomComponent")
         let componentDecoder = sut.componentDecoders["custom:newcustomcomponent"]
         
         // Then
@@ -69,7 +69,7 @@ public final class ComponentDecoderTests: XCTestCase {
         let sut = ComponentDecoder()
 
         // When
-        sut.register(action: TestAction.self, for: "NewCustomAction")
+        sut.register(action: TestAction.self, named: "NewCustomAction")
         let actionDecoder = sut.actionDecoders["custom:newcustomaction"]
         
         // Then

--- a/iOS/Schema/Sources/Decoding/Tests/ComponentDecoderTests.swift
+++ b/iOS/Schema/Sources/Decoding/Tests/ComponentDecoderTests.swift
@@ -33,7 +33,7 @@ public final class ComponentDecoderTests: XCTestCase {
         assertSnapshot(matching: sut.actionDecoders, as: .dump)
     }
     
-    func test_whenANewTypeIsRegistered_thenItShouldBeAbleToDecodeIt() throws {
+    func testRegisterAndDecodeCustomComponent() throws {
         // Given
         let expectedText = "something"
         let jsonData = """
@@ -44,11 +44,37 @@ public final class ComponentDecoderTests: XCTestCase {
         """.data(using: .utf8)!
 
         // When
-        sut.register(NewComponent.self, for: "NewComponent")
+        sut.register(component: NewComponent.self)
         let component = try sut.decodeComponent(from: jsonData) as? NewComponent
         
         // Then
         XCTAssertEqual(component?.text, expectedText)
+    }
+    
+    func testRegisterComponentWithCustomTypeName() throws {
+        // Given
+        let sut = ComponentDecoder()
+
+        // When
+        sut.register(component: NewComponent.self, for: "NewCustomComponent")
+        let componentDecoder = sut.componentDecoders["custom:newcustomcomponent"]
+        
+        // Then
+        XCTAssertNotNil(componentDecoder)
+        XCTAssert(componentDecoder is NewComponent.Type)
+    }
+    
+    func testRegisterActionWithCustomTypeName() throws {
+        // Given
+        let sut = ComponentDecoder()
+
+        // When
+        sut.register(action: TestAction.self, for: "NewCustomAction")
+        let actionDecoder = sut.actionDecoders["custom:newcustomaction"]
+        
+        // Then
+        XCTAssertNotNil(actionDecoder)
+        XCTAssert(actionDecoder is TestAction.Type)
     }
 
     func testDecodeDefaultType() throws {
@@ -72,7 +98,7 @@ public final class ComponentDecoderTests: XCTestCase {
         XCTAssertEqual(string, expectedText)
     }
 
-    func test_whenAnUnknownTypeIsDecoded_thenItShouldReturnNil() throws {
+    func testUnknownTypeIsDecodeShouldReturnNil() throws {
         // Given
         let jsonData = """
         {
@@ -85,7 +111,7 @@ public final class ComponentDecoderTests: XCTestCase {
         let unknown = try sut.decodeComponent(from: jsonData) as? UnknownComponent
 
         // Then
-        XCTAssert(unknown?.type == "beagle:unknown")
+        XCTAssertEqual(unknown?.type, "beagle:unknown")
     }
 
     func testDecodeAction() throws {
@@ -105,12 +131,12 @@ public final class ComponentDecoderTests: XCTestCase {
     func testRegisterAndDecodeCustomAction() throws {
         let data = """
         {
-            "_beagleAction_":"custom:testcustomaction",
+            "_beagleAction_":"custom:testaction",
             "value": 42
         }
         """.data(using: .utf8)!
 
-        sut.register(TestAction.self, for: "TestCustomAction")
+        sut.register(action: TestAction.self)
         let action = try sut.decodeAction(from: data)
         let testAction = action as? TestAction
 

--- a/iOS/Schema/Sources/ServerDrivenComponent/PageIndicator/Indicator/Tests/PageIndicatorTests.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/PageIndicator/Indicator/Tests/PageIndicatorTests.swift
@@ -31,7 +31,7 @@ class PageIndicatorTests: XCTestCase {
         super.setUp()
         dependencies.decoder.register(
             component: CustomPageIndicator.self,
-            for: PageIndicatorTests.typeName
+            named: PageIndicatorTests.typeName
         )
     }
     

--- a/iOS/Schema/Sources/ServerDrivenComponent/PageIndicator/Indicator/Tests/PageIndicatorTests.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/PageIndicator/Indicator/Tests/PageIndicatorTests.swift
@@ -30,7 +30,7 @@ class PageIndicatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         dependencies.decoder.register(
-            CustomPageIndicator.self,
+            component: CustomPageIndicator.self,
             for: PageIndicatorTests.typeName
         )
     }

--- a/iOS/Sources/Beagle/Sources/Components/Lazy+Renderable/Tests/LazyComponentTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Lazy+Renderable/Tests/LazyComponentTests.swift
@@ -132,26 +132,32 @@ class LazyRepositoryStub: Repository {
     
     private(set) var formData: Request.FormData?
 
-    func fetchComponent(url: String,
-                        additionalData: RemoteScreenAdditionalData?,
-                        useCache: Bool,
-                        completion: @escaping (Result<ServerDrivenComponent, Request.Error>) -> Void) -> RequestToken? {
+    func fetchComponent(
+        url: String,
+        additionalData: RemoteScreenAdditionalData?,
+        useCache: Bool,
+        completion: @escaping (Result<ServerDrivenComponent, Request.Error>) -> Void
+    ) -> RequestToken? {
         componentCompletion = completion
         return nil
     }
-
-    func submitForm(url: String,
-                    additionalData: RemoteScreenAdditionalData?,
-                    data: Request.FormData,
-                    completion: @escaping (Result<RawAction, Request.Error>) -> Void) -> RequestToken? {
+    
+    func submitForm(
+        url: String,
+        additionalData: RemoteScreenAdditionalData?,
+        data: Request.FormData,
+        completion: @escaping (Result<RawAction, Request.Error>) -> Void
+    ) -> RequestToken? {
         formData = data
         formCompletion = completion
         return nil
     }
-
-    func fetchImage(url: String,
-                    additionalData: RemoteScreenAdditionalData?,
-                    completion: @escaping (Result<Data, Request.Error>) -> Void) -> RequestToken? {
+    
+    func fetchImage(
+        url: String,
+        additionalData: RemoteScreenAdditionalData?,
+        completion: @escaping (Result<Data, Request.Error>) -> Void
+    ) -> RequestToken? {
         imageCompletion = completion
         return nil
     }

--- a/iOS/Sources/Beagle/Sources/Components/Page+Renderable/Tests/CustomPageIndicator/CustomPageIndicatorTest.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Page+Renderable/Tests/CustomPageIndicator/CustomPageIndicatorTest.swift
@@ -37,7 +37,7 @@ class CustomPageIndicatorTest: XCTestCase {
         super.setUp()
         Beagle.dependencies = BeagleDependencies()
         Beagle.dependencies.decoder.register(
-            CustomPageIndicator.self,
+            component: CustomPageIndicator.self,
             for: CustomPageIndicatorTest.typeName
         )
     }

--- a/iOS/Sources/Beagle/Sources/Components/Page+Renderable/Tests/CustomPageIndicator/CustomPageIndicatorTest.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Page+Renderable/Tests/CustomPageIndicator/CustomPageIndicatorTest.swift
@@ -38,7 +38,7 @@ class CustomPageIndicatorTest: XCTestCase {
         Beagle.dependencies = BeagleDependencies()
         Beagle.dependencies.decoder.register(
             component: CustomPageIndicator.self,
-            for: CustomPageIndicatorTest.typeName
+            named: CustomPageIndicatorTest.typeName
         )
     }
     

--- a/iOS/Sources/Beagle/Sources/Navigation/BeagleNavigator.swift
+++ b/iOS/Sources/Beagle/Sources/Navigation/BeagleNavigator.swift
@@ -66,12 +66,17 @@ class BeagleNavigator: BeagleNavigation {
     // MARK: - Navigate Handle
     
     private func navigate(route: Route, origin: BeagleController, animated: Bool, transition: @escaping Transition) {
-        viewController(route: route, origin: origin, retry: {
-            [weak origin] in guard let origin = origin else { return }
-            self.navigate(route: route, origin: origin, animated: animated, transition: transition)
-        }) {
-            transition(origin, $0, animated)
-        }
+        viewController(
+            route: route,
+            origin: origin,
+            retry: {
+                [weak origin] in guard let origin = origin else { return }
+                self.navigate(route: route, origin: origin, animated: animated, transition: transition)
+            },
+            success: {
+                transition(origin, $0, animated)
+            }
+        )
     }
     
     private func openExternalURL(path: String, controller: BeagleController) {

--- a/iOS/Sources/Beagle/Sources/Navigation/BeagleNavigator.swift
+++ b/iOS/Sources/Beagle/Sources/Navigation/BeagleNavigator.swift
@@ -69,8 +69,8 @@ class BeagleNavigator: BeagleNavigation {
         viewController(
             route: route,
             origin: origin,
-            retry: {
-                [weak origin] in guard let origin = origin else { return }
+            retry: { [weak origin] in
+                guard let origin = origin else { return }
                 self.navigate(route: route, origin: origin, animated: animated, transition: transition)
             },
             success: {

--- a/iOS/Sources/Beagle/Sources/Networking/Tests/RepositoryTests.swift
+++ b/iOS/Sources/Beagle/Sources/Networking/Tests/RepositoryTests.swift
@@ -156,8 +156,10 @@ final class RepositoryTests: XCTestCase {
 // MARK: - Testing Helpers
 
 final class ComponentDecodingStub: ComponentDecoding {
-    func register<T>(_ type: T.Type, for typeName: String) where T: BeagleSchema.RawComponent {}
-    func register<A>(_ type: A.Type, for typeName: String) where A: BeagleSchema.RawAction {}
+    func register<T>(component type: T.Type) where T: RawComponent {}
+    func register<A>(action type: A.Type) where A: RawAction {}
+    func register<T>(component type: T.Type, for typeName: String) where T: BeagleSchema.RawComponent {}
+    func register<A>(action type: A.Type, for typeName: String) where A: BeagleSchema.RawAction {}
     func componentType(forType type: String) -> Decodable.Type? { return nil }
     func actionType(forType type: String) -> Decodable.Type? { return nil }
     
@@ -207,21 +209,25 @@ final class RepositoryStub: Repository {
         self.imageResult = imageResult
     }
 
-    func fetchComponent(url: String,
-                        additionalData: RemoteScreenAdditionalData?,
-                        useCache: Bool,
-                        completion: @escaping (Result<ServerDrivenComponent, Request.Error>) -> Void) -> RequestToken? {
+    func fetchComponent(
+        url: String,
+        additionalData: RemoteScreenAdditionalData?,
+        useCache: Bool,
+        completion: @escaping (Result<ServerDrivenComponent, Request.Error>) -> Void
+    ) -> RequestToken? {
         didCallDispatch = true
         if let result = componentResult {
             completion(result)
         }
         return token
     }
-
-    func submitForm(url: String,
-                    additionalData: RemoteScreenAdditionalData?,
-                    data: Request.FormData,
-                    completion: @escaping (Result<RawAction, Request.Error>) -> Void) -> RequestToken? {
+    
+    func submitForm(
+        url: String,
+        additionalData: RemoteScreenAdditionalData?,
+        data: Request.FormData,
+        completion: @escaping (Result<RawAction, Request.Error>) -> Void
+    ) -> RequestToken? {
         didCallDispatch = true
         formData = data
         if let result = formResult {
@@ -229,10 +235,12 @@ final class RepositoryStub: Repository {
         }
         return token
     }
-
-    func fetchImage(url: String,
-                    additionalData: RemoteScreenAdditionalData?,
-                    completion: @escaping (Result<Data, Request.Error>) -> Void) -> RequestToken? {
+    
+    func fetchImage(
+        url: String,
+        additionalData: RemoteScreenAdditionalData?,
+        completion: @escaping (Result<Data, Request.Error>) -> Void
+    ) -> RequestToken? {
         didCallDispatch = true
         if let result = imageResult {
             completion(result)

--- a/iOS/Sources/Beagle/Sources/Networking/Tests/RepositoryTests.swift
+++ b/iOS/Sources/Beagle/Sources/Networking/Tests/RepositoryTests.swift
@@ -158,8 +158,8 @@ final class RepositoryTests: XCTestCase {
 final class ComponentDecodingStub: ComponentDecoding {
     func register<T>(component type: T.Type) where T: RawComponent {}
     func register<A>(action type: A.Type) where A: RawAction {}
-    func register<T>(component type: T.Type, for typeName: String) where T: BeagleSchema.RawComponent {}
-    func register<A>(action type: A.Type, for typeName: String) where A: BeagleSchema.RawAction {}
+    func register<T>(component type: T.Type, named typeName: String) where T: BeagleSchema.RawComponent {}
+    func register<A>(action type: A.Type, named typeName: String) where A: BeagleSchema.RawAction {}
     func componentType(forType type: String) -> Decodable.Type? { return nil }
     func actionType(forType type: String) -> Decodable.Type? { return nil }
     

--- a/iOS/Sources/Beagle/Sources/Setup/BeagleSetup.swift
+++ b/iOS/Sources/Beagle/Sources/Setup/BeagleSetup.swift
@@ -24,19 +24,21 @@ public var dependencies: BeagleDependenciesProtocol = BeagleDependencies() {
 // MARK: - Public Functions
 
 /// Register a custom component
+@available(*, deprecated, message: "use decoder.register in BeagleDependencies instead")
 public func registerCustomComponent<C: ServerDrivenComponent>(
     _ name: String,
     componentType: C.Type
 ) {
-    dependencies.decoder.register(componentType, for: name)
+    dependencies.decoder.register(component: componentType, for: name)
 }
 
 /// Register a custom action
+@available(*, deprecated, message: "use decoder.register in BeagleDependencies instead")
 public func registerCustomAction<A: Action>(
     _ name: String,
     actionType: A.Type
 ) {
-    dependencies.decoder.register(actionType, for: name)
+    dependencies.decoder.register(action: actionType, for: name)
 }
 
 public func screen(_ type: ScreenType) -> BeagleScreenViewController {

--- a/iOS/Sources/Beagle/Sources/Setup/BeagleSetup.swift
+++ b/iOS/Sources/Beagle/Sources/Setup/BeagleSetup.swift
@@ -29,7 +29,7 @@ public func registerCustomComponent<C: ServerDrivenComponent>(
     _ name: String,
     componentType: C.Type
 ) {
-    dependencies.decoder.register(component: componentType, for: name)
+    dependencies.decoder.register(component: componentType, named: name)
 }
 
 /// Register a custom action
@@ -38,7 +38,7 @@ public func registerCustomAction<A: Action>(
     _ name: String,
     actionType: A.Type
 ) {
-    dependencies.decoder.register(action: actionType, for: name)
+    dependencies.decoder.register(action: actionType, named: name)
 }
 
 public func screen(_ type: ScreenType) -> BeagleScreenViewController {

--- a/iOS/Sources/Beagle/Sources/Setup/Tests/BeagleSetupTests.swift
+++ b/iOS/Sources/Beagle/Sources/Setup/Tests/BeagleSetupTests.swift
@@ -102,8 +102,10 @@ final class FormDataStoreHandlerDummy: FormDataStoreHandling {
 }
 
 final class ComponentDecodingDummy: ComponentDecoding {
-    func register<T>(_ type: T.Type, for typeName: String) where T: BeagleSchema.RawComponent {}
-    func register<A>(_ type: A.Type, for typeName: String) where A: BeagleSchema.RawAction {}
+    func register<T>(component type: T.Type) where T: RawComponent {}
+    func register<A>(action type: A.Type) where A: RawAction {}
+    func register<T>(component type: T.Type, for typeName: String) where T: BeagleSchema.RawComponent {}
+    func register<A>(action type: A.Type, for typeName: String) where A: BeagleSchema.RawAction {}
     func componentType(forType type: String) -> Decodable.Type? { return nil }
     func actionType(forType type: String) -> Decodable.Type? { return nil }
     func decodeComponent(from data: Data) throws -> BeagleSchema.RawComponent { return ComponentDummy() }

--- a/iOS/Sources/Beagle/Sources/Setup/Tests/BeagleSetupTests.swift
+++ b/iOS/Sources/Beagle/Sources/Setup/Tests/BeagleSetupTests.swift
@@ -104,8 +104,8 @@ final class FormDataStoreHandlerDummy: FormDataStoreHandling {
 final class ComponentDecodingDummy: ComponentDecoding {
     func register<T>(component type: T.Type) where T: RawComponent {}
     func register<A>(action type: A.Type) where A: RawAction {}
-    func register<T>(component type: T.Type, for typeName: String) where T: BeagleSchema.RawComponent {}
-    func register<A>(action type: A.Type, for typeName: String) where A: BeagleSchema.RawAction {}
+    func register<T>(component type: T.Type, named typeName: String) where T: BeagleSchema.RawComponent {}
+    func register<A>(action type: A.Type, named typeName: String) where A: BeagleSchema.RawAction {}
     func componentType(forType type: String) -> Decodable.Type? { return nil }
     func actionType(forType type: String) -> Decodable.Type? { return nil }
     func decodeComponent(from data: Data) throws -> BeagleSchema.RawComponent { return ComponentDummy() }


### PR DESCRIPTION
## Description

*Components and actions registering does not work when we register before setting the dependencies.*

## Solution
*I deprecated old registration methods located at BeagleSetup Archive, and now to register components and actions we need to use decoder instance of BeagleDependencies calling:*

```
///Uses struct name automatically as component type name
func register<T: RawComponent>(component type: T.Type)
func register<A: RawAction>(action type: A.Type)

///Uses custom type name 
func register<T: RawComponent>(component type: T.Type, for typeName: String)
func register<A: RawAction>(action type: A.Type, for typeName: String)
```
## Related Issues

#656 

## Tests

I updated the following tests:

```
ComponentDecoderTests
PageIndicatorTests
LazyComponentTests (SwiftLint warnings)
CustomPageIndicatorTests
RepositoryTests
BeagleSetupTests
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/