### PR TITLE
fix: skip publishing shared modules when releasing backend

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,6 +50,14 @@ allprojects {
         config = files("$rootDir/../config/detekt-default-config.yml")
     }
 
+    tasks.withType(PublishToMavenRepository) {
+        onlyIf {
+            Arrays.asList("backend", "framework", "starter").any {
+                publication.artifactId.contains(it)
+            }
+        }
+    }
+
     compileKotlin {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8

--- a/backend/widgets-dsl/gradle.properties
+++ b/backend/widgets-dsl/gradle.properties
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
-ARTIFACT_NAME=backend-widgets-dsl
+POM_ARTIFACT_ID=backend-widgets-dsl
+POM_NAME=backend-widgets-dsl

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,6 +19,7 @@ platform :android do
 
   desc "Deploy current code to production"
   lane :deploy_to_production do
+    sh "bash ./release/maven_signing.sh"
     deploy_to_stage
     gradle(project_dir: "android", task: "closeAndReleaseRepository")
   end
@@ -65,8 +66,6 @@ desc "Publish new release based on last two tags"
 lane :deploy do
   git_pull
   ENV["VERSION_DEPLOY"] = last_git_tag
-
-  sh "bash ./release/maven_signing.sh"
 
   sh "fastlane android deploy_to_production"
   sh "fastlane backend deploy_to_production"
@@ -135,6 +134,7 @@ platform :backend do
 
   desc "Deploy current code to production"
   lane :deploy_to_production do
+    sh "bash ./release/maven_signing.sh"
     deploy_to_stage
     gradle(project_dir: "backend", task: "closeAndReleaseRepository")
   end

--- a/maven-publish.gradle
+++ b/maven-publish.gradle
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
- apply plugin: "com.vanniktech.maven.publish"
+apply plugin: "com.vanniktech.maven.publish"
 
- def versionName = System.env.VERSION_DEPLOY != null ? System.env.VERSION_DEPLOY : VERSION_NAME ?: ""
+def versionName = System.env.VERSION_DEPLOY != null ? System.env.VERSION_DEPLOY : VERSION_NAME ?: ""
 
 version = versionName
 
- mavenPublish {
-
-     nexus {
+mavenPublish {
+    nexus {
         stagingProfile = "br.com.zup"
-     }
+    }
 }


### PR DESCRIPTION
## Description
Updated backend build scripts to only publish its exclusive modules, skipping shared ones. This is done by checking the id of the artifact to be published.

## Related Issues
Fixes #686.

## Tests
Ran local publish.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/