### PR TITLE
refactor: WebView component does not render error screen when it fails

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/WebView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/WebView.kt
@@ -48,7 +48,7 @@ data class WebView(
     @SuppressLint("SetJavaScriptEnabled")
     override fun buildView(rootView: RootView): View {
         val webView = viewFactory.makeWebView(rootView.getContext())
-        webView.webViewClient = BeagleWebViewClient(webView.context)
+        webView.webViewClient = BeagleWebViewClient(rootView.getContext())
         webView.settings.javaScriptEnabled = true
         observeBindChanges(rootView, webView, url) {
             it?.let { webView.loadUrl(it) }


### PR DESCRIPTION
…t class

## Description
The WebView component does not process the error screen when it fails, because in the BeagleWebViewClient class it passes the value of the webView context. The solution is to pass the rootView context to the BeagleWebViewClient class.

## Related Issues
closes #695 

## Tests

I added the following tests:
Tests not changed

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/