### PR TITLE
fix: wrong path in dangerfile for iOS swiftlint

### DIFF
--- a/danger/ios/Dangerfile
+++ b/danger/ios/Dangerfile
@@ -1,5 +1,5 @@
 # Swift config
 
-swiftlint.config_file = 'iOS/Sources/BeagleUI/.swiftlint.yml'
+swiftlint.config_file = 'iOS/Sources/Beagle/.swiftlint.yml'
 swiftlint.verbose = true
 swiftlint.lint_files inline_mode: true


### PR DESCRIPTION
## Description
Dangerfile for iOS had a wrong path referencing to the older BeagleUI folder.

## Related Issues
No issues were created.

## Tests
No tests were added or changed for this pull request.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.