### PR TITLE
fix: context escape ignore double quote

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataEvaluation.kt
@@ -26,7 +26,7 @@ import com.squareup.moshi.Moshi
 import org.json.JSONArray
 import org.json.JSONObject
 import java.lang.reflect.Type
-import java.util.LinkedList
+import kotlin.text.Regex.Companion.escapeReplacement
 
 internal class ContextDataEvaluation(
     private val contextDataManipulator: ContextDataManipulator = ContextDataManipulator(),
@@ -96,7 +96,7 @@ internal class ContextDataEvaluation(
                 val key = "\\{([^\\{]*)\\}".toRegex().find(it)?.groups?.get(1)?.value
                 it.replace(
                     "\\@\\{\\w.+(\\.|\\w+)\\}".toRegex(),
-                    evaluatedExpressions[key].toString()
+                    escapeReplacement(evaluatedExpressions[key].toString())
                 )
             } else {
                 it

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
@@ -18,7 +18,6 @@ package br.com.zup.beagle.android.context
 
 import androidx.collection.LruCache
 import br.com.zup.beagle.android.extensions.once
-import br.com.zup.beagle.android.jsonpath.JsonPathFinder
 import br.com.zup.beagle.android.logger.BeagleMessageLogs
 import br.com.zup.beagle.android.mockdata.ComponentModel
 import br.com.zup.beagle.android.testutil.RandomData
@@ -30,7 +29,6 @@ import org.json.JSONObject
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -332,6 +330,11 @@ internal class ContextDataEvaluationTest {
         EscapingTestCases(
             "This is a @{context} of \\ expression \\@{context}",
             "This is a value of \\ expression @{context}"
+        ),
+        EscapingTestCases(
+            "@{context}",
+            "\\\"value\\\"",
+            ContextData("context", "\\\"value\\\"")
         )
     )
 


### PR DESCRIPTION
## Description

We identified one case on expression escaping logic that if we send a string that has double quote and a escape character for this string, when the escaping algorithm run, it removes the escape character.

Example:
`"\"test\"` would be evaluated to `"test"`, removing the escape characters.

## Related Issues

Fixes: #694

## Tests

Created another test case for this problem.