### PR TITLE
fix: Refactor PathType to ImagePath

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/builder/layout/ScreenComponentBuilder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/builder/layout/ScreenComponentBuilder.kt
@@ -19,7 +19,7 @@ package br.com.zup.beagle.android.builder.layout
 import br.com.zup.beagle.analytics.ScreenEvent
 import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.builder.context.ContextDataBuilder
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.layout.NavigationBar
 import br.com.zup.beagle.android.components.layout.NavigationBarItem
 import br.com.zup.beagle.android.components.layout.SafeArea
@@ -77,12 +77,12 @@ fun navigationBarItem(block: NavigationBarItemBuilder.() -> Unit)
 
 class NavigationBarItemBuilder : BeagleBuilder<NavigationBarItem> {
     var text: String by Delegates.notNull()
-    var image: PathType.Local? = null
+    var image: ImagePath.Local? = null
     var action: Action by Delegates.notNull()
     var accessibility: Accessibility? = null
 
     fun text(text: String) = this.apply { this.text = text }
-    fun image(image: PathType.Local?) = this.apply { this.image = image }
+    fun image(image: ImagePath.Local?) = this.apply { this.image = image }
     fun action(action: Action) = this.apply { this.action = action }
     fun accessibility(accessibility: Accessibility?) = this.apply { this.accessibility = accessibility }
 
@@ -91,7 +91,7 @@ class NavigationBarItemBuilder : BeagleBuilder<NavigationBarItem> {
     }
 
     fun image(block: () -> String) {
-        image(PathType.Local(block.invoke()))
+        image(ImagePath.Local(block.invoke()))
     }
 
     fun action(block: () -> Action) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/builder/ui/ImageBuilder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/builder/ui/ImageBuilder.kt
@@ -17,7 +17,7 @@
 package br.com.zup.beagle.android.builder.ui
 
 import br.com.zup.beagle.android.components.Image
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.builder.BeagleBuilder
 import br.com.zup.beagle.widget.core.ImageContentMode
@@ -26,13 +26,13 @@ import kotlin.properties.Delegates
 fun image(block: ImageBuilder.() -> Unit) = ImageBuilder().apply(block).build()
 
 class ImageBuilder : BeagleBuilder<Image> {
-    var path: Bind<PathType> by Delegates.notNull()
+    var path: Bind<ImagePath> by Delegates.notNull()
     var mode: ImageContentMode? = null
 
-    fun path(path: Bind<PathType>) = this.apply { this.path = path }
+    fun path(path: Bind<ImagePath>) = this.apply { this.path = path }
     fun mode(mode: ImageContentMode?) = this.apply { this.mode = mode }
 
-    fun path(block: () -> Bind<PathType>) {
+    fun path(block: () -> Bind<ImagePath>) {
         path(block.invoke())
     }
 
@@ -47,11 +47,11 @@ fun pathTypeLocal(block: PathTypeLocalBuilder.() -> Unit) = PathTypeLocalBuilder
 fun pathTypeRemote(block: PathTypeRemoteBuilder.() -> Unit) = PathTypeRemoteBuilder().apply(block).build()
 
 interface ImagePathBuilderHelper {
-    var imagePath: PathType
+    var imagePath: ImagePath
 
-    fun imagePath(imagePath: PathType) = this.apply { this.imagePath = imagePath }
+    fun imagePath(imagePath: ImagePath) = this.apply { this.imagePath = imagePath }
 
-    fun imagePath(block: () -> PathType){
+    fun imagePath(block: () -> ImagePath){
         imagePath(block.invoke())
     }
 
@@ -65,26 +65,26 @@ interface ImagePathBuilderHelper {
 
 }
 
-class PathTypeRemoteBuilder: BeagleBuilder<PathType.Remote> {
+class PathTypeRemoteBuilder: BeagleBuilder<ImagePath.Remote> {
     var url: String by Delegates.notNull()
-    var placeholder: PathType.Local? = null
+    var placeholder: ImagePath.Local? = null
 
     fun url(url: String) = this.apply { this.url = url }
-    fun placeholder(placeholder: PathType.Local?) = this.apply { this.placeholder = placeholder }
+    fun placeholder(placeholder: ImagePath.Local?) = this.apply { this.placeholder = placeholder }
 
     fun url(block: () -> String){
         url(block.invoke())
     }
 
     fun placeholder(block: () -> String){
-        placeholder(PathType.Local(block.invoke()))
+        placeholder(ImagePath.Local(block.invoke()))
     }
 
-    override fun build() = PathType.Remote(url, placeholder)
+    override fun build() = ImagePath.Remote(url, placeholder)
 
 }
 
-class PathTypeLocalBuilder : BeagleBuilder<PathType.Local> {
+class PathTypeLocalBuilder : BeagleBuilder<ImagePath.Local> {
     var mobileId: String by Delegates.notNull()
 
     fun mobileId(mobileId: String) = this.apply { this.mobileId = mobileId }
@@ -93,5 +93,5 @@ class PathTypeLocalBuilder : BeagleBuilder<PathType.Local> {
         mobileId(block.invoke())
     }
 
-    override fun build() = PathType.Local(mobileId)
+    override fun build() = ImagePath.Local(mobileId)
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/builder/ui/TabBarBuilder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/builder/ui/TabBarBuilder.kt
@@ -17,7 +17,7 @@
 package br.com.zup.beagle.android.builder.ui
 
 import br.com.zup.beagle.android.action.Action
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.TabBar
 import br.com.zup.beagle.android.components.TabBarItem
 import br.com.zup.beagle.android.context.Bind
@@ -67,17 +67,17 @@ fun tabBarItem(block: TabBarItemBuilder.() -> Unit) = TabBarItemBuilder().apply(
 
 class TabBarItemBuilder: BeagleBuilder<TabBarItem>{
     var title: String? = null
-    var icon: PathType.Local? = null
+    var icon: ImagePath.Local? = null
 
     fun title(title: String?) = this.apply { this.title = title }
-    fun icon(icon: PathType.Local?) = this.apply { this.icon = icon }
+    fun icon(icon: ImagePath.Local?) = this.apply { this.icon = icon }
 
     fun title(block: () -> String?){
         title(block.invoke())
     }
 
     fun icon(block: () -> String){
-        icon(PathType.Local(block.invoke()))
+        icon(ImagePath.Local(block.invoke()))
     }
 
     override fun build() = TabBarItem(title, icon)

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/builder/ui/TabViewBuilder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/builder/ui/TabViewBuilder.kt
@@ -17,7 +17,7 @@
 package br.com.zup.beagle.android.builder.ui
 
 import br.com.zup.beagle.android.builder.context.ContextDataBuilder
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.TabItem
 import br.com.zup.beagle.android.components.TabView
 import br.com.zup.beagle.android.context.ContextData
@@ -61,11 +61,11 @@ fun tabItem(block: TabItemBuilder.() -> Unit) = TabItemBuilder().apply(block).bu
 class TabItemBuilder : BeagleBuilder<TabItem> {
     var title: String? = null
     var child: ServerDrivenComponent by Delegates.notNull()
-    var icon: PathType.Local? = null
+    var icon: ImagePath.Local? = null
 
     fun title(title: String?) = this.apply { this.title = title }
     fun child(child: ServerDrivenComponent) = this.apply { this.child = child }
-    fun icon(icon: PathType.Local?) = this.apply { this.icon = icon }
+    fun icon(icon: ImagePath.Local?) = this.apply { this.icon = icon }
 
     fun title(block: () -> String?) {
         title(block.invoke())
@@ -76,7 +76,7 @@ class TabItemBuilder : BeagleBuilder<TabItem> {
     }
 
     fun icon(block: () -> String) {
-        icon(PathType.Local(block.invoke()))
+        icon(ImagePath.Local(block.invoke()))
     }
 
     override fun build() = TabItem(

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -41,11 +41,11 @@ import com.bumptech.glide.request.transition.Transition
 
 @RegisterWidget
 data class Image(
-    val path: Bind<PathType>,
+    val path: Bind<ImagePath>,
     val mode: ImageContentMode? = null
 ) : WidgetView() {
     constructor(
-        path: PathType,
+        path: ImagePath,
         mode: ImageContentMode? = null
     ) : this(
         valueOf(path),
@@ -62,7 +62,7 @@ data class Image(
         val imageView: RoundedImageView = getImageView(rootView)
         observeBindChanges(rootView, imageView, path) { pathType ->
             when (pathType) {
-                is PathType.Local -> {
+                is ImagePath.Local -> {
                     imageView.apply {
                         BeagleEnvironment.beagleSdk.designSystem?.image(pathType.mobileId)?.let {
                             try {
@@ -73,7 +73,7 @@ data class Image(
                         }
                     }
                 }
-                is PathType.Remote -> {
+                is ImagePath.Remote -> {
                     val placeholder = pathType.placeholder?.mobileId
                     val requestOptions = getGlideRequestOptions(placeholder)
                     imageView.loadImage(pathType, requestOptions)
@@ -89,7 +89,7 @@ data class Image(
     }
 
     private fun ImageView.loadImage(
-        path: PathType.Remote,
+        path: ImagePath.Remote,
         requestOptions: RequestOptions) {
         Glide.with(this)
             .setDefaultRequestOptions(requestOptions)
@@ -120,7 +120,7 @@ data class Image(
 
 }
 
-sealed class PathType {
-    data class Local(val mobileId: String) : PathType()
-    data class Remote(val url: String, val placeholder: Local? = null) : PathType()
+sealed class ImagePath {
+    data class Local(val mobileId: String) : ImagePath()
+    data class Remote(val url: String, val placeholder: Local? = null) : ImagePath()
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabBar.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabBar.kt
@@ -18,7 +18,6 @@ package br.com.zup.beagle.android.components
 
 import android.content.Context
 import android.graphics.drawable.Drawable
-import android.icu.text.CaseMap
 import android.view.View
 import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
@@ -26,7 +25,6 @@ import br.com.zup.beagle.R
 import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.components.utils.styleManagerFactory
 import br.com.zup.beagle.android.context.Bind
-import br.com.zup.beagle.android.context.ContextComponent
 import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.utils.dp
@@ -140,5 +138,5 @@ data class TabBar(
 
 data class TabBarItem(
     val title: String? = null,
-    val icon: PathType.Local? = null
+    val icon: ImagePath.Local? = null
 )

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabItem.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabItem.kt
@@ -28,7 +28,7 @@ import br.com.zup.beagle.core.ServerDrivenComponent
 data class TabItem(
     val title: String? = null,
     val child: ServerDrivenComponent,
-    val icon: PathType.Local? = null
+    val icon: ImagePath.Local? = null
 ) : WidgetView() {
 
     @Transient

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/Screen.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/Screen.kt
@@ -5,7 +5,7 @@ import br.com.zup.beagle.analytics.ScreenEvent
 import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.context.ContextComponent
 import br.com.zup.beagle.android.context.ContextData
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.core.Accessibility
 import br.com.zup.beagle.core.IdentifierComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
@@ -20,7 +20,7 @@ data class SafeArea(
 
 data class NavigationBarItem(
     val text: String,
-    val image: PathType.Local? = null,
+    val image: ImagePath.Local? = null,
     val action: Action,
     val accessibility: Accessibility? = null
 ) : IdentifierComponent {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/ImagePathTypeJsonAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/ImagePathTypeJsonAdapterFactory.kt
@@ -16,15 +16,15 @@
 
 package br.com.zup.beagle.android.data.serializer.adapter
 
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.data.serializer.PolymorphicJsonAdapterFactory
 
 private const val BEAGLE_IMAGE_TYPE = "_beagleImagePath_"
 
 internal object ImagePathTypeJsonAdapterFactory {
-    fun make(): PolymorphicJsonAdapterFactory<PathType> =
-        PolymorphicJsonAdapterFactory.of(PathType::class.java, BEAGLE_IMAGE_TYPE)
-            .withSubtype(PathType.Local::class.java, "local")
-            .withSubtype(PathType.Remote::class.java, "remote")
+    fun make(): PolymorphicJsonAdapterFactory<ImagePath> =
+        PolymorphicJsonAdapterFactory.of(ImagePath::class.java, BEAGLE_IMAGE_TYPE)
+            .withSubtype(ImagePath.Local::class.java, "local")
+            .withSubtype(ImagePath.Remote::class.java, "remote")
 
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/ImageTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/ImageTest.kt
@@ -17,17 +17,13 @@
 package br.com.zup.beagle.android.components
 
 import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
-import android.view.View
 import android.widget.ImageView
-import br.com.zup.beagle.android.components.utils.ComponentStylization
 import br.com.zup.beagle.android.components.utils.RoundedImageView
 import br.com.zup.beagle.android.data.formatUrl
 import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.testutil.RandomData
 import br.com.zup.beagle.android.view.ViewFactory
-import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.ext.applyStyle
 import br.com.zup.beagle.ext.unitReal
@@ -41,10 +37,8 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.slot
-import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.Assert
 import org.junit.Test
@@ -81,8 +75,8 @@ class ImageViewRendererTest : BaseComponentTest() {
         every { beagleSdk.designSystem } returns mockk()
         every { beagleSdk.designSystem!!.image(any()) } returns IMAGE_RES
 
-        imageLocal = Image(PathType.Local("imageName"))
-        imageRemote = Image(PathType.Remote(DEFAULT_URL)).applyStyle(style)
+        imageLocal = Image(ImagePath.Local("imageName"))
+        imageRemote = Image(ImagePath.Remote(DEFAULT_URL)).applyStyle(style)
     }
 
     @Test
@@ -97,7 +91,7 @@ class ImageViewRendererTest : BaseComponentTest() {
     @Test
     fun build_should_return_a_beagle_image_view_instance_and_set_data_when_path_is_remote() {
         //Given
-        imageRemote = Image(PathType.Remote(""))
+        imageRemote = Image(ImagePath.Remote(""))
 
         // When
         val view = imageRemote.buildView(rootView)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/TabBarTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/TabBarTest.kt
@@ -17,19 +17,15 @@
 package br.com.zup.beagle.android.components
 
 import android.widget.FrameLayout
-import androidx.core.view.children
 import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.components.utils.styleManagerFactory
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextData
-import br.com.zup.beagle.android.engine.renderer.FragmentRootView
 import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.setup.BeagleEnvironment
-import br.com.zup.beagle.android.testutil.RandomData
 import br.com.zup.beagle.android.utils.*
 import br.com.zup.beagle.android.view.ViewFactory
 import br.com.zup.beagle.android.view.custom.BeagleTabLayout
-import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import br.com.zup.beagle.core.Style
 import com.google.android.material.tabs.TabLayout
 import io.mockk.*
@@ -49,7 +45,7 @@ class TabBarTest : BaseComponentTest() {
     private val styleManager: StyleManager = mockk(relaxed = true)
     private val currentTab: Bind<Int> = mockk(relaxed = true)
     private val onTabSelection: List<Action> = mockk(relaxed = true)
-    private val icon: PathType.Local = mockk(relaxed = true)
+    private val icon: ImagePath.Local = mockk(relaxed = true)
     private val styleSlot = mutableListOf<Style>()
     private val onTabSelectedSlot = slot<TabLayout.OnTabSelectedListener>()
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
@@ -28,10 +28,9 @@ import br.com.zup.beagle.android.action.Navigate
 import br.com.zup.beagle.android.action.UndefinedAction
 import br.com.zup.beagle.android.components.Button
 import br.com.zup.beagle.android.components.Image
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.LazyComponent
 import br.com.zup.beagle.android.components.ListView
-import br.com.zup.beagle.android.components.TabItem
 import br.com.zup.beagle.android.components.TabView
 import br.com.zup.beagle.android.components.Text
 import br.com.zup.beagle.android.components.form.Form
@@ -54,7 +53,6 @@ import br.com.zup.beagle.android.widget.UndefinedWidget
 import br.com.zup.beagle.android.widget.WidgetView
 import br.com.zup.beagle.core.ServerDrivenComponent
 import com.squareup.moshi.Moshi
-import io.mockk.clearStaticMockk
 import io.mockk.every
 import io.mockk.mockk
 import org.json.JSONArray
@@ -182,7 +180,7 @@ class BeagleMoshiTest : BaseTest() {
     @Test
     fun make_should_return_moshi_to_serialize_a_Image_Local() {
         // Given
-        val component = Image(PathType.Local(RandomData.string()))
+        val component = Image(ImagePath.Local(RandomData.string()))
 
         // When
         val actual = moshi.adapter(ServerDrivenComponent::class.java).toJson(component)
@@ -207,7 +205,7 @@ class BeagleMoshiTest : BaseTest() {
     @Test
     fun make_should_return_moshi_to_serialize_a_NetworkImage() {
         // Given
-        val component = Image(PathType.Remote(RandomData.string()))
+        val component = Image(ImagePath.Remote(RandomData.string()))
 
         // When
         val actual = moshi.adapter(ServerDrivenComponent::class.java).toJson(component)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ToolbarManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ToolbarManagerTest.kt
@@ -28,7 +28,7 @@ import androidx.core.content.res.ResourcesCompat
 import br.com.zup.beagle.R
 import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.action.Action
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.layout.NavigationBar
 import br.com.zup.beagle.android.components.layout.NavigationBarItem
 import br.com.zup.beagle.android.components.layout.ScreenComponent
@@ -236,7 +236,7 @@ class ToolbarManagerTest : BaseTest() {
         every { context.getToolbar() } returns toolbar
         every { toolbar.menu } returns menu
         val navigationBarItems = listOf(
-            NavigationBarItem(text = "Stub", image = PathType.Local("image"), action = action)
+            NavigationBarItem(text = "Stub", image = ImagePath.Local("image"), action = action)
         )
         every { navigationBar.navigationBarItems } returns navigationBarItems
         val menuItem = spyk<MenuItem>()

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
@@ -23,7 +23,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import br.com.zup.beagle.android.components.Image
 import br.com.zup.beagle.android.components.Text
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.utils.toView
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.components.layout.Screen
@@ -37,7 +37,7 @@ class ImageViewFragment : Fragment() {
             child = Container(
                 children = listOf(
                     Image(
-                        path = PathType.Remote("https://cdn-images-1.medium.com/max/1200/1*kjiNJPB3Y-ZVmjxco_bORA.png")
+                        path = ImagePath.Remote("https://cdn-images-1.medium.com/max/1200/1*kjiNJPB3Y-ZVmjxco_bORA.png")
                     ),
                     Text(text = "Opa!!!")
                 )

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/LazyComponentFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/LazyComponentFragment.kt
@@ -22,7 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import br.com.zup.beagle.android.components.Image
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.LazyComponent
 import br.com.zup.beagle.android.components.Text
 import br.com.zup.beagle.core.Style
@@ -52,7 +52,7 @@ class LazyComponentFragment : Fragment() {
     private fun buildScrollView() = ScrollView(
         children = listOf(
             Image(
-                PathType.Remote(
+                ImagePath.Remote(
                     "https://www.petlove.com.br/images/breeds/193436/profile/original/beagle-p.jpg?1532538271"
                 )
             ).applyStyle(Style(cornerRadius = CornerRadius(30.0))),

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ListViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ListViewFragment.kt
@@ -22,16 +22,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import br.com.zup.beagle.android.components.Image
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.LazyComponent
 import br.com.zup.beagle.android.components.ListView
 import br.com.zup.beagle.android.components.Text
-import br.com.zup.beagle.ext.applyFlex
 import br.com.zup.beagle.ext.unitReal
 import br.com.zup.beagle.android.utils.toView
 import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.ext.applyStyle
-import br.com.zup.beagle.widget.core.Flex
 import br.com.zup.beagle.widget.core.Size
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.components.layout.NavigationBar
@@ -74,12 +72,12 @@ class ListViewFragment : Fragment() {
             Text("0011"),
             Text("0012"),
             Text("0013"),
-            Image(PathType.Local("beagle")),
+            Image(ImagePath.Local("beagle")),
             Text("0014"),
             Text("0015"),
             Text("0016"),
             Image(
-                PathType.Remote(
+                ImagePath.Remote(
                     "https://www.petlove.com.br/images/breeds/193436/profile/original/beagle-p.jpg?1532538271"
                 )
             ),

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ScrollViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ScrollViewFragment.kt
@@ -23,7 +23,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import br.com.zup.beagle.android.components.Button
 import br.com.zup.beagle.android.components.Image
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.core.CornerRadius
 import br.com.zup.beagle.ext.applyFlex
@@ -71,7 +71,7 @@ class ScrollViewFragment : Fragment() {
                 )
             ).applyStyle(Style(size = Size(height = UnitValue(100.0, UnitType.REAL)))),
             Image(
-                PathType.Remote(
+                ImagePath.Remote(
                     "https://www.petlove.com.br/images/breeds/193436/profile/original/beagle-p.jpg?1532538271"
                 )
             ).applyStyle(Style(

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/TabViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/TabViewFragment.kt
@@ -34,12 +34,11 @@ import br.com.zup.beagle.widget.core.UnitValue
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.components.Button
 import br.com.zup.beagle.android.components.Image
-import br.com.zup.beagle.android.components.PathType
+import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.TabItem
 import br.com.zup.beagle.android.components.TabView
 import br.com.zup.beagle.android.components.Text
 import br.com.zup.beagle.android.utils.toView
-import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.widget.core.TextAlignment
 
 class TabViewFragment : Fragment() {
@@ -64,7 +63,7 @@ class TabViewFragment : Fragment() {
                                 )
                             )
                         ),
-                        Image(PathType.Local("imageBeagle"))
+                        Image(ImagePath.Local("imageBeagle"))
                     ))),
                 buildTabView(title = "Title 2", child = Button("button")),
                 buildTabView(
@@ -105,7 +104,7 @@ class TabViewFragment : Fragment() {
         return TabItem(
             title = title,
             child = child,
-            icon = PathType.Local("ic_launcher_foreground")
+            icon = ImagePath.Local("ic_launcher_foreground")
         )
     }
 


### PR DESCRIPTION
## Description
Renamed PathType to ImagePath, because are inconsistencies between the Android and Backend implementations.

## Related Issues
#669

## Tests
no new tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

BREAKING CHANGE: In Android declarative the pathType now is imagePath

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [X] Yes, this is a breaking change. *If not, delete the remainder of this section.*


