### PR TITLE
fix: Adds method to configure SoLoader in test mode, this is needed to use beagle with robolectric

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
@@ -47,9 +47,6 @@ interface BeagleSdk {
     fun registeredActions(): List<Class<Action>>
 
     fun init(application: Application) {
-        if (config.environment == Environment.DEBUG)
-            setInTestMode()
-
         BeagleEnvironment.beagleSdk = this
         BeagleEnvironment.application = application
         SoLoader.init(application, false)

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
@@ -53,8 +53,10 @@ interface BeagleSdk {
         SoLoader.init(application, false)
     }
 
-    @VisibleForTesting
-    fun setInTestMode() {
-        SoLoader.setInTestMode()
+    companion object {
+        @VisibleForTesting
+        fun setInTestMode() {
+            SoLoader.setInTestMode()
+        }
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
@@ -17,9 +17,9 @@
 package br.com.zup.beagle.android.setup
 
 import android.app.Application
-import br.com.zup.beagle.android.action.FormLocalActionHandler
 import br.com.zup.beagle.analytics.Analytics
 import br.com.zup.beagle.android.action.Action
+import br.com.zup.beagle.android.action.FormLocalActionHandler
 import br.com.zup.beagle.android.components.form.core.ValidatorHandler
 import br.com.zup.beagle.android.logger.BeagleLogger
 import br.com.zup.beagle.android.navigation.DeepLinkHandler
@@ -50,5 +50,9 @@ interface BeagleSdk {
         BeagleEnvironment.beagleSdk = this
         BeagleEnvironment.application = application
         SoLoader.init(application, false)
+    }
+
+    fun setInTestMode() {
+        SoLoader.setInTestMode()
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
@@ -47,6 +47,9 @@ interface BeagleSdk {
     fun registeredActions(): List<Class<Action>>
 
     fun init(application: Application) {
+        if (config.environment == Environment.DEBUG)
+            setInTestMode()
+
         BeagleEnvironment.beagleSdk = this
         BeagleEnvironment.application = application
         SoLoader.init(application, false)

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.android.setup
 
 import android.app.Application
+import androidx.annotation.VisibleForTesting
 import br.com.zup.beagle.analytics.Analytics
 import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.action.FormLocalActionHandler
@@ -52,6 +53,7 @@ interface BeagleSdk {
         SoLoader.init(application, false)
     }
 
+    @VisibleForTesting
     fun setInTestMode() {
         SoLoader.setInTestMode()
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
@@ -58,5 +58,10 @@ interface BeagleSdk {
         fun setInTestMode() {
             SoLoader.setInTestMode()
         }
+
+        @VisibleForTesting
+        fun deinitForTest() {
+            SoLoader.deinitForTest()
+        }
     }
 }


### PR DESCRIPTION
We need a way for the user to configure SoLoader in test mode if its using robolectric to avoid the NullPointerException
