### PR TITLE
ci: iOS when releasing Pods, tries to avoid eventual consistency problem

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,7 +78,7 @@ platform :ios do
     version_bump_podspec(path: "Beagle.podspec", version_number: last_git_tag)
     version_bump_podspec(path: "BeagleSchema.podspec", version_number: last_git_tag)
     pod_push(path: "BeagleSchema.podspec", allow_warnings: true)
-    pod_push(path: "Beagle.podspec", allow_warnings: true)
+    pod_push(path: "Beagle.podspec", allow_warnings: true, synchronous: true)
   end
 
 end


### PR DESCRIPTION
### Description

There is a problem when pushing Pods with dependencies within themselves version due to how frequently CocoaPods trunk refreshes its content. Since `Beagle.spec` depends on `BeagleSchema.spec`, we are exposed to this problem, and so by using the `synchronous` flag, we can try to avoid it.
