### PR TITLE
fix: Avoid showing cold cache from disk

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/cache/CacheManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/cache/CacheManager.kt
@@ -24,7 +24,6 @@ import br.com.zup.beagle.android.store.StoreType
 import br.com.zup.beagle.android.utils.nanoTimeInSeconds
 import br.com.zup.beagle.android.utils.toLowerKeys
 import br.com.zup.beagle.android.view.ScreenRequest
-import java.lang.NumberFormatException
 
 private const val BEAGLE_HASH = "beagle-hash"
 private const val CACHE_CONTROL_HEADER = "cache-control"
@@ -71,9 +70,7 @@ internal class CacheManager(
         val beagleJson = cachedData[beagleJsonKey]
 
         return if (beagleHashValue != null && beagleJson != null) {
-            persistCacheOnMemory(url, beagleJson, beagleHashValue, null)
-
-            return BeagleCache(
+            BeagleCache(
                 isHot = false,
                 hash = beagleHashValue,
                 json = beagleJson
@@ -103,6 +100,7 @@ internal class CacheManager(
         responseData: ResponseData
     ): String {
         return if (responseData.statusCode == 304 && beagleCache != null) {
+            persistCacheOnMemory(url, beagleCache.json, beagleCache.hash, null)
             beagleCache.json
         } else {
             val headers = responseData.headers.toLowerKeys()

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/ComponentRequester.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/ComponentRequester.kt
@@ -17,11 +17,11 @@
 package br.com.zup.beagle.android.data
 
 import br.com.zup.beagle.android.cache.CacheManager
-import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.exception.BeagleException
 import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.android.view.mapper.toRequestData
+import br.com.zup.beagle.core.ServerDrivenComponent
 
 internal class ComponentRequester(
     private val beagleApi: BeagleApi = BeagleApi(),

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/cache/CacheManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/cache/CacheManagerTest.kt
@@ -226,6 +226,7 @@ class CacheManagerTest {
         // Given
         val beagleCache = mockk<BeagleCache> {
             every { json } returns BEAGLE_JSON_VALUE
+            every { hash } returns BEAGLE_HASH_VALUE
         }
         every { responseData.statusCode } returns 304
 


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>

## Description

Changed `CacheManager` to only push disk cache to memory when API returns 304 status code.

## Related Issues

https://github.com/ZupIT/beagle/issues/716

## Tests

Adjusted CacheManager tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [DCO].
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/