### PR TITLE
refactor: GlobalContext - Changed the parameters position in GlobalContext.set constructor

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -103,7 +103,7 @@ internal class ContextDataManager(
 
     fun updateContext(view: View, setContextInternal: SetContextInternal) {
         if (setContextInternal.contextId == globalContext.context.id) {
-            GlobalContext.set(setContextInternal.path, setContextInternal.value)
+            GlobalContext.set(setContextInternal.value, setContextInternal.path)
         } else {
             view.findParentContextWithId(setContextInternal.contextId)?.let { parentView ->
                 val currentContextBinding = parentView.getContextBinding()

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/GlobalContext.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/GlobalContext.kt
@@ -34,7 +34,7 @@ object GlobalContext {
         return contextDataManipulator.get(globalContext, path)
     }
 
-    fun set(path: String? = null, value: Any) {
+    fun set(value: Any, path: String? = null) {
         val result = contextDataManipulator.set(globalContext, path, value)
         notifyContextChanges(result)
     }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -243,7 +243,7 @@ class ContextDataManagerTest : BaseTest() {
         contextDataManager.updateContext(viewContext, updateContext)
 
         // Then
-        verify(exactly = once()) { GlobalContext.set(updateContext.path, updateContext.value) }
+        verify(exactly = once()) { GlobalContext.set(updateContext.value, updateContext.path) }
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/GlobalContextTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/GlobalContextTest.kt
@@ -41,7 +41,7 @@ class GlobalContextTest : BaseTest() {
         // Given
         val path = RandomData.string()
         val value = RandomData.string()
-        GlobalContext.set(path = path, value = value)
+        GlobalContext.set(value = value, path = path)
 
         // When
         val result = GlobalContext.get(path)
@@ -81,7 +81,7 @@ class GlobalContextTest : BaseTest() {
         val value = RandomData.string()
         val path = RandomData.string()
 
-        GlobalContext.set(path = path, value = value)
+        GlobalContext.set(value = value, path = path)
         val result = GlobalContext.get(path)
 
         assertEquals(value, result)
@@ -92,11 +92,11 @@ class GlobalContextTest : BaseTest() {
 
         val valueOne = RandomData.string()
         val pathOne = RandomData.string()
-        GlobalContext.set(pathOne, valueOne)
+        GlobalContext.set(valueOne, pathOne)
         val valueTwo = RandomData.string()
         val pathTwo = RandomData.string()
 
-        GlobalContext.set( value = valueTwo, path = pathTwo)
+        GlobalContext.set(value = valueTwo, path = pathTwo)
         val resultOne = GlobalContext.get(pathOne)
         val resultTwo = GlobalContext.get(pathTwo)
 
@@ -110,7 +110,7 @@ class GlobalContextTest : BaseTest() {
         val pathForSet = RandomData.string()
         val value = RandomData.string()
         val valueAfterClear = ""
-        GlobalContext.set(path = pathForSet, value = value)
+        GlobalContext.set(value = value, path = pathForSet)
         val path = null
 
         GlobalContext.clear(path)
@@ -124,7 +124,7 @@ class GlobalContextTest : BaseTest() {
         // Given
         val path = RandomData.string()
         val value = RandomData.string()
-        GlobalContext.set(path = path, value = value)
+        GlobalContext.set(value = value, path = path)
 
         // When
         GlobalContext.clear(path)
@@ -138,8 +138,8 @@ class GlobalContextTest : BaseTest() {
     fun clear_should_remove_attribute_from_JSON_object() {
         //Given
         val attributeContent = RandomData.string()
-        GlobalContext.set(path = "a.b", value = attributeContent)
-        GlobalContext.set(path = "a.c", value = attributeContent)
+        GlobalContext.set(value = attributeContent, path = "a.b")
+        GlobalContext.set(value = attributeContent, path = "a.c")
 
         //When
         GlobalContext.clear("a.b")

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/GlobalContextTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/GlobalContextTest.kt
@@ -96,7 +96,7 @@ class GlobalContextTest : BaseTest() {
         val valueTwo = RandomData.string()
         val pathTwo = RandomData.string()
 
-        GlobalContext.set(pathTwo, value = valueTwo)
+        GlobalContext.set( value = valueTwo, path = pathTwo)
         val resultOne = GlobalContext.get(pathOne)
         val resultTwo = GlobalContext.get(pathTwo)
 
@@ -171,7 +171,7 @@ class GlobalContextTest : BaseTest() {
     @Test
     fun clear_should_not_clear_a_path_that_does_not_exist_in_JSONObject() {
         //Given
-        GlobalContext.set("f.e", true)
+        GlobalContext.set(true, "f.e")
         val objectPath = "a[0].c.e"
 
         //When


### PR DESCRIPTION
## Description

We have been requested to change the parameters position at the GlobalContext.set constructor in order to list the VALUE parameter first since it is a mandatory parameter and place the PATH parameter second since it is a OPTIONAL parameter.

## Related Issues

No issue has been created for this. We have changed that following replies from the documentation and in order to keep in balance with WEB constructors.

## Tests
Changed the parameters position at tests

set_should_not_override_other_paths_in_global_context_root
updateContext_should_call_global_context_when_id_is_global

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/