### PR TITLE
fix: SendRequest for Android Declarative

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/action/SendRequest.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/action/SendRequest.kt
@@ -86,7 +86,7 @@ data class SendRequest(
 
         when (state) {
             is ActionRequestViewModel.FetchViewState.Error -> onError?.let {
-                handleEvent(rootView, origin, it, ContextData("onError", state.response))
+                handleEvent(rootView, origin, it, ContextData("onError", state.response.normalizeContextValue()))
             }
             is ActionRequestViewModel.FetchViewState.Success -> onSuccess?.let {
                 handleEvent(rootView, origin, it, ContextData("onSuccess", state.response.normalizeContextValue()))

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/action/SendRequest.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/action/SendRequest.kt
@@ -86,10 +86,10 @@ data class SendRequest(
 
         when (state) {
             is ActionRequestViewModel.FetchViewState.Error -> onError?.let {
-                handleEvent(rootView, origin, it, ContextData("onError", state.response.normalizeContextValue()))
+                handleEvent(rootView, origin, it, ContextData("onError", state.response))
             }
             is ActionRequestViewModel.FetchViewState.Success -> onSuccess?.let {
-                handleEvent(rootView, origin, it, ContextData("onSuccess", state.response.normalizeContextValue()))
+                handleEvent(rootView, origin, it, ContextData("onSuccess", state.response))
             }
         }
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/action/SendRequest.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/action/SendRequest.kt
@@ -25,6 +25,7 @@ import br.com.zup.beagle.android.view.viewmodel.ActionRequestViewModel
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextData
+import br.com.zup.beagle.android.context.normalizeContextValue
 import br.com.zup.beagle.android.utils.evaluateExpression
 
 @SuppressWarnings("UNUSED_PARAMETER")
@@ -88,7 +89,7 @@ data class SendRequest(
                 handleEvent(rootView, origin, it, ContextData("onError", state.response))
             }
             is ActionRequestViewModel.FetchViewState.Success -> onSuccess?.let {
-                handleEvent(rootView, origin, it, ContextData("onSuccess", state.response))
+                handleEvent(rootView, origin, it, ContextData("onSuccess", state.response.normalizeContextValue()))
             }
         }
     }
@@ -97,7 +98,7 @@ data class SendRequest(
         url = evaluateExpression(rootView, origin, this.url) ?: "",
         method = evaluateExpression(rootView, origin, this.method) ?: RequestActionMethod.GET,
         headers = this.headers?.let { evaluateExpression(rootView, origin, it) },
-        data = this.data?.let { evaluateExpression(rootView, origin, it) },
+        data = this.data?.normalizeContextValue()?.let { evaluateExpression(rootView, origin, it) },
         onSuccess = this.onSuccess,
         onError = this.onError,
         onFinish = this.onFinish

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/action/SendRequestTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/action/SendRequestTest.kt
@@ -207,7 +207,6 @@ class SendRequestTest {
             every { evaluateExpression(rootView, view, any<Any>()) } returns ""
             every { handleEvent(rootView, view, any<List<Action>>(), capture(contextDataSlot)) } just Runs
             every { handleEvent(rootView, view, any<List<Action>>()) } just Runs
-
         }
     }
 }


### PR DESCRIPTION
## Description

The data attribute content on the SendRequest class is not being converted into a JSON Object when sent in a RequestActionMethod.POST via declarative view on the FRONTEND.

It is being turned into a regular String.

- I have fixed this by adding the `normalizeContextValue()` treatment at the data sent on the SendRequest class.

## Related Issues

https://github.com/ZupIT/beagle/issues/737

## Tests
none

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/