### PR TITLE
fix: Global context does not clear cache

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -162,6 +162,7 @@ internal class ContextDataManager(
 
     private fun updateGlobalContext(contextData: ContextData) {
         globalContext = globalContext.copy(context = contextData)
+        globalContext.cache.evictAll()
         contexts[GLOBAL_CONTEXT_ID] = globalContext
         notifyBindingChanges(globalContext)
     }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.android.context
 
 import android.view.View
+import androidx.collection.LruCache
 import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.action.SetContextInternal
 import br.com.zup.beagle.android.extensions.once
@@ -24,12 +25,19 @@ import br.com.zup.beagle.android.logger.BeagleMessageLogs
 import br.com.zup.beagle.android.mockdata.createViewForContext
 import br.com.zup.beagle.android.testutil.RandomData
 import br.com.zup.beagle.android.testutil.getPrivateField
+import br.com.zup.beagle.android.testutil.setPrivateField
 import br.com.zup.beagle.android.utils.Observer
 import br.com.zup.beagle.android.utils.getContextData
 import br.com.zup.beagle.android.utils.setContextBinding
-import androidx.collection.LruCache
-import br.com.zup.beagle.android.testutil.setPrivateField
-import io.mockk.*
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import io.mockk.spyk
+import io.mockk.slot
+import io.mockk.mockkObject
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -70,10 +78,10 @@ class ContextDataManagerTest : BaseTest() {
     fun init_should_add_observer_to_GlobalContext() {
         // Given
         every { GlobalContext.observeGlobalContextChange(any()) } just Runs
-        
+
         // When
         val contextDataManager = ContextDataManager()
-        
+
         // Then
         val contexts = contextDataManager.getPrivateField<Map<Int, ContextBinding>>("contexts")
         assertNotNull(contexts[Int.MAX_VALUE])
@@ -365,12 +373,12 @@ class ContextDataManagerTest : BaseTest() {
     }
 
     @Test
-    fun init_must_add_observer_to_GlobalContext_and_validate_the_updateGlobalContext_method(){
+    fun init_must_add_observer_to_GlobalContext_and_validate_the_updateGlobalContext_method() {
         // Given
         val globalContextObserver = slot<GlobalContextObserver>()
-        val contextData = ContextData("global","")
-        val globalContextMock = mockk<ContextBinding>(relaxed = true){
-            every { copy(any(),any(),any()) } returns this
+        val contextData = ContextData("global", "")
+        val globalContextMock = mockk<ContextBinding>(relaxed = true) {
+            every { copy(any(), any(), any()) } returns this
         }
         val cache = mockk<LruCache<String, Any>>(relaxed = true)
         every { globalContextMock.cache } returns cache
@@ -383,11 +391,11 @@ class ContextDataManagerTest : BaseTest() {
         globalContextObserver.captured.invoke(contextData)
 
         // Then
-        verify{
-            globalContextMock.copy(context = contextData,cache = any(), bindings = any())
+        verifyOrder {
+            globalContextMock.copy(context = contextData, cache = any(), bindings = any())
             cache.evictAll()
             contextDataManager.notifyBindingChanges(globalContextMock)
         }
-        assertEquals(contexts[Int.MAX_VALUE],globalContextMock)
+        assertEquals(contexts[Int.MAX_VALUE], globalContextMock)
     }
 }


### PR DESCRIPTION
## Description
After retrieves the value from the global context and updating the value on the same screen, you cannot update the value.

## Related Issues
closes #738 

## Tests

I added the following tests:
the ContextDataManagerTest class was modified to validate that the cache is being cleared when the global context has an update

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/