### PR TITLE
fix: Bind deserialization for Map and List

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/Bind.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/Bind.kt
@@ -18,14 +18,20 @@ package br.com.zup.beagle.android.context
 
 import br.com.zup.beagle.android.utils.BeagleConstants
 import br.com.zup.beagle.core.BindAttribute
+import java.lang.reflect.Type
 
 sealed class Bind<T> : BindAttribute<T> {
-    abstract val type: Class<T>
+    abstract val type: Type
 
     class Expression<T>(
         override val value: String,
-        override val type: Class<T>
-    ): Bind<T>()
+        override val type: Type
+    ): Bind<T>() {
+        constructor(
+            value: String,
+            type: Class<T>
+        ) : this(value, type as Type)
+    }
 
     data class Value<T: Any>(override val value: T) : Bind<T>() {
         override val type: Class<T> = value.javaClass

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/BindAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/BindAdapterFactory.kt
@@ -53,7 +53,12 @@ private class BindAdapter(
         val expression = reader.peekJson().readJsonValue()
         if (expression != null && expression is String && expression.isExpression()) {
             reader.skipValue()
-            return Bind.Expression(expression, type as Class<Any>)
+            val valueType = if (type is ParameterizedType) {
+                type.rawType
+            } else {
+                type
+            }
+            return Bind.Expression(expression, valueType)
         }
 
         val value = adapter.fromJson(reader)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
@@ -43,6 +43,7 @@ import br.com.zup.beagle.android.components.page.PageIndicator
 import br.com.zup.beagle.android.components.page.PageView
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextData
+import br.com.zup.beagle.android.context.valueOf
 import br.com.zup.beagle.android.mockdata.ComponentBinding
 import br.com.zup.beagle.android.mockdata.CustomAndroidAction
 import br.com.zup.beagle.android.mockdata.CustomInputWidget
@@ -682,14 +683,40 @@ class BeagleMoshiTest : BaseTest() {
         // Then
         val bindComponent = component as ComponentBinding
         assertNull(bindComponent.value1)
-        assertEquals("Hello @{context.name}", bindComponent.value2.value)
-        assertTrue(bindComponent.value2 is Bind.Expression<String>)
+        assertEquals("Hello", bindComponent.value2.value)
+        assertTrue(bindComponent.value2 is Bind.Value<String>)
         assertEquals(String::class.java, bindComponent.value2.type)
-        assertEquals("@{hello}", bindComponent.value3.value)
-        assertTrue(bindComponent.value3 is Bind.Expression<Boolean>)
+        assertEquals(true, bindComponent.value3.value)
+        assertTrue(bindComponent.value3 is Bind.Value<Boolean>)
         assertEquals(Boolean::class.javaObjectType, bindComponent.value3.type)
         assertNotNull(bindComponent.value4.value)
         assertEquals(InternalObject::class.java, bindComponent.value4.type)
+        assertEquals(mapOf("test1" to "a", "test2" to "b"), bindComponent.value5.value)
+        assertEquals(listOf("test1", "test2"), bindComponent.value6.value)
+    }
+
+    @Test
+    fun moshi_should_deserialize_bindComponent_with_expressions() {
+        // Given
+        val jsonComponent = makeBindComponentExpression()
+
+        // When
+        val component = moshi.adapter(ServerDrivenComponent::class.java).fromJson(jsonComponent)
+
+        // Then
+        val bindComponent = component as ComponentBinding
+        assertEquals("@{intExpression}", bindComponent.value1?.value)
+        assertTrue(bindComponent.value1 is Bind.Expression<Int>)
+        assertEquals("Hello @{context.name}", bindComponent.value2.value)
+        assertTrue(bindComponent.value2 is Bind.Expression<String>)
+        assertEquals("@{booleanExpression}", bindComponent.value3.value)
+        assertTrue(bindComponent.value3 is Bind.Expression<Boolean>)
+        assertEquals("@{objectExpression}", bindComponent.value4.value)
+        assertTrue(bindComponent.value4 is Bind.Expression<InternalObject>)
+        assertEquals("@{mapExpression}", bindComponent.value5.value)
+        assertTrue(bindComponent.value5 is Bind.Expression<Map<String, String>>)
+        assertEquals("@{listExpression}", bindComponent.value6.value)
+        assertTrue(bindComponent.value6 is Bind.Expression<List<String>>)
     }
 
     @Test
@@ -719,7 +746,9 @@ class BeagleMoshiTest : BaseTest() {
                     "",
                     1
                 )
-            )
+            ),
+            value5 = valueOf(mapOf()),
+            value6 = valueOf(listOf())
         )
 
         // When

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
@@ -292,9 +292,23 @@ fun makeBindComponent() = """
     {
         "_beagleComponent_": "custom:componentbinding",
         "value1": null,
+        "value2": "Hello",
+        "value3": true,
+        "value4": ${makeInternalObject()},
+        "value5": {"test1":"a","test2":"b"},
+        "value6": ["test1", "test2"]
+    }
+"""
+
+fun makeBindComponentExpression() = """
+    {
+        "_beagleComponent_": "custom:componentbinding",
+        "value1": "@{intExpression}",
         "value2": "Hello @{context.name}",
-        "value3": "@{hello}",
-        "value4": ${makeInternalObject()}
+        "value3": "@{booleanExpression}",
+        "value4": "@{objectExpression}",
+        "value5": "@{mapExpression}",
+        "value6": "@{listExpression}"
     }
 """
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/ComponentBinding.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/ComponentBinding.kt
@@ -25,5 +25,7 @@ data class ComponentBinding(
     val value1: Bind<Int>?,
     val value2: Bind<String>,
     val value3: Bind<Boolean>,
-    val value4: Bind<InternalObject>
+    val value4: Bind<InternalObject>,
+    val value5: Bind<Map<String, String>>,
+    val value6: Bind<List<String>>
 ) : ServerDrivenComponent


### PR DESCRIPTION
## Description

When a bind attribute is type of List or Map, our deserialiser is not handling and crashing.

Example:
`val map: Bind<Map<String, String>>` or `val list: Bind<List<String>>`

## Tests

Create more unit test to make sure this will nor occur again.