### PR TITLE
fix: image placeholder on android

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -92,6 +92,14 @@ data class Image(
         imageView.loadImage(pathType, requestOptions)
     }
 
+    @SuppressLint("CheckResult")
+    private fun getGlideRequestOptions(placeholder: String?): RequestOptions {
+        val requestOptions = RequestOptions()
+        getImage(placeholder)?.let {
+            requestOptions.placeholder(it)
+        }
+        return requestOptions
+    }
 
     private fun ImageView.loadImage(
         path: ImagePath.Remote,
@@ -101,15 +109,6 @@ data class Image(
             .asBitmap()
             .load(path.url.formatUrl())
             .into(this@loadImage)
-    }
-
-    @SuppressLint("CheckResult")
-    private fun getGlideRequestOptions(placeholder: String?): RequestOptions {
-        val requestOptions = RequestOptions()
-        getImage(placeholder)?.let {
-            requestOptions.placeholder(it)
-        }
-        return requestOptions
     }
 
     private fun getImage(imagePath: String?): Int? =

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -17,8 +17,6 @@
 package br.com.zup.beagle.android.components
 
 import android.annotation.SuppressLint
-import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.ImageView
 import br.com.zup.beagle.android.components.utils.RoundedImageView
@@ -36,8 +34,6 @@ import br.com.zup.beagle.annotation.RegisterWidget
 import br.com.zup.beagle.widget.core.ImageContentMode
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
-import com.bumptech.glide.request.target.CustomTarget
-import com.bumptech.glide.request.transition.Transition
 
 @RegisterWidget
 data class Image(
@@ -63,20 +59,10 @@ data class Image(
         observeBindChanges(rootView, imageView, path) { pathType ->
             when (pathType) {
                 is ImagePath.Local -> {
-                    imageView.apply {
-                        BeagleEnvironment.beagleSdk.designSystem?.image(pathType.mobileId)?.let {
-                            try {
-                                setImageResource(it)
-                            } catch (ex: Exception) {
-                                BeagleMessageLogs.errorWhileTryingToSetInvalidImage(pathType.mobileId, ex)
-                            }
-                        }
-                    }
+                    loadLocalImage(imageView, pathType)
                 }
                 is ImagePath.Remote -> {
-                    val placeholder = pathType.placeholder?.mobileId
-                    val requestOptions = getGlideRequestOptions(placeholder)
-                    imageView.loadImage(pathType, requestOptions)
+                    loadRemoteImage(imageView, pathType)
                 }
             }
         }
@@ -88,6 +74,25 @@ data class Image(
         scaleType = viewMapper.toScaleType(mode ?: ImageContentMode.FIT_CENTER)
     }
 
+    private fun loadLocalImage(imageView: ImageView, pathType: ImagePath.Local) {
+        imageView.apply {
+            getImage(pathType.mobileId)?.let {
+                try {
+                    setImageResource(it)
+                } catch (ex: Exception) {
+                    BeagleMessageLogs.errorWhileTryingToSetInvalidImage(pathType.mobileId, ex)
+                }
+            }
+        }
+    }
+
+    private fun loadRemoteImage(imageView: ImageView, pathType: ImagePath.Remote) {
+        val placeholder = pathType.placeholder?.mobileId
+        val requestOptions = getGlideRequestOptions(placeholder)
+        imageView.loadImage(pathType, requestOptions)
+    }
+
+
     private fun ImageView.loadImage(
         path: ImagePath.Remote,
         requestOptions: RequestOptions) {
@@ -95,26 +100,20 @@ data class Image(
             .setDefaultRequestOptions(requestOptions)
             .asBitmap()
             .load(path.url.formatUrl())
-            .into(object : CustomTarget<Bitmap>() {
-                override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
-                    this@loadImage.setImageBitmap(resource)
-                }
-
-                override fun onLoadCleared(placeholder: Drawable?) {}
-            })
+            .into(this@loadImage)
     }
 
     @SuppressLint("CheckResult")
     private fun getGlideRequestOptions(placeholder: String?): RequestOptions {
         val requestOptions = RequestOptions()
-        getPlaceholder(placeholder)?.let {
+        getImage(placeholder)?.let {
             requestOptions.placeholder(it)
         }
         return requestOptions
     }
 
-    private fun getPlaceholder(placeholder: String?): Int? =
-        placeholder?.let {
+    private fun getImage(imagePath: String?): Int? =
+        imagePath?.let {
             BeagleEnvironment.beagleSdk.designSystem?.image(it)
         }
 


### PR DESCRIPTION
## Description

Fix image to show placeholder
## Related Issues

#729 

## Tests
Fix a mock on setup, remove the build_should_call_setImageBitmap_reloadNetworkImageView_when_component_has_not_flex() and add build_should_setPlaceholder_when_imagePath_is_remote_and_placeholder_is_declared()

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/