### PR TITLE
feat: Adds method to check if the activity have a server driven screen loaded

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
@@ -158,6 +158,8 @@ abstract class BeagleActivity : AppCompatActivity() {
         }
     }
 
+    fun hasServerDrivenScreen(): Boolean = supportFragmentManager.backStackEntryCount > 0
+
     fun navigateTo(screenRequest: ScreenRequest, screen: Screen?) {
         fetch(screenRequest, screen?.toComponent())
     }

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/activities/SampleServerDrivenActivity.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/activities/SampleServerDrivenActivity.kt
@@ -21,7 +21,6 @@ import android.view.View
 import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.ProgressBar
-import android.widget.Toast
 import androidx.appcompat.widget.Toolbar
 import br.com.zup.beagle.android.annotation.BeagleComponent
 import br.com.zup.beagle.android.view.BeagleActivity


### PR DESCRIPTION
## Description

This pr creates a method for the user check at any moment if the beagle activity has any screen loaded.

## Related Issues
https://github.com/ZupIT/beagle/issues/788

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [DCO].
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/ZupIT/beagle/issues
[DCO]: https://developercertificate.org/