### PR TITLE
refactor: added rootView to BeagleFlexView as parameter on Android

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/LazyComponent.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/LazyComponent.kt
@@ -34,9 +34,9 @@ data class LazyComponent(
     private val viewFactory: ViewFactory = ViewFactory()
 
     override fun buildView(rootView: RootView): View {
-        return viewFactory.makeBeagleView(rootView.getContext()).apply {
-            addServerDrivenComponent(initialState, rootView)
-            updateView(rootView, path, this[0])
+        return viewFactory.makeBeagleView(rootView).apply {
+            addServerDrivenComponent(initialState)
+            updateView(path, this[0])
         }
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
@@ -27,6 +27,7 @@ import br.com.zup.beagle.annotation.RegisterWidget
 import br.com.zup.beagle.core.MultiChildComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.widget.core.ListDirection
+
 @RegisterWidget
 data class ListView(
     override val children: List<ServerDrivenComponent>,
@@ -54,7 +55,6 @@ data class ListView(
     }
 }
 
-
 internal class ListViewRecyclerAdapter(
     private val children: List<ServerDrivenComponent>,
     private val viewFactory: ViewFactory,
@@ -65,13 +65,13 @@ internal class ListViewRecyclerAdapter(
     override fun getItemViewType(position: Int): Int = position
 
     override fun onCreateViewHolder(parent: ViewGroup, position: Int): ViewHolder {
-        val view = viewFactory.makeBeagleFlexView(rootView.getContext()).also {
+        val view = viewFactory.makeBeagleFlexView(rootView).also {
             val width = if (orientation == RecyclerView.VERTICAL)
                 ViewGroup.LayoutParams.MATCH_PARENT else
                 ViewGroup.LayoutParams.WRAP_CONTENT
             val layoutParams = ViewGroup.LayoutParams(width, ViewGroup.LayoutParams.WRAP_CONTENT)
             it.layoutParams = layoutParams
-            it.addServerDrivenComponent(children[position], rootView)
+            it.addServerDrivenComponent(children[position])
         }
         return ViewHolder(view)
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabBar.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabBar.kt
@@ -54,14 +54,14 @@ data class TabBar(
     override fun buildView(rootView: RootView): View {
         val containerFlex = Style(flex = Flex(grow = 1.0))
         val tabBar = makeTabLayout(rootView.getContext())
-        val container = viewFactory.makeBeagleFlexView(rootView.getContext(), containerFlex)
+        val container = viewFactory.makeBeagleFlexView(rootView, containerFlex)
         configTabSelectedListener(tabBar, rootView)
         configCurrentTabObserver(tabBar, rootView)
         container.addView(tabBar)
         return container
     }
 
-    private fun makeTabLayout(context: Context) : TabLayout = viewFactory.makeTabLayout(
+    private fun makeTabLayout(context: Context): TabLayout = viewFactory.makeTabLayout(
         context,
         styleManagerFactory.getTabViewStyle(styleId)
     ).apply {
@@ -119,7 +119,6 @@ data class TabBar(
             override fun onTabReselected(tab: TabLayout.Tab?) {}
 
             override fun onTabUnselected(tab: TabLayout.Tab?) {}
-
         })
     }
 
@@ -131,9 +130,7 @@ data class TabBar(
                 }
             }
         }
-
     }
-
 }
 
 data class TabBarItem(

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabItem.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabItem.kt
@@ -37,8 +37,8 @@ data class TabItem(
     private val viewFactory: ViewFactory = ViewFactory()
 
     override fun buildView(rootView: RootView): View {
-        return viewFactory.makeBeagleFlexView(rootView.getContext()).also {
-            it.addServerDrivenComponent(child, rootView)
+        return viewFactory.makeBeagleFlexView(rootView).also {
+            it.addServerDrivenComponent(child)
         }
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabView.kt
@@ -58,7 +58,7 @@ data class TabView(
     override fun buildView(rootView: RootView): View {
         val containerFlex = Style(flex = Flex(grow = 1.0))
 
-        val container = viewFactory.makeBeagleFlexView(rootView.getContext(), containerFlex)
+        val container = viewFactory.makeBeagleFlexView(rootView, containerFlex)
 
         val tabLayout = makeTabLayout(rootView)
 
@@ -70,10 +70,9 @@ data class TabView(
             )
         }
 
-        val containerViewPager =
-            viewFactory.makeBeagleFlexView(rootView.getContext()).apply {
-                addView(viewPager)
-            }
+        val containerViewPager = viewFactory.makeBeagleFlexView(rootView).apply {
+            addView(viewPager)
+        }
 
         tabLayout.addOnTabSelectedListener(getTabSelectedListener(viewPager))
         viewPager.addOnPageChangeListener(getViewPagerChangePageListener(tabLayout))
@@ -171,8 +170,8 @@ internal class ContentAdapter(
     override fun getCount(): Int = children.size
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
-        val view = viewFactory.makeBeagleFlexView(container.context).also {
-            it.addServerDrivenComponent(children[position].child, rootView)
+        val view = viewFactory.makeBeagleFlexView(rootView).also {
+            it.addServerDrivenComponent(children[position].child)
         }
         container.addView(view)
         return view

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/form/SimpleForm.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/form/SimpleForm.kt
@@ -57,16 +57,16 @@ data class SimpleForm(
 
     override fun buildView(rootView: RootView): View {
         preFetchHelper.handlePreFetch(rootView, onSubmit)
-        return viewFactory.makeBeagleFlexView(rootView.getContext(), style ?: Style())
+        return viewFactory.makeBeagleFlexView(rootView, style ?: Style())
             .apply {
                 beagleComponent = this@SimpleForm
-                addChildrenForm(this, rootView)
+                addChildrenForm(this)
             }
     }
 
-    private fun addChildrenForm(beagleFlexView: BeagleFlexView, rootView: RootView) {
+    private fun addChildrenForm(beagleFlexView: BeagleFlexView) {
         children.forEach { child ->
-            beagleFlexView.addServerDrivenComponent(child, rootView)
+            beagleFlexView.addServerDrivenComponent(child)
         }
     }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/ComposeComponent.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/ComposeComponent.kt
@@ -28,8 +28,8 @@ abstract class ComposeComponent : WidgetView() {
     private val viewFactory = ViewFactory()
 
     override fun buildView(rootView: RootView): View {
-        return viewFactory.makeBeagleFlexView(rootView.getContext()).apply {
-            addServerDrivenComponent(build(), rootView)
+        return viewFactory.makeBeagleFlexView(rootView).apply {
+            addServerDrivenComponent(build())
         }
     }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/Container.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/Container.kt
@@ -42,19 +42,18 @@ data class Container(
     private val viewFactory = ViewFactory()
 
     override fun buildView(rootView: RootView): View {
-        val view = viewFactory.makeBeagleFlexView(rootView.getContext(), style ?: Style())
+        val view = viewFactory.makeBeagleFlexView(rootView, style ?: Style())
         onInit?.let {
             this@Container.handleEvent(rootView, view, it)
         }
-
         return view.apply {
-            addChildren(this, rootView)
+            addChildren(this)
         }
     }
 
-    private fun addChildren(beagleFlexView: BeagleFlexView, rootView: RootView) {
+    private fun addChildren(beagleFlexView: BeagleFlexView) {
         children.forEach { child ->
-            beagleFlexView.addServerDrivenComponent(child, rootView)
+            beagleFlexView.addServerDrivenComponent(child)
         }
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/ScreenComponent.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/ScreenComponent.kt
@@ -53,9 +53,9 @@ internal data class ScreenComponent(
     override fun buildView(rootView: RootView): View {
         addNavigationBarIfNecessary(rootView, navigationBar)
 
-        val container = viewFactory.makeBeagleFlexView(rootView.getContext(), Style(flex = Flex(grow = 1.0)))
+        val container = viewFactory.makeBeagleFlexView(rootView, Style(flex = Flex(grow = 1.0)))
 
-        container.addServerDrivenComponent(child, rootView)
+        container.addServerDrivenComponent(child)
 
         screenAnalyticsEvent?.let {
             container.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/ScrollView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/ScrollView.kt
@@ -55,7 +55,7 @@ data class ScrollView(
         val styleParent = Style(flex = Flex(grow = 1.0))
         val styleChild = Style(flex = Flex(flexDirection = flexDirection))
 
-        return viewFactory.makeBeagleFlexView(rootView.getContext(), styleParent).apply {
+        return viewFactory.makeBeagleFlexView(rootView, styleParent).apply {
 
             addView(if (scrollDirection == ScrollAxis.HORIZONTAL) {
                 viewFactory.makeHorizontalScrollView(context).apply {
@@ -77,9 +77,9 @@ data class ScrollView(
         rootView: RootView,
         styleChild: Style
     ) {
-        val viewGroup = viewFactory.makeBeagleFlexView(rootView.getContext(), styleChild)
+        val viewGroup = viewFactory.makeBeagleFlexView(rootView, styleChild)
         children.forEach { component ->
-            viewGroup.addServerDrivenComponent(component, rootView)
+            viewGroup.addServerDrivenComponent(component)
         }
         scrollView.addView(viewGroup)
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageView.kt
@@ -95,7 +95,7 @@ data class PageView(
             adapter = PageViewAdapter(rootView, children, viewFactory)
         }
 
-        val container = viewFactory.makeBeagleFlexView(rootView.getContext(), style).apply {
+        val container = viewFactory.makeBeagleFlexView(rootView, style).apply {
             addView(viewPager, style)
         }
 
@@ -139,8 +139,8 @@ internal class PageViewAdapter(
 ) : PagerAdapter() {
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
-        val view = viewFactory.makeBeagleFlexView(rootView.getContext()).also {
-            it.addServerDrivenComponent(children[position], rootView)
+        val view = viewFactory.makeBeagleFlexView(rootView).also {
+            it.addServerDrivenComponent(children[position])
         }
         container.addView(view)
         return view

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageViewTwo.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageViewTwo.kt
@@ -51,7 +51,7 @@ internal data class PageViewTwo(
             adapter = PageViewAdapterTwo(rootView, children, viewFactory)
         }
 
-        val container = viewFactory.makeBeagleFlexView(rootView.getContext(), style).apply {
+        val container = viewFactory.makeBeagleFlexView(rootView, style).apply {
             addView(viewPager, style)
         }
 
@@ -93,7 +93,6 @@ internal data class PageViewTwo(
             }
         }
     }
-
 }
 
 internal class PageViewAdapterTwo(
@@ -103,8 +102,8 @@ internal class PageViewAdapterTwo(
 ) : PagerAdapter() {
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
-        val view = viewFactory.makeBeagleFlexView(rootView.getContext()).also {
-            it.addServerDrivenComponent(children[position], rootView)
+        val view = viewFactory.makeBeagleFlexView(rootView).also {
+            it.addServerDrivenComponent(children[position])
         }
         container.addView(view)
         return view

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextComponentHandler.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextComponentHandler.kt
@@ -17,21 +17,15 @@
 package br.com.zup.beagle.android.context
 
 import android.view.View
-import br.com.zup.beagle.android.utils.generateViewModelInstance
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
-import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.core.ServerDrivenComponent
 
 internal class ContextComponentHandler {
 
-    fun handleContext(
-        rootView: RootView,
-        view: View,
-        component: ServerDrivenComponent
-    ) {
+    fun handleContext(viewModel: ScreenContextViewModel, view: View, component: ServerDrivenComponent) {
         if (component is ContextComponent) {
             component.context?.let { context ->
-                rootView.generateViewModelInstance<ScreenContextViewModel>().addContext(view, context)
+                viewModel.addContext(view, context)
             }
         }
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/engine/renderer/ViewRenderer.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/engine/renderer/ViewRenderer.kt
@@ -32,12 +32,13 @@ internal abstract class ViewRenderer<T : ServerDrivenComponent>(
     abstract val component: T
 
     fun build(rootView: RootView): View {
+        val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
         val builtView = buildView(rootView)
         componentStylization.apply(builtView, component)
         if (builtView.id == View.NO_ID) {
-            builtView.id = rootView.generateViewModelInstance<ScreenContextViewModel>().generateNewViewId()
+            builtView.id = viewModel.generateNewViewId()
         }
-        contextComponentHandler.handleContext(rootView, builtView, component)
+        contextComponentHandler.handleContext(viewModel, builtView, component)
         return builtView
     }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -59,9 +59,9 @@ private fun loadView(
 ) {
     val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
     viewModel.resetIds()
-    val view = viewExtensionsViewFactory.makeBeagleView(viewGroup.context).apply {
+    val view = viewExtensionsViewFactory.makeBeagleView(rootView).apply {
         stateChangedListener = listener
-        loadView(rootView, screenRequest)
+        loadView(screenRequest)
     }
     view.loadCompletedListener = {
         viewGroup.addView(view)

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
@@ -147,8 +147,8 @@ fun ServerDrivenComponent.toView(fragment: Fragment) = this.toView(FragmentRootV
 fun ServerDrivenComponent.toView(rootView: RootView): View {
     val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
     viewModel.resetIds()
-    return viewFactory.makeBeagleFlexView(rootView.getContext()).apply {
-        addServerDrivenComponent(this@toView, rootView)
+    return viewFactory.makeBeagleFlexView(rootView).apply {
+        addServerDrivenComponent(this@toView)
         viewModel.linkBindingToContextAndEvaluateThem()
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/ViewFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/ViewFactory.kt
@@ -36,30 +36,26 @@ import br.com.zup.beagle.android.view.custom.BeaglePageIndicatorView
 import br.com.zup.beagle.android.view.custom.BeaglePageView
 import br.com.zup.beagle.android.view.custom.BeagleTabLayout
 import br.com.zup.beagle.android.view.custom.BeagleView
+import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.core.Style
 
 internal class ViewFactory {
 
     fun makeView(context: Context) = View(context)
 
-    fun makeBeagleView(context: Context) =
-        BeagleView(context = context)
+    fun makeBeagleView(rootView: RootView) = BeagleView(rootView)
 
-    fun makeBeagleFlexView(context: Context) =
-        BeagleFlexView(context = context)
+    fun makeBeagleFlexView(rootView: RootView) = BeagleFlexView(rootView)
 
-    fun makeBeagleFlexView(context: Context, style: Style) =
-        BeagleFlexView(context = context, style = style)
+    fun makeBeagleFlexView(rootView: RootView, style: Style) = BeagleFlexView(rootView, style)
 
-    fun makeScrollView(context: Context) =
-        ScrollView(context).apply {
-            isFillViewport = true
-        }
+    fun makeScrollView(context: Context) = ScrollView(context).apply {
+        isFillViewport = true
+    }
 
-    fun makeHorizontalScrollView(context: Context) =
-        HorizontalScrollView(context).apply {
-            isFillViewport = true
-        }
+    fun makeHorizontalScrollView(context: Context) = HorizontalScrollView(context).apply {
+        isFillViewport = true
+    }
 
     fun makeButton(context: Context, id: Int) = Button(ContextThemeWrapper(context, id), null, 0)
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
@@ -21,32 +21,34 @@ import android.content.Context
 import android.view.View
 import br.com.zup.beagle.android.engine.mapper.FlexMapper
 import br.com.zup.beagle.android.engine.renderer.ViewRendererFactory
+import br.com.zup.beagle.android.utils.generateViewModelInstance
 import br.com.zup.beagle.android.view.YogaLayout
+import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.core.GhostComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.core.StyleComponent
 
-
 @SuppressLint("ViewConstructor")
 internal open class BeagleFlexView(
-    context: Context,
+    private val rootView: RootView,
     style: Style,
     private val flexMapper: FlexMapper = FlexMapper(),
-    private val viewRendererFactory: ViewRendererFactory = ViewRendererFactory()
-) : YogaLayout(context, flexMapper.makeYogaNode(style)) {
+    private val viewRendererFactory: ViewRendererFactory = ViewRendererFactory(),
+    private val viewModel: ScreenContextViewModel = rootView.generateViewModelInstance()
+) : YogaLayout(rootView.getContext(), flexMapper.makeYogaNode(style)) {
 
     constructor(
-        context: Context,
+        rootView: RootView,
         flexMapper: FlexMapper = FlexMapper()
-    ) : this(context, Style(), flexMapper)
+    ) : this(rootView, Style(), flexMapper)
 
     fun addView(child: View, style: Style) {
         super.addView(child, flexMapper.makeYogaNode(style))
     }
 
-    fun addServerDrivenComponent(serverDrivenComponent: ServerDrivenComponent, rootView: RootView) {
+    fun addServerDrivenComponent(serverDrivenComponent: ServerDrivenComponent) {
         val component = if (serverDrivenComponent is GhostComponent) {
             serverDrivenComponent.child
         } else {

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/BaseTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/BaseTest.kt
@@ -16,7 +16,6 @@
 
 package br.com.zup.beagle.android
 
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.android.engine.renderer.ActivityRootView

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/LazyComponentTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/LazyComponentTest.kt
@@ -59,7 +59,7 @@ class LazyComponentTest : BaseComponentTest() {
     fun build_should_add_initialState_and_trigger_updateView() {
         lazyComponent.buildView(rootView)
 
-        verify(exactly = once()) { beagleView.addServerDrivenComponent(initialState, rootView) }
-        verify(exactly = once()) { beagleView.updateView(rootView, URL, initialStateView) }
+        verify(exactly = once()) { beagleView.addServerDrivenComponent(initialState) }
+        verify(exactly = once()) { beagleView.updateView(URL, initialStateView) }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/form/SimpleFormTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/form/SimpleFormTest.kt
@@ -23,7 +23,11 @@ import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.core.ServerDrivenComponent
-import io.mockk.*
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Test
 import kotlin.test.assertTrue
 
@@ -58,7 +62,7 @@ internal class SimpleFormTest : BaseComponentTest() {
         simpleForm.buildView(rootView)
 
         // Then
-        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(children[0], rootView) }
+        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(children[0]) }
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ComposeComponentTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ComposeComponentTest.kt
@@ -31,7 +31,6 @@ class ComposeComponentTest : BaseComponentTest() {
     private val child: WidgetView = mockk()
     private lateinit var composeComponent: ComposeComponent
 
-
     override fun setUp() {
         super.setUp()
         composeComponent = object : ComposeComponent() {
@@ -54,7 +53,7 @@ class ComposeComponentTest : BaseComponentTest() {
         composeComponent.buildView(rootView)
 
         // THEN
-        verify(exactly = once()) { anyConstructed<ViewFactory>().makeBeagleFlexView(rootView.getContext()) }
+        verify(exactly = once()) { anyConstructed<ViewFactory>().makeBeagleFlexView(rootView) }
     }
 
     @Test
@@ -63,6 +62,6 @@ class ComposeComponentTest : BaseComponentTest() {
         composeComponent.buildView(rootView)
 
         // THEN
-        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(child, rootView) }
+        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(child) }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ContainerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ContainerTest.kt
@@ -17,14 +17,11 @@
 package br.com.zup.beagle.android.components.layout
 
 import br.com.zup.beagle.android.components.BaseComponentTest
-import br.com.zup.beagle.android.components.Button
-import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.view.ViewFactory
+import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.core.Style
-import br.com.zup.beagle.ext.applyFlex
 import br.com.zup.beagle.ext.applyStyle
-import br.com.zup.beagle.widget.core.Flex
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -52,7 +49,7 @@ class ContainerTest : BaseComponentTest() {
         container.buildView(rootView)
 
         // THEN
-        verify(exactly = once()) { anyConstructed<ViewFactory>().makeBeagleFlexView(rootView.getContext(), style) }
+        verify(exactly = once()) { anyConstructed<ViewFactory>().makeBeagleFlexView(rootView, style) }
     }
 
     @Test
@@ -61,6 +58,6 @@ class ContainerTest : BaseComponentTest() {
         container.buildView(rootView)
 
         // THEN
-        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(containerChildren[0], rootView) }
+        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(containerChildren[0]) }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ScreenComponentTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ScreenComponentTest.kt
@@ -26,10 +26,10 @@ import br.com.zup.beagle.android.components.BaseComponentTest
 import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.utils.ToolbarManager
 import br.com.zup.beagle.android.view.BeagleActivity
-import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.android.view.ViewFactory
-import br.com.zup.beagle.core.Style
+import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.core.ServerDrivenComponent
+import br.com.zup.beagle.core.Style
 import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.every
@@ -40,7 +40,6 @@ import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.slot
-import io.mockk.unmockkAll
 import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.Test
@@ -104,7 +103,7 @@ class ScreenComponentTest : BaseComponentTest() {
         screenComponent.buildView(rootView)
 
         // Then
-        verify(atLeast = once()) { beagleFlexView.addServerDrivenComponent(component, rootView) }
+        verify(atLeast = once()) { beagleFlexView.addServerDrivenComponent(component) }
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ScrollViewTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ScrollViewTest.kt
@@ -20,12 +20,11 @@ import android.content.Context
 import android.widget.HorizontalScrollView
 import br.com.zup.beagle.android.components.BaseComponentTest
 import br.com.zup.beagle.android.components.Button
-import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.android.extensions.once
-import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.android.view.ViewFactory
+import br.com.zup.beagle.android.view.custom.BeagleFlexView
+import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.core.Style
-import br.com.zup.beagle.widget.core.Flex
 import br.com.zup.beagle.widget.core.FlexDirection
 import br.com.zup.beagle.widget.core.ScrollAxis
 import io.mockk.Runs
@@ -57,7 +56,7 @@ class ScrollViewTest : BaseComponentTest() {
         every { scrollView.addView(any()) } just Runs
         every { horizontalScrollView.addView(any()) } just Runs
         every { anyConstructed<ViewFactory>().makeBeagleFlexView(any(), capture(style)) } returns beagleFlexView
-        every { beagleFlexView.addServerDrivenComponent(any(), any()) } just Runs
+        every { beagleFlexView.addServerDrivenComponent(any()) } just Runs
         every { beagleFlexView.context } returns context
         every { anyConstructed<ViewFactory>().makeScrollView(any()) } returns scrollView
         every { anyConstructed<ViewFactory>().makeHorizontalScrollView(any()) } returns horizontalScrollView
@@ -75,7 +74,7 @@ class ScrollViewTest : BaseComponentTest() {
 
         // Then
         verify {
-            anyConstructed<ViewFactory>().makeBeagleFlexView(rootView.getContext(), style.first())
+            anyConstructed<ViewFactory>().makeBeagleFlexView(rootView, style.first())
         }
         verify(exactly = once()) { anyConstructed<ViewFactory>().makeScrollView(context) }
         verify(exactly = once()) { scrollView.addView(beagleFlexView) }
@@ -99,10 +98,10 @@ class ScrollViewTest : BaseComponentTest() {
 
         // Then
         verify {
-            anyConstructed<ViewFactory>().makeBeagleFlexView(rootView.getContext(), style.first())
+            anyConstructed<ViewFactory>().makeBeagleFlexView(rootView, style.first())
         }
         verify(exactly = once()) { anyConstructed<ViewFactory>().makeHorizontalScrollView(context) }
-        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(components[0], rootView) }
+        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(components[0]) }
         assertEquals(false, scrollBarEnabled.captured)
         assertEquals(1.0, style[0].flex?.grow)
         assertEquals(FlexDirection.ROW, style[1].flex?.flexDirection)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
@@ -16,9 +16,7 @@
 
 package br.com.zup.beagle.android.components.utils
 
-
 import android.app.Activity
-import android.os.IBinder
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
@@ -45,7 +43,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.just
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
@@ -62,7 +59,7 @@ class ViewExtensionsKtTest : BaseTest() {
     private lateinit var viewGroup: ViewGroup
 
     @MockK(relaxUnitFun = true, relaxed = true)
-    private lateinit var viewModel : ScreenContextViewModel
+    private lateinit var viewModel: ScreenContextViewModel
 
     @RelaxedMockK
     private lateinit var fragment: Fragment
@@ -102,7 +99,7 @@ class ViewExtensionsKtTest : BaseTest() {
         every { viewFactory.makeView(any()) } returns beagleView
         every { viewGroup.addView(capture(viewSlot)) } just Runs
         every { viewGroup.context } returns activity
-        every { beagleView.loadView(any(), any()) } just Runs
+        every { beagleView.loadView(any()) } just Runs
         every { activity.getSystemService(Activity.INPUT_METHOD_SERVICE) } returns inputMethodManager
         every { BeagleEnvironment.beagleSdk.designSystem } returns designSystem
         every { TextViewCompat.setTextAppearance(any(), any()) } just Runs
@@ -118,9 +115,9 @@ class ViewExtensionsKtTest : BaseTest() {
         // Then
         verifySequence {
             viewModel.resetIds()
-            viewFactory.makeBeagleView(activity)
+            viewFactory.makeBeagleView(any<FragmentRootView>())
             beagleView.stateChangedListener = any()
-            beagleView.loadView(any<FragmentRootView>(), screenRequest)
+            beagleView.loadView(screenRequest)
             beagleView.loadCompletedListener = any()
         }
     }
@@ -131,8 +128,8 @@ class ViewExtensionsKtTest : BaseTest() {
         viewGroup.loadView(activity, screenRequest)
 
         // Then
-        verify { viewFactory.makeBeagleView(activity) }
-        verify { beagleView.loadView(any<ActivityRootView>(), screenRequest) }
+        verify { viewFactory.makeBeagleView(any<ActivityRootView>()) }
+        verify { beagleView.loadView(screenRequest) }
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextComponentHandlerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextComponentHandlerTest.kt
@@ -17,9 +17,7 @@
 package br.com.zup.beagle.android.context
 
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
-import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.engine.renderer.ActivityRootView
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
@@ -28,7 +26,6 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
-import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
@@ -51,7 +48,6 @@ class ContextComponentHandlerTest {
         every { rootView.getViewModelStoreOwner() } returns rootView.activity
         mockkConstructor(ViewModelProvider::class)
         every { anyConstructed<ViewModelProvider>().get(ScreenContextViewModel::class.java) } returns viewModel
-
     }
 
     @After
@@ -68,7 +64,7 @@ class ContextComponentHandlerTest {
         every { viewModel.addContext(any(), any()) } just Runs
 
         // When
-        contextComponentHandler.handleContext(rootView, view, component)
+        contextComponentHandler.handleContext(viewModel, view, component)
 
         // Then
         verify(exactly = 1) { viewModel.addContext(view, context) }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/engine/renderer/AbstractViewRendererTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/engine/renderer/AbstractViewRendererTest.kt
@@ -83,7 +83,7 @@ class AbstractViewRendererTest : BaseTest() {
             view.id
             viewModel.generateNewViewId()
             view.id = viewId
-            contextViewRenderer.handleContext(rootView, view, component)
+            contextViewRenderer.handleContext(viewModel, view, component)
         }
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/WidgetExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/WidgetExtensionsKtTest.kt
@@ -16,7 +16,6 @@
 
 package br.com.zup.beagle.android.utils
 
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.components.layout.NavigationBar
@@ -92,7 +91,7 @@ class WidgetExtensionsKtTest : BaseTest() {
         // Then
         verifySequence {
             viewModelMock.resetIds()
-            beagleFlexView.addServerDrivenComponent(component, rootView)
+            beagleFlexView.addServerDrivenComponent(component)
             viewModelMock.linkBindingToContextAndEvaluateThem()
         }
         assertEquals(beagleFlexView, actual)


### PR DESCRIPTION
### Description and Example

This PR changes the parameters of `BeagleFlexView` and `BeagleView` so that instead of receiving an attribute of type `context`, they receive `rootView`. This way the code is a little cleaner and these classes will have reference to the `viewModel`. It is worth mentioning that these changes are necessary for the implementation of the `ListView` with context.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
