### PR TITLE
fix: configBinding retain cycle

### DIFF
--- a/iOS/Sources/Beagle/Sources/ContextExpression/Tests/UIView+ContextTests.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Tests/UIView+ContextTests.swift
@@ -141,7 +141,9 @@ final class UIViewContextTests: XCTestCase {
         
         let singleExpression = SingleExpression(context: contextId, path: .init(nodes: []))
         let multipleExpression = MultipleExpression(nodes: [.expression(singleExpression)])
-        let updateFunction: (String?) -> Void = { _ in }
+        let updateFunction: (String?) -> Void = { _ in
+            // ...
+        }
 
         view?.configBinding(for: .single(singleExpression), completion: updateFunction)
         view?.configBinding(for: .multiple(multipleExpression), completion: updateFunction)
@@ -150,6 +152,7 @@ final class UIViewContextTests: XCTestCase {
         view = nil
         
         // Then
+        XCTAssertNil(view)
         XCTAssertNil(weakReference)
     }
 

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Tests/UIView+ContextTests.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Tests/UIView+ContextTests.swift
@@ -129,6 +129,31 @@ final class UIViewContextTests: XCTestCase {
         contextObservableRoot.value = Context(id: "context", value: ["a": 2])
         XCTAssertEqual(leaf.text, "")
         XCTAssertEqual(leaf.placeholder, "exp: ")
-   }
+    }
+    
+    func testConfigBindingShouldNotRetainTheView() {
+        // Given
+        var view: UILabel? = UILabel()
+        weak var weakReference = view
+        
+        let contextId = "context"
+        view?.setContext(Context(id: contextId, value: .empty))
+        
+        let singleExpression = SingleExpression(context: contextId, path: .init(nodes: []))
+        let multipleExpression = MultipleExpression(nodes: [.expression(singleExpression)])
+
+        view?.configBinding(for: .single(singleExpression), completion: {
+            view?.text = $0
+        })
+        view?.configBinding(for: .multiple(multipleExpression), completion: {
+            view?.text = $0
+        })
+        
+        // When
+        view = nil
+        
+        // Then
+        XCTAssertNil(weakReference)
+    }
 
 }

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Tests/UIView+ContextTests.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Tests/UIView+ContextTests.swift
@@ -141,13 +141,10 @@ final class UIViewContextTests: XCTestCase {
         
         let singleExpression = SingleExpression(context: contextId, path: .init(nodes: []))
         let multipleExpression = MultipleExpression(nodes: [.expression(singleExpression)])
+        let updateFunction: (String?) -> Void = { _ in }
 
-        view?.configBinding(for: .single(singleExpression), completion: {
-            view?.text = $0
-        })
-        view?.configBinding(for: .multiple(multipleExpression), completion: {
-            view?.text = $0
-        })
+        view?.configBinding(for: .single(singleExpression), completion: updateFunction)
+        view?.configBinding(for: .multiple(multipleExpression), completion: updateFunction)
         
         // When
         view = nil

--- a/iOS/Sources/Beagle/Sources/ContextExpression/UIView+Context.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/UIView+Context.swift
@@ -72,9 +72,9 @@ extension UIView {
     
     private func configBinding<T: Decodable>(for expression: SingleExpression, completion: @escaping (T?) -> Void) {
         guard let context = getContext(with: expression.context) else { return }
-        let closure: (Context) -> Void = { context in
+        let closure: (Context) -> Void = { [weak self] context in
             let dynamicObject = expression.evaluate(model: context.value)
-            let value: T? = self.transform(dynamicObject)
+            let value: T? = self?.transform(dynamicObject)
             completion(value)
         }
         let contextObserver = ContextObserver(onContextChange: closure)
@@ -95,15 +95,15 @@ extension UIView {
         expression.nodes.forEach {
             if case let .expression(single) = $0 {
                 guard let context = getContext(with: single.context) else { return }
-                let closure: (Context) -> Void = { _ in
-                    let value: T? = self.evaluate(for: expression, contextId: single.context)
+                let closure: (Context) -> Void = { [weak self] _ in
+                    let value: T? = self?.evaluate(for: expression, contextId: single.context)
                     completion(value)
                 }
                 let contextObserver = ContextObserver(onContextChange: closure)
                 context.addObserver(contextObserver)
             }
         }
-        let value: T? = self.evaluate(for: expression)
+        let value: T? = evaluate(for: expression)
         completion(value)
     }
     


### PR DESCRIPTION
### Description and Example

The extension method `UIView.configBinding(for:completion:)` retains the view and there is no way to release it.

#### How to reproduce

- create a view
- call `view.configBinding(for:completion:)`
- create a weak reference to the view
- release the strong reference to the view
- check if the weak reference points to nil

See `UIViewContextTests.testConfigBindingShouldNotRetainTheView`

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
