### PR TITLE
fix: generate id if some error happen

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/engine/renderer/ViewRenderer.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/engine/renderer/ViewRenderer.kt
@@ -20,11 +20,13 @@ import android.view.View
 import br.com.zup.beagle.android.components.utils.ComponentStylization
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.android.context.ContextComponentHandler
+import br.com.zup.beagle.android.logger.BeagleMessageLogs
 import br.com.zup.beagle.android.utils.generateViewModelInstance
 import br.com.zup.beagle.android.view.viewmodel.GenerateIdViewModel
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.ViewConvertable
+import java.lang.Exception
 
 internal abstract class ViewRenderer<T : ServerDrivenComponent>(
     private val componentStylization: ComponentStylization<T> = ComponentStylization(),
@@ -37,8 +39,13 @@ internal abstract class ViewRenderer<T : ServerDrivenComponent>(
         val builtView = buildView(rootView)
         componentStylization.apply(builtView, component)
         if (builtView.id == View.NO_ID) {
-            builtView.id = rootView.generateViewModelInstance<GenerateIdViewModel>()
-                .getViewId(rootView.getParentId())
+            val generateIdViewModel = rootView.generateViewModelInstance<GenerateIdViewModel>()
+            builtView.id = try {
+                generateIdViewModel.getViewId(rootView.getParentId())
+            } catch (exception: Exception) {
+                BeagleMessageLogs.somethingHappenGenerateId(exception)
+                View.generateViewId()
+            }
         }
         contextComponentHandler.handleContext(viewModel, builtView, component)
         return builtView

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/logger/BeagleMessageLogs.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/logger/BeagleMessageLogs.kt
@@ -129,4 +129,8 @@ internal object BeagleMessageLogs {
         val errorMessage = "Context name global is a reserved keyword for Global Context only"
         BeagleLoggerProxy.warning(errorMessage)
     }
+
+    fun somethingHappenGenerateId(ex: Exception) {
+        BeagleLoggerProxy.error("Something Happen when generate id", ex)
+    }
 }


### PR DESCRIPTION
### Description and Example

if some error happens when generating id, generate automatically id without using view model.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
