### PR TITLE
fix: iOS - Execute actions with implicit context

### DIFF
--- a/iOS/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
+++ b/iOS/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
@@ -121,7 +121,7 @@ public class BeagleScreenViewController: BeagleController {
     public func execute(actions: [RawAction]?, with contextId: String, and contextValue: DynamicObject, origin: UIView) {
         guard let actions = actions else { return }
         let context = Context(id: contextId, value: contextValue)
-        view.setContext(context)
+        origin.setContext(context)
         execute(actions: actions, origin: origin)
     }
             

--- a/iOS/Sources/Beagle/Sources/Renderer/Tests/BeagleScreenViewControllerTests.swift
+++ b/iOS/Sources/Beagle/Sources/Renderer/Tests/BeagleScreenViewControllerTests.swift
@@ -346,6 +346,21 @@ final class BeagleScreenViewControllerTests: XCTestCase {
         XCTAssert(label.text == previousText)
         XCTAssert(label.isEnabled == previousIsEnabled)
     }
+    
+    func testExecuteActions() {
+        // Given
+        let action = ActionSpy()
+        let context = Context(id: "implicitContext", value: ["key": "value"])
+        let origin = UIView()
+        
+        // When
+        controller.execute(actions: [action], with: context.id, and: context.value, origin: origin)
+        
+        // Then
+        XCTAssertEqual(action.executionCount, 1)
+        XCTAssertEqual(action.lastOrigin, origin)
+        XCTAssertEqual(origin.contextMap[context.id]?.value, context)
+    }
 }
 
 // MARK: - Testing Helpers


### PR DESCRIPTION
### Description and Example

In `execute(actions:contextId:contextValue:origin:)` the view configured with the implicit context must be the origin view. Before it was configured for the root view and in most cases it works because the context was resolved too, even at the root.

I added `testExecuteActions` for check this specific scenario.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
