### PR TITLE
fix: iOS - Adds a func to check if the controller have a server driven screen loaded

### DIFF
--- a/iOS/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
+++ b/iOS/Sources/Beagle/Sources/Renderer/BeagleScreenViewController.swift
@@ -224,6 +224,10 @@ public class BeagleScreenViewController: BeagleController {
         createContent()
     }
     
+    public func hasServerDrivenScreen() -> Bool {
+        return screen != nil
+    }
+    
     // MARK: - View Setup
     
     private func initView() {


### PR DESCRIPTION
### Related Issues

#788, #818 

### Description and Example

Creates a function for the user check at any moment if the view controller has any screen loaded.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
