### PR TITLE
fix: making init in network structs inside log public

### DIFF
--- a/iOS/Sources/Beagle/Sources/Logger/BeagleMessageLogs.swift
+++ b/iOS/Sources/Beagle/Sources/Logger/BeagleMessageLogs.swift
@@ -115,11 +115,9 @@ public enum Log {
         }
         
         public init(
-            data: Data? = nil,
-            response: URLResponse? = nil
+            url: URLRequest? = nil
         ) {
-            self.data = data
-            self.response = response
+            self.url = url
         }
         
     }

--- a/iOS/Sources/Beagle/Sources/Logger/BeagleMessageLogs.swift
+++ b/iOS/Sources/Beagle/Sources/Logger/BeagleMessageLogs.swift
@@ -90,6 +90,14 @@ public enum Log {
             """
             return string
         }
+        
+        public init(
+            data: Data? = nil,
+            response: URLResponse? = nil
+        ) {
+            self.data = data
+            self.response = response
+        }
     }
 
     public struct NetworkRequest {
@@ -105,6 +113,15 @@ public enum Log {
             """
             return string
         }
+        
+        public init(
+            data: Data? = nil,
+            response: URLResponse? = nil
+        ) {
+            self.data = data
+            self.response = response
+        }
+        
     }
 
     public enum Expression {


### PR DESCRIPTION
### Related Issues

We can't use `NetworkRequest` and `NetworkResponse` inside log because their init methods are not public.

### Description and Example

Now we can log events like this:
`dependencies.logger.log(Log.network(Log.Network.httpResponse(response: .init(data: nil, response: nil))))`
` dependencies.logger.log(Log.network(Log.Network.httpRequest(request: .init(url: nil))))`

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
