### PR TITLE
fix: parse expression with index path

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/tokenizer/TokenInterpreter.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/tokenizer/TokenInterpreter.kt
@@ -30,17 +30,17 @@ internal class TokenInterpreter(value: String) {
     }
 
     private fun readToken(): Token? {
-        return when {
-            lastChar == '\'' -> readString()
-            lastChar == '(' -> {
+        return when (lastChar) {
+            '\'' -> readString()
+            '(' -> {
                 resetLastChar()
                 tokenOpenBracket()
             }
-            lastChar == ')' -> {
+            ')' -> {
                 resetLastChar()
                 tokenOfCloseBracket()
             }
-            lastChar == ',' -> {
+            ',' -> {
                 resetLastChar()
                 tokenOfComma()
             }
@@ -79,7 +79,7 @@ internal class TokenInterpreter(value: String) {
 
     private fun readVariableOrFunction(): Token? {
         val sb = StringBuilder()
-        while (lastChar.isJavaIdentifierPart() || lastChar == '.') {
+        while (lastChar.isJavaIdentifierPart() || lastChar == '.' || lastChar == '[' || lastChar == ']') {
             sb.append(lastChar)
             lastChar = reader.read().toChar()
         }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/tokenizer/TokenInterpreter.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/tokenizer/TokenInterpreter.kt
@@ -79,7 +79,7 @@ internal class TokenInterpreter(value: String) {
 
     private fun readVariableOrFunction(): Token? {
         val sb = StringBuilder()
-        while (lastChar.isJavaIdentifierPart() || lastChar == '.' || lastChar == '[' || lastChar == ']') {
+        while (lastChar.isJavaIdentifierPart() || isExpressionCharacter()) {
             sb.append(lastChar)
             lastChar = reader.read().toChar()
         }
@@ -100,6 +100,8 @@ internal class TokenInterpreter(value: String) {
             value.getTokenNumber() ?: tokenOfBinding(value)
         }
     }
+
+    private fun isExpressionCharacter() = lastChar == '.' || lastChar == '[' || lastChar == ']'
 
     private fun resetLastChar() {
         lastChar = Char.MIN_VALUE

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/tokenizer/TokenParserTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/tokenizer/TokenParserTest.kt
@@ -128,6 +128,19 @@ class TokenParserTest {
     }
 
     @Test
+    fun parse_should_return_binding_with_path_list() {
+        // Given
+        val expression = "bindingId.bindingValue[0]"
+
+        // When
+        val result = tokenParser.parse(expression)
+
+        // Then
+        assertTrue { result.token is TokenBinding }
+        assertEquals(expression, result.token.value)
+    }
+
+    @Test
     fun parse_should_return_binding_with_number() {
         // Given
         val expression = "1bind2ingId3.4bind5ingValue6"


### PR DESCRIPTION
### Description and Example

When parsing expressions on Android, all characters that are different from `.` were excluded. Whit that, when the expression made reference to an index of a list, this path was ignored as well. This PR adds as allowed characters in addition to `.` the `[` and `]`.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
