### PR TITLE
fix: improve generate id to async view

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -16,6 +16,7 @@
 
 package br.com.zup.beagle.android.utils
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -101,6 +102,9 @@ private fun loadView(
     }
     view.loadCompletedListener = {
         viewGroup.addView(view)
+
+    }
+    view.onViewDetachedFromWindow {
         viewModel.setViewCreated(rootView.getParentId())
     }
 }
@@ -120,6 +124,9 @@ private fun loadView(
     }
     view.loadCompletedListener = {
         viewGroup.addView(view)
+    }
+
+    view.onViewDetachedFromWindow {
         viewModel.setViewCreated(rootView.getParentId())
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -47,7 +47,7 @@ fun ViewGroup.loadView(
     screenRequest: ScreenRequest,
     listener: OnServerStateChanged? = null
 ) {
-    loadView(this, ActivityRootView(activity, this.id), screenRequest, listener)
+    loadView(this, ActivityRootView(activity, this.id), screenRequest, null, listener)
 }
 
 /**
@@ -62,7 +62,7 @@ fun ViewGroup.loadView(
     screenRequest: ScreenRequest,
     listener: OnServerStateChanged? = null
 ) {
-    loadView(this, FragmentRootView(fragment, this.id), screenRequest, listener)
+    loadView(this, FragmentRootView(fragment, this.id), screenRequest, null, listener)
 }
 
 /**
@@ -87,46 +87,25 @@ fun ViewGroup.loadView(fragment: Fragment, screenRequest: ScreenRequest, listene
     loadView(this, FragmentRootView(fragment, this.id), screenRequest, listener)
 }
 
-@Deprecated(DEPRECATED_LOADING_VIEW)
 private fun loadView(
     viewGroup: ViewGroup,
     rootView: RootView,
     screenRequest: ScreenRequest,
-    listener: OnStateChanged?
+    listener: OnStateChanged? = null,
+    newListener: OnServerStateChanged? = null
 ) {
     val viewModel = rootView.generateViewModelInstance<GenerateIdViewModel>()
     viewModel.createIfNotExisting(rootView.getParentId())
     val view = viewExtensionsViewFactory.makeBeagleView(rootView).apply {
         stateChangedListener = listener
+        serverStateChangedListener = newListener
         loadView(screenRequest)
     }
     view.loadCompletedListener = {
         viewGroup.addView(view)
 
     }
-    view.onViewDetachedFromWindow {
-        viewModel.setViewCreated(rootView.getParentId())
-    }
-}
-
-@JvmName("loadView2")
-private fun loadView(
-    viewGroup: ViewGroup,
-    rootView: RootView,
-    screenRequest: ScreenRequest,
-    listener: OnServerStateChanged?
-) {
-    val viewModel = rootView.generateViewModelInstance<GenerateIdViewModel>()
-    viewModel.createIfNotExisting(rootView.getParentId())
-    val view = viewExtensionsViewFactory.makeBeagleView(rootView).apply {
-        serverStateChangedListener = listener
-        loadView(screenRequest)
-    }
-    view.loadCompletedListener = {
-        viewGroup.addView(view)
-    }
-
-    view.onViewDetachedFromWindow {
+    view.listenerOnViewDetachedFromWindow = {
         viewModel.setViewCreated(rootView.getParentId())
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
@@ -157,6 +157,7 @@ internal fun ServerDrivenComponent.toView(rootView: RootView): View {
     return viewFactory.makeBeagleFlexView(rootView).apply {
         id = rootView.getParentId()
         addServerDrivenComponent(this@toView)
+    }.onViewDetachedFromWindow {
         viewModel.setViewCreated(rootView.getParentId())
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
@@ -154,10 +154,14 @@ fun ServerDrivenComponent.toView(fragment: Fragment, idView: Int = R.id.beagle_d
 internal fun ServerDrivenComponent.toView(rootView: RootView): View {
     val viewModel = rootView.generateViewModelInstance<GenerateIdViewModel>()
     viewModel.createIfNotExisting(rootView.getParentId())
-    return viewFactory.makeBeagleFlexView(rootView).apply {
+    val view = viewFactory.makeBeagleFlexView(rootView).apply {
         id = rootView.getParentId()
         addServerDrivenComponent(this@toView)
-    }.onViewDetachedFromWindow {
+    }
+
+    view.listenerOnViewDetachedFromWindow = {
         viewModel.setViewCreated(rootView.getParentId())
     }
+
+    return view
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
@@ -64,4 +64,18 @@ internal open class BeagleFlexView(
         super.onAttachedToWindow()
         viewModel.linkBindingToContextAndEvaluateThem(this)
     }
+
+    fun onViewDetachedFromWindow(callback: () -> Unit): BeagleFlexView {
+        this.addOnAttachStateChangeListener(
+            object : OnAttachStateChangeListener {
+                override fun onViewDetachedFromWindow(v: View?) {
+                    callback()
+                }
+
+                override fun onViewAttachedToWindow(v: View?) {}
+            })
+        return this
+    }
+
+
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
@@ -44,6 +44,8 @@ internal open class BeagleFlexView(
         flexMapper: FlexMapper = FlexMapper()
     ) : this(rootView, Style(), flexMapper)
 
+    var listenerOnViewDetachedFromWindow: (() -> Unit)? = null
+
     fun addView(child: View, style: Style) {
         super.addView(child, flexMapper.makeYogaNode(style))
     }
@@ -65,17 +67,9 @@ internal open class BeagleFlexView(
         viewModel.linkBindingToContextAndEvaluateThem(this)
     }
 
-    fun onViewDetachedFromWindow(callback: () -> Unit): BeagleFlexView {
-        this.addOnAttachStateChangeListener(
-            object : OnAttachStateChangeListener {
-                override fun onViewDetachedFromWindow(v: View?) {
-                    callback()
-                }
-
-                override fun onViewAttachedToWindow(v: View?) {}
-            })
-        return this
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        listenerOnViewDetachedFromWindow?.invoke()
     }
-
 
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
@@ -124,6 +124,7 @@ class ViewExtensionsKtTest : BaseTest() {
             beagleView.stateChangedListener = any()
             beagleView.loadView(screenRequest)
             beagleView.loadCompletedListener = any()
+            beagleView.onViewDetachedFromWindow(any())
         }
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
@@ -122,9 +122,10 @@ class ViewExtensionsKtTest : BaseTest() {
             generateIdViewModel.createIfNotExisting(0)
             viewFactory.makeBeagleView(any<FragmentRootView>())
             beagleView.stateChangedListener = any()
+            beagleView.serverStateChangedListener = any()
             beagleView.loadView(screenRequest)
             beagleView.loadCompletedListener = any()
-            beagleView.onViewDetachedFromWindow(any())
+            beagleView.listenerOnViewDetachedFromWindow = any()
         }
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/WidgetExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/WidgetExtensionsKtTest.kt
@@ -78,7 +78,6 @@ class WidgetExtensionsKtTest : BaseTest() {
         val beagleFlexView = mockk<BeagleFlexView>(relaxed = true, relaxUnitFun = true)
 
         every { viewFactory.makeBeagleFlexView(any()) } returns beagleFlexView
-        every { beagleFlexView.onViewDetachedFromWindow(any()) } returns beagleFlexView
         every { rootView.getContext() } returns mockk()
 
         // When
@@ -89,7 +88,7 @@ class WidgetExtensionsKtTest : BaseTest() {
             generateIdViewModel.createIfNotExisting(0)
             beagleFlexView.id = 0
             beagleFlexView.addServerDrivenComponent(component)
-            beagleFlexView.onViewDetachedFromWindow(any())
+            beagleFlexView.listenerOnViewDetachedFromWindow = any()
         }
 
         assertEquals(beagleFlexView, actual)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/WidgetExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/WidgetExtensionsKtTest.kt
@@ -78,6 +78,7 @@ class WidgetExtensionsKtTest : BaseTest() {
         val beagleFlexView = mockk<BeagleFlexView>(relaxed = true, relaxUnitFun = true)
 
         every { viewFactory.makeBeagleFlexView(any()) } returns beagleFlexView
+        every { beagleFlexView.onViewDetachedFromWindow(any()) } returns beagleFlexView
         every { rootView.getContext() } returns mockk()
 
         // When
@@ -88,7 +89,7 @@ class WidgetExtensionsKtTest : BaseTest() {
             generateIdViewModel.createIfNotExisting(0)
             beagleFlexView.id = 0
             beagleFlexView.addServerDrivenComponent(component)
-            generateIdViewModel.setViewCreated(0)
+            beagleFlexView.onViewDetachedFromWindow(any())
         }
 
         assertEquals(beagleFlexView, actual)


### PR DESCRIPTION
### Description and Example

Change the place where the call method `viewCreated` now this code will work better to async view because I only put the view created when someone rotate the screen.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
