### PR TITLE
fix: update context in tabbar and pageview

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabBar.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TabBar.kt
@@ -31,6 +31,7 @@ import br.com.zup.beagle.android.utils.dp
 import br.com.zup.beagle.android.utils.handleEvent
 import br.com.zup.beagle.android.utils.observeBindChanges
 import br.com.zup.beagle.android.view.ViewFactory
+import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.WidgetView
 import br.com.zup.beagle.annotation.RegisterWidget
@@ -56,7 +57,7 @@ data class TabBar(
         val tabBar = makeTabLayout(rootView.getContext())
         val container = viewFactory.makeBeagleFlexView(rootView, containerFlex)
         configTabSelectedListener(tabBar, rootView)
-        configCurrentTabObserver(tabBar, rootView)
+        configCurrentTabObserver(tabBar, container, rootView)
         container.addView(tabBar)
         return container
     }
@@ -122,9 +123,9 @@ data class TabBar(
         })
     }
 
-    private fun configCurrentTabObserver(tabBar: TabLayout, rootView: RootView) {
+    private fun configCurrentTabObserver(tabBar: TabLayout, container: BeagleFlexView, rootView: RootView) {
         currentTab?.let {
-            observeBindChanges(rootView, tabBar, it) { position ->
+            observeBindChanges(rootView, container, it) { position ->
                 position?.let { newPosition ->
                     tabBar.getTabAt(newPosition)?.select()
                 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageViewTwo.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageViewTwo.kt
@@ -27,6 +27,7 @@ import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.utils.handleEvent
 import br.com.zup.beagle.android.utils.observeBindChanges
 import br.com.zup.beagle.android.view.ViewFactory
+import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.android.view.custom.BeaglePageView
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.WidgetView
@@ -56,7 +57,7 @@ internal data class PageViewTwo(
         }
 
         configPageChangeListener(viewPager, rootView)
-        observerCurrentPage(viewPager, rootView)
+        observerCurrentPage(viewPager, container, rootView)
 
         return container
     }
@@ -84,10 +85,10 @@ internal data class PageViewTwo(
         }
     }
 
-    private fun observerCurrentPage(viewPager: BeaglePageView, rootView: RootView){
+    private fun observerCurrentPage(viewPager: BeaglePageView, container: BeagleFlexView, rootView: RootView) {
         currentPage?.let {
-            observeBindChanges(rootView = rootView, view = viewPager,  bind = it){position ->
-                position?.let{
+            observeBindChanges(rootView = rootView, view = container, bind = it) { position ->
+                position?.let {
                     viewPager.swapToPage(position)
                 }
             }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/TabBarTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/TabBarTest.kt
@@ -144,11 +144,12 @@ class TabBarTest : BaseComponentTest() {
         every {
             tabBar.observeBindChanges(
                 rootView = rootView,
-                view = tabLayout,
+                view = beagleFlexView,
                 bind = currentTab,
                 observes = capture(currentTabSlot)
             )
         } just Runs
+
         //WHEN
         tabBar.buildView(rootView)
 
@@ -179,14 +180,16 @@ class TabBarTest : BaseComponentTest() {
     fun observers_bind_change_should_be_called_when_current_page_change() {
         //GIVEN
         val currentTabSlot = slot<Observer<Int?>>()
+
         every {
             tabBar.observeBindChanges(
                 rootView = rootView,
-                view = tabLayout,
+                view = beagleFlexView,
                 bind = currentTab,
                 observes = capture(currentTabSlot)
             )
         } just Runs
+
         //WHEN
         tabBar.buildView(rootView)
         currentTabSlot.captured.invoke(1)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/page/PageViewTwoTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/page/PageViewTwoTest.kt
@@ -97,12 +97,14 @@ class PageViewTwoTest : BaseComponentTest() {
             context,
             currentPage = currentPage
         )
-        every { pageView.observeBindChanges(
-            rootView = rootView,
-            view = beaglePageView,
-            bind = currentPage,
-            observes = capture(currentPageSlot)
-        ) } just Runs
+        every {
+            pageView.observeBindChanges(
+                rootView = rootView,
+                view = beaglePageView,
+                bind = currentPage,
+                observes = capture(currentPageSlot)
+            )
+        } just Runs
 
         // WHEN
         pageView.buildView(rootView)
@@ -192,19 +194,23 @@ class PageViewTwoTest : BaseComponentTest() {
         }
     }
 
-    private fun commonMock(){
+    private fun commonMock() {
         pageView = PageViewTwo(
             children,
             context,
             onPageChange,
             currentPage
         )
-        every { pageView.observeBindChanges(
-            rootView = rootView,
-            view = beaglePageView,
-            bind = currentPage,
-            observes = capture(currentPageSlot)
-        ) } just Runs
+
+        every {
+            pageView.observeBindChanges(
+                rootView = rootView,
+                view = beagleFlexView,
+                bind = currentPage,
+                observes = capture(currentPageSlot)
+            )
+        } just Runs
+
         every {
             pageView.handleEvent(
                 rootView,


### PR DESCRIPTION
#395 # Description and Example

When I update the context the `TabBar` and `PageView` they not updated:
![pageview](https://user-images.githubusercontent.com/63263091/91799170-7c689e00-ebf4-11ea-903a-8b9658002615.gif)

Adjust the correct reference of the view to the context can be notified:
![fix](https://user-images.githubusercontent.com/63263091/91799199-8f7b6e00-ebf4-11ea-9da8-1f344b0db8f3.gif)


### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
