### PR TITLE
fix: adjust load view

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -26,6 +26,7 @@ import br.com.zup.beagle.android.engine.renderer.FragmentRootView
 import br.com.zup.beagle.android.utils.DeprecationMessages.DEPRECATED_LOADING_VIEW
 import br.com.zup.beagle.android.view.BeagleFragment
 import br.com.zup.beagle.android.view.ScreenRequest
+import br.com.zup.beagle.android.view.ServerDrivenState
 import br.com.zup.beagle.android.view.custom.OnServerStateChanged
 import br.com.zup.beagle.android.view.custom.OnStateChanged
 import br.com.zup.beagle.android.view.viewmodel.GenerateIdViewModel
@@ -33,6 +34,34 @@ import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import br.com.zup.beagle.android.widget.RootView
 
 internal var beagleSerializerFactory = BeagleSerializer()
+
+/**
+ * Load a ServerDrivenComponent into this ViewGroup
+ * @property activity that is parent of this view
+ * @property screenRequest to create your request data to fetch the component
+ */
+fun ViewGroup.loadView(
+    activity: AppCompatActivity,
+    screenRequest: ScreenRequest
+) {
+    loadView(this, ActivityRootView(activity, this.id), screenRequest, object : OnServerStateChanged {
+        override fun invoke(serverState: ServerDrivenState) {}
+    })
+}
+
+/**
+ * Load a ServerDrivenComponent into this ViewGroup
+ * @property fragment that is parent of this view
+ * @property screenRequest to create your request data to fetch the component
+ */
+fun ViewGroup.loadView(
+    fragment: Fragment,
+    screenRequest: ScreenRequest
+) {
+    loadView(this, FragmentRootView(fragment, this.id), screenRequest, object : OnServerStateChanged {
+        override fun invoke(serverState: ServerDrivenState) {}
+    })
+}
 
 /**
  * Load a ServerDrivenComponent into this ViewGroup
@@ -71,7 +100,11 @@ fun ViewGroup.loadView(
  * @property listener is called when the loading is started and finished
  */
 @Deprecated(DEPRECATED_LOADING_VIEW)
-fun ViewGroup.loadView(activity: AppCompatActivity, screenRequest: ScreenRequest, listener: OnStateChanged? = null) {
+fun ViewGroup.loadView(
+    activity: AppCompatActivity,
+    screenRequest: ScreenRequest,
+    listener: OnStateChanged? = null
+) {
     loadView(this, ActivityRootView(activity, this.id), screenRequest, listener)
 }
 
@@ -82,7 +115,11 @@ fun ViewGroup.loadView(activity: AppCompatActivity, screenRequest: ScreenRequest
  * @property listener is called when the loading is started and finished
  */
 @Deprecated(DEPRECATED_LOADING_VIEW)
-fun ViewGroup.loadView(fragment: Fragment, screenRequest: ScreenRequest, listener: OnStateChanged? = null) {
+fun ViewGroup.loadView(
+    fragment: Fragment,
+    screenRequest: ScreenRequest,
+    listener: OnStateChanged? = null
+) {
     loadView(this, FragmentRootView(fragment, this.id), screenRequest, listener)
 }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
@@ -152,6 +152,22 @@ class ViewExtensionsKtTest : BaseTest() {
         verify(exactly = once()) { viewGroup.addView(beagleView) }
     }
 
+
+    @Test
+    fun `loadView without state should addView when load complete`() {
+        // Given
+        val slot = slot<OnLoadCompleted>()
+        every { beagleView.loadCompletedListener = capture(slot) } just Runs
+
+        // When
+        viewGroup.loadView(fragment, screenRequest)
+        slot.captured.invoke()
+
+        // Then
+        assertEquals(beagleView, viewSlot.captured)
+        verify(exactly = once()) { viewGroup.addView(beagleView) }
+    }
+
     @Test
     fun `loadView should set stateChangedListener to beagleView`() {
         // Given


### PR DESCRIPTION
### Description and Example

Some developers to test the beagle use only a simple load view:
<img width="575" alt="Screen Shot 2020-09-01 at 10 35 08" src="https://user-images.githubusercontent.com/63263091/91864947-dd1cc880-ec3e-11ea-8c3d-73ea6190e6d4.png">
but with the new version, the method broke, I created the new methods where you don't need to pass the listener.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
