### PR TITLE
fix: objects inside arrays are converted to String

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/JsonReaderExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/JsonReaderExtensions.kt
@@ -63,7 +63,7 @@ internal fun JsonReader.readArray(): JSONArray {
 
     beginArray()
     while (peek() != JsonReader.Token.END_ARRAY) {
-        jsonArray.put(readJsonValue())
+        jsonArray.put(readValue())
     }
     endArray()
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
@@ -783,6 +783,20 @@ class BeagleMoshiTest : BaseTest() {
     }
 
     @Test
+    fun make_should_create_contextData_with_jsonArray_and_jsonObject() {
+        // Given
+        val contextDataJson = makeContextWithJsonArrayAndJsonObject()
+
+        // When
+        val contextData = moshi.adapter(ContextData::class.java).fromJson(contextDataJson)
+        val childContextData = (contextData?.value as? JSONArray)?.get(0)
+
+        // Then
+        assertTrue(contextData?.value is JSONArray)
+        assertTrue(childContextData is JSONObject)
+    }
+
+    @Test
     fun make_should_create_contextData_with_primitive() {
         // Given
         val contextDataJson = makeContextWithPrimitive()

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
@@ -334,6 +334,21 @@ fun makeContextWithJsonArray() = """
     }
 """
 
+fun makeContextWithJsonArrayAndJsonObject() = """
+    {
+        "id": "contextId",
+        "value": [
+            {
+                "name" : "John",
+                "age" : 20
+            }, {
+                "name" : "Mary",
+                "age" : 30
+          }
+        ]
+    }
+"""
+
 fun makeContextWithPrimitive() = """
     {
         "id": "contextId",


### PR DESCRIPTION
### Description and Example

This PR fixes the bug when Beagle deserialized an array where its children were objects, and these were mistakenly converted to strings.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
