### PR TITLE
fix: assert made in moshi tests

### DIFF
--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
@@ -767,7 +767,9 @@ class BeagleMoshiTest : BaseTest() {
         val contextData = moshi.adapter(ContextData::class.java).fromJson(contextDataJson)
 
         // Then
-        assertTrue(contextData?.value is JSONObject)
+        val value = contextData?.value as? JSONObject
+        assertEquals(true, value?.getBoolean("a"))
+        assertEquals("a", value?.getString("b"))
     }
 
     @Test
@@ -779,21 +781,9 @@ class BeagleMoshiTest : BaseTest() {
         val contextData = moshi.adapter(ContextData::class.java).fromJson(contextDataJson)
 
         // Then
-        assertTrue(contextData?.value is JSONArray)
-    }
-
-    @Test
-    fun make_should_create_contextData_with_jsonArray_and_jsonObject() {
-        // Given
-        val contextDataJson = makeContextWithJsonArrayAndJsonObject()
-
-        // When
-        val contextData = moshi.adapter(ContextData::class.java).fromJson(contextDataJson)
-        val childContextData = (contextData?.value as? JSONArray)?.get(0)
-
-        // Then
-        assertTrue(contextData?.value is JSONArray)
-        assertTrue(childContextData is JSONObject)
+        val value = (contextData?.value as? JSONArray)?.getJSONObject(0)
+        assertEquals(true, value?.getBoolean("a"))
+        assertEquals("a", value?.getString("b"))
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
@@ -334,21 +334,6 @@ fun makeContextWithJsonArray() = """
     }
 """
 
-fun makeContextWithJsonArrayAndJsonObject() = """
-    {
-        "id": "contextId",
-        "value": [
-            {
-                "name" : "John",
-                "age" : 20
-            }, {
-                "name" : "Mary",
-                "age" : 30
-          }
-        ]
-    }
-"""
-
 fun makeContextWithPrimitive() = """
     {
         "id": "contextId",


### PR DESCRIPTION
### Description and Example

This PR changes the assertions made in the Moshi test class. The tests in JsonObject and JsonArray are more assertive because in addition to validating the type, we validate the values of each received value.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
