### PR TITLE
feat: Generating extra class for Widget and Actions registration

### DIFF
--- a/android/internal-processor/src/main/java/br/com/zup/beagle/android/internal/processor/InternalWidgetFactoryProcessor.kt
+++ b/android/internal-processor/src/main/java/br/com/zup/beagle/android/internal/processor/InternalWidgetFactoryProcessor.kt
@@ -39,10 +39,7 @@ class InternalWidgetFactoryProcessor(
 
         val typeSpec = TypeSpec.objectBuilder(className)
             .addModifiers(KModifier.INTERNAL)
-            .addFunction(beagleSetupRegisteredWidgetGenerator.generate(
-                roundEnvironment = roundEnvironment,
-                isOverride = false
-            ))
+            .addFunction(beagleSetupRegisteredWidgetGenerator.generate(roundEnvironment))
             .build()
 
         val beagleSetupFile = FileSpec.builder(

--- a/android/processor/src/main/java/br/com/zup/beagle/android/compiler/BeagleSetupProcessor.kt
+++ b/android/processor/src/main/java/br/com/zup/beagle/android/compiler/BeagleSetupProcessor.kt
@@ -39,9 +39,10 @@ import javax.annotation.processing.RoundEnvironment
 
 class BeagleSetupProcessor(
     private val processingEnv: ProcessingEnvironment,
-    private val beagleSetupRegisteredWidgetGenerator: BeagleSetupRegisteredWidgetGenerator =
-        BeagleSetupRegisteredWidgetGenerator(),
-    private val registeredActionGenerator: RegisteredActionGenerator = RegisteredActionGenerator(),
+    private val registerWidgetProcessorProcessor: RegisterWidgetProcessorProcessor =
+        RegisterWidgetProcessorProcessor(processingEnv),
+    private val registerActionProcessorProcessor: RegisterActionProcessorProcessor =
+        RegisterActionProcessorProcessor(processingEnv),
     private val beagleSetupPropertyGenerator: BeagleSetupPropertyGenerator =
         BeagleSetupPropertyGenerator(processingEnv),
     private val registerAnnotationProcessor: RegisterControllerProcessor =
@@ -62,8 +63,8 @@ class BeagleSetupProcessor(
         val typeSpec = TypeSpec.classBuilder(beagleSetupClassName)
             .addModifiers(KModifier.PUBLIC, KModifier.FINAL)
             .addSuperinterface(ClassName(BEAGLE_SDK.packageName, BEAGLE_SDK.className))
-            .addFunction(beagleSetupRegisteredWidgetGenerator.generate(roundEnvironment))
-            .addFunction(registeredActionGenerator.generate(roundEnvironment))
+            .addFunction(registerWidgetProcessorProcessor.createRegisteredWidgetsFunction())
+            .addFunction(registerActionProcessorProcessor.createRegisteredActionsFunction())
 
 
         val beagleSetupFile = FileSpec.builder(
@@ -85,6 +86,8 @@ class BeagleSetupProcessor(
 
         var property = properties[propertyIndex]
 
+        registerWidgetProcessorProcessor.process(basePackageName, roundEnvironment)
+        registerActionProcessorProcessor.process(basePackageName, roundEnvironment)
         registerAnnotationProcessor.process(basePackageName, roundEnvironment, property.initializer.toString())
 
         val defaultActivity = registerAnnotationProcessor.defaultActivityRegistered

--- a/android/processor/src/main/java/br/com/zup/beagle/android/compiler/RegisterActionProcessor.kt
+++ b/android/processor/src/main/java/br/com/zup/beagle/android/compiler/RegisterActionProcessor.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.compiler
+
+import br.com.zup.beagle.compiler.REGISTERED_ACTIONS
+import br.com.zup.beagle.compiler.REGISTERED_WIDGETS
+import br.com.zup.beagle.compiler.RegisteredActionGenerator
+import br.com.zup.beagle.compiler.error
+import br.com.zup.beagle.widget.Widget
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeSpec
+import java.io.IOException
+import javax.annotation.processing.ProcessingEnvironment
+import javax.annotation.processing.RoundEnvironment
+
+const val REGISTERED_ACTIONS_GENERATED = "RegisteredActions"
+
+class RegisterActionProcessorProcessor(
+    private val processingEnv: ProcessingEnvironment,
+    private val registeredActionGenerator: RegisteredActionGenerator =
+        RegisteredActionGenerator()
+) {
+
+    fun process(packageName: String, roundEnvironment: RoundEnvironment) {
+        val typeSpec = TypeSpec.classBuilder(REGISTERED_ACTIONS_GENERATED)
+            .addModifiers(KModifier.PUBLIC, KModifier.FINAL)
+            .addFunction(createRegisteredActionsFunctionInternal(roundEnvironment))
+            .build()
+
+        try {
+            FileSpec.builder(packageName, REGISTERED_ACTIONS_GENERATED)
+                .addImport(Widget::class, "")
+                .addAnnotation(
+                    AnnotationSpec.builder(Suppress::class.java)
+                        .addMember("%S", "UNCHECKED_CAST")
+                        .build()
+                )
+                .addType(typeSpec)
+                .build()
+                .writeTo(processingEnv.filer)
+        } catch (e: IOException) {
+            val errorMessage = "Error when trying to generate code.\n${e.message!!}"
+            processingEnv.messager.error(errorMessage)
+        }
+    }
+
+    private fun createRegisteredActionsFunctionInternal(roundEnvironment: RoundEnvironment): FunSpec {
+        return registeredActionGenerator.generate(roundEnvironment)
+    }
+
+    fun createRegisteredActionsFunction(): FunSpec {
+        return registeredActionGenerator.createFuncSpec()
+            .addModifiers(KModifier.OVERRIDE)
+            .addStatement("return $REGISTERED_ACTIONS_GENERATED().$REGISTERED_ACTIONS()")
+            .build()
+    }
+}

--- a/android/processor/src/main/java/br/com/zup/beagle/android/compiler/RegisterActionProcessor.kt
+++ b/android/processor/src/main/java/br/com/zup/beagle/android/compiler/RegisterActionProcessor.kt
@@ -17,7 +17,6 @@
 package br.com.zup.beagle.android.compiler
 
 import br.com.zup.beagle.compiler.REGISTERED_ACTIONS
-import br.com.zup.beagle.compiler.REGISTERED_WIDGETS
 import br.com.zup.beagle.compiler.RegisteredActionGenerator
 import br.com.zup.beagle.compiler.error
 import br.com.zup.beagle.widget.Widget

--- a/android/processor/src/main/java/br/com/zup/beagle/android/compiler/RegisterWidgetProcessor.kt
+++ b/android/processor/src/main/java/br/com/zup/beagle/android/compiler/RegisterWidgetProcessor.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.compiler
+
+import br.com.zup.beagle.compiler.BeagleSetupRegisteredWidgetGenerator
+import br.com.zup.beagle.compiler.REGISTERED_WIDGETS
+import br.com.zup.beagle.compiler.error
+import br.com.zup.beagle.widget.Widget
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeSpec
+import java.io.IOException
+import javax.annotation.processing.ProcessingEnvironment
+import javax.annotation.processing.RoundEnvironment
+
+const val REGISTERED_WIDGETS_GENERATED = "RegisteredWidgets"
+
+class RegisterWidgetProcessorProcessor(
+    private val processingEnv: ProcessingEnvironment,
+    private val beagleSetupRegisteredWidgetGenerator: BeagleSetupRegisteredWidgetGenerator =
+        BeagleSetupRegisteredWidgetGenerator()
+) {
+
+    fun process(packageName: String, roundEnvironment: RoundEnvironment) {
+        val typeSpec = TypeSpec.classBuilder(REGISTERED_WIDGETS_GENERATED)
+            .addModifiers(KModifier.PUBLIC, KModifier.FINAL)
+            .addFunction(createRegisteredWidgetsFunctionInternal(roundEnvironment))
+            .build()
+
+        try {
+            FileSpec.builder(packageName, REGISTERED_WIDGETS_GENERATED)
+                .addImport(Widget::class, "")
+                .addAnnotation(
+                    AnnotationSpec.builder(Suppress::class.java)
+                        .addMember("%S", "UNCHECKED_CAST")
+                        .build()
+                )
+                .addType(typeSpec)
+                .build()
+                .writeTo(processingEnv.filer)
+        } catch (e: IOException) {
+            val errorMessage = "Error when trying to generate code.\n${e.message!!}"
+            processingEnv.messager.error(errorMessage)
+        }
+    }
+
+    private fun createRegisteredWidgetsFunctionInternal(roundEnvironment: RoundEnvironment): FunSpec {
+        return beagleSetupRegisteredWidgetGenerator.generate(roundEnvironment)
+    }
+
+    fun createRegisteredWidgetsFunction(): FunSpec {
+        return beagleSetupRegisteredWidgetGenerator.createFuncSpec()
+            .addModifiers(KModifier.OVERRIDE)
+            .addStatement("return $REGISTERED_WIDGETS_GENERATED().$REGISTERED_WIDGETS()")
+            .build()
+    }
+}

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/RegisteredActionGenerator.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/RegisteredActionGenerator.kt
@@ -24,29 +24,35 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.asClassName
 import javax.annotation.processing.RoundEnvironment
 
+const val REGISTERED_ACTIONS = "registeredActions"
+
 class RegisteredActionGenerator {
 
     fun generate(roundEnvironment: RoundEnvironment): FunSpec {
         val registerAnnotatedClasses = roundEnvironment.getElementsAnnotatedWith(RegisterAction::class.java)
+
+        val classValues = registerAnnotatedClasses.joinToString(",\n") { element ->
+            "\t${element}::class.java as Class<Action>"
+        }
+
+        return createFuncSpec()
+            .addCode("""
+                        |val $REGISTERED_ACTIONS = listOf<Class<Action>>(
+                        |   $classValues
+                        |)
+                    |""".trimMargin())
+            .addStatement("return $REGISTERED_ACTIONS")
+            .build()
+    }
+
+    fun createFuncSpec(): FunSpec.Builder {
         val listReturnType = List::class.asClassName().parameterizedBy(
             Class::class.asClassName().parameterizedBy(
                 ClassName(ANDROID_ACTION.packageName, ANDROID_ACTION.className)
             )
         )
 
-        val classValues = registerAnnotatedClasses.joinToString(",\n") { element ->
-            "\t${element}::class.java as Class<Action>"
-        }
-
-        return FunSpec.builder("registeredActions")
-            .addModifiers(KModifier.OVERRIDE)
+        return FunSpec.builder(REGISTERED_ACTIONS)
             .returns(listReturnType)
-            .addCode("""
-                        |val registeredActions = listOf<Class<Action>>(
-                        |   $classValues
-                        |)
-                    |""".trimMargin())
-            .addStatement("return registeredActions")
-            .build()
     }
 }


### PR DESCRIPTION
### Related Issues

fixes: #673 

### Description and Example

As we are generating the boilerplate for widgets and actions registration, now developers can create their own BeagleSetup class to control how @BeagleComponent classes will be instantiated, using dependency injection or not and use these two generated class to return the registration of widget and actions.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
