### PR TITLE
feat: add support to user register adapter to moshi

### DIFF
--- a/android/android-annotation/src/main/kotlin/br/com/zup/beagle/android/annotation/RegisterBeagleAdapter.kt
+++ b/android/android-annotation/src/main/kotlin/br/com/zup/beagle/android/annotation/RegisterBeagleAdapter.kt
@@ -14,24 +14,8 @@
  * limitations under the License.
  */
 
-package br.com.zup.beagle.android.mockdata
+package br.com.zup.beagle.android.annotation
 
-import android.view.View
-import br.com.zup.beagle.android.widget.RootView
-import br.com.zup.beagle.android.widget.WidgetView
-import io.mockk.mockk
-
-interface PersonInterface
-
-data class Person(val names: ArrayList<String>): PersonInterface
-
-class CustomWidget(
-    val arrayList: ArrayList<Person>?,
-    val pair: Pair<Person, String>?,
-    val charSequence: CharSequence?,
-    val personInterface: PersonInterface
-) : WidgetView() {
-    override fun buildView(rootView: RootView): View {
-        return mockk()
-    }
-}
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RegisterBeagleAdapter

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/BeagleMoshi.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/BeagleMoshi.kt
@@ -24,6 +24,12 @@ import br.com.zup.beagle.android.data.serializer.adapter.BindAdapterFactory
 import br.com.zup.beagle.android.data.serializer.adapter.ComponentJsonAdapterFactory
 import br.com.zup.beagle.android.data.serializer.adapter.ContextDataAdapterFactory
 import br.com.zup.beagle.android.data.serializer.adapter.ImagePathTypeJsonAdapterFactory
+import br.com.zup.beagle.android.data.serializer.adapter.defaults.CharSequenceAdapter
+import br.com.zup.beagle.android.data.serializer.adapter.defaults.MoshiArrayListJsonAdapter
+import br.com.zup.beagle.android.data.serializer.adapter.defaults.PairAdapterFactory
+import br.com.zup.beagle.android.data.serializer.adapter.generic.BeagleGenericAdapterFactory
+import br.com.zup.beagle.android.setup.BeagleEnvironment
+import br.com.zup.beagle.android.setup.BeagleSdk
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
@@ -40,8 +46,16 @@ internal object BeagleMoshi {
         .add(ComponentJsonAdapterFactory.make())
         .add(RouteAdapterFactory())
         .add(AndroidActionJsonAdapterFactory.make())
-        .add(KotlinJsonAdapterFactory())
         .add(ContextDataAdapterFactory())
+        .add(MoshiArrayListJsonAdapter.FACTORY)
+        .add(CharSequenceAdapter())
+        .add(PairAdapterFactory)
+        .apply {
+            BeagleEnvironment.beagleSdk.typeAdapterResolver?.let {
+                add(BeagleGenericAdapterFactory(it))
+            }
+        }
         .add(SimpleJsonAdapter())
+        .add(KotlinJsonAdapterFactory())
         .build()
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/defaults/CharSequenceAdapter.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/defaults/CharSequenceAdapter.kt
@@ -1,0 +1,13 @@
+package br.com.zup.beagle.android.data.serializer.adapter.defaults
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+
+internal class CharSequenceAdapter {
+
+    @ToJson
+    fun toJson(charSequence: CharSequence): String = charSequence.toString()
+
+    @FromJson
+    fun fromJson(json: String): CharSequence = json
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/defaults/MoshiArrayListJsonAdapter.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/defaults/MoshiArrayListJsonAdapter.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.data.serializer.adapter.defaults
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import java.io.IOException
+import java.lang.reflect.Type
+
+internal abstract class MoshiArrayListJsonAdapter<C : MutableCollection<T>?, T>
+private constructor(
+    private val elementAdapter: JsonAdapter<T>
+) :
+    JsonAdapter<C>() {
+    abstract fun newCollection(): C
+
+    @Throws(IOException::class)
+    override fun fromJson(reader: JsonReader): C {
+        val result = newCollection()
+        reader.beginArray()
+        while (reader.hasNext()) {
+            result?.add(elementAdapter.fromJson(reader)!!)
+        }
+        reader.endArray()
+        return result
+    }
+
+    @Throws(IOException::class)
+    override fun toJson(writer: JsonWriter, value: C?) {
+        writer.beginArray()
+        for (element in value!!) {
+            elementAdapter.toJson(writer, element)
+        }
+        writer.endArray()
+    }
+
+    override fun toString(): String {
+        return "$elementAdapter.collection()"
+    }
+
+    companion object {
+        val FACTORY = Factory { type, _, moshi ->
+            val rawType = Types.getRawType(type)
+            if (rawType == ArrayList::class.java) {
+                return@Factory newArrayListAdapter<Any>(
+                    type,
+                    moshi
+                ).nullSafe()
+            }
+            null
+        }
+
+        private fun <T> newArrayListAdapter(
+            type: Type,
+            moshi: Moshi
+        ): JsonAdapter<MutableCollection<T>> {
+            val elementType =
+                Types.collectionElementType(
+                    type,
+                    MutableCollection::class.java
+                )
+
+            val elementAdapter: JsonAdapter<T> = moshi.adapter(elementType)
+
+            return object :
+                MoshiArrayListJsonAdapter<MutableCollection<T>, T>(elementAdapter) {
+                override fun newCollection(): MutableCollection<T> {
+                    return ArrayList()
+                }
+            }
+        }
+    }
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/defaults/PairAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/defaults/PairAdapterFactory.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.data.serializer.adapter.defaults
+
+import br.com.zup.beagle.android.utils.readObject
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import org.json.JSONArray
+import org.json.JSONObject
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+private const val FIRST_KEY = "first"
+private const val SECOND_KEY = "second"
+
+internal object PairAdapterFactory : JsonAdapter.Factory {
+
+    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+        if (type !is ParameterizedType || Pair::class.java != type.rawType) return null
+
+        return PairAdapter(
+            moshi.adapter(type.actualTypeArguments[0]),
+            moshi.adapter(type.actualTypeArguments[1])
+        )
+    }
+
+    private class PairAdapter(
+        private val firstAdapter: JsonAdapter<Any>,
+        private val secondAdapter: JsonAdapter<Any>
+    ) : JsonAdapter<Pair<Any, Any>>() {
+
+        override fun toJson(writer: JsonWriter, value: Pair<Any, Any>?) {
+            writer.beginObject()
+            writer.name(FIRST_KEY)
+            firstAdapter.toJson(writer, value?.first)
+            writer.name(SECOND_KEY)
+            secondAdapter.toJson(writer, value?.second)
+            writer.endObject()
+        }
+
+        override fun fromJson(reader: JsonReader): Pair<Any, Any>? {
+            val jsonObject = reader.readObject()
+
+            val first = jsonObject.get(FIRST_KEY)
+            val second = jsonObject.get(SECOND_KEY)
+            return getObject(first, firstAdapter) to getObject(second, secondAdapter)
+        }
+
+        private fun getObject(jsonObject: Any, adapter: JsonAdapter<Any>): Any {
+            return if (jsonObject is JSONArray || jsonObject is JSONObject)
+                adapter.fromJson(jsonObject.toString())!! else adapter.fromJsonValue(jsonObject)!!
+        }
+    }
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/generic/BeagleGenericAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/generic/BeagleGenericAdapterFactory.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.data.serializer.adapter.generic
+
+import br.com.zup.beagle.android.data.serializer.BeagleMoshi
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import java.lang.reflect.Type
+
+@Suppress("UNREACHABLE_CODE")
+class BeagleGenericAdapterFactory(private val typeAdapterResolver: TypeAdapterResolver) : JsonAdapter.Factory {
+
+    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+        val genericAdapter = typeAdapterResolver.getAdapter<Type>(type)
+
+        if (genericAdapter != null) {
+            return TypeAdapter(genericAdapter)
+        }
+
+        return null
+    }
+
+    private class TypeAdapter<T>(
+        private val beagleTypeAdapter: BeagleTypeAdapter<T>
+    ) : JsonAdapter<T>() {
+
+        override fun fromJson(reader: JsonReader): T {
+            val value = reader.readJsonValue()!!
+            var json = value
+            if (value !is String) {
+                json = BeagleMoshi.moshi.adapter(Any::class.java).toJson(value)
+            }
+
+            return beagleTypeAdapter.fromJson(json as String)
+        }
+
+
+        override fun toJson(writer: JsonWriter, value: T?) {
+            if (value != null) {
+                writer.value(beagleTypeAdapter.toJson(value))
+            } else {
+                writer.nullValue()
+            }
+        }
+    }
+}

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/generic/BeagleTypeAdapter.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/generic/BeagleTypeAdapter.kt
@@ -14,24 +14,9 @@
  * limitations under the License.
  */
 
-package br.com.zup.beagle.android.mockdata
+package br.com.zup.beagle.android.data.serializer.adapter.generic
 
-import android.view.View
-import br.com.zup.beagle.android.widget.RootView
-import br.com.zup.beagle.android.widget.WidgetView
-import io.mockk.mockk
-
-interface PersonInterface
-
-data class Person(val names: ArrayList<String>): PersonInterface
-
-class CustomWidget(
-    val arrayList: ArrayList<Person>?,
-    val pair: Pair<Person, String>?,
-    val charSequence: CharSequence?,
-    val personInterface: PersonInterface
-) : WidgetView() {
-    override fun buildView(rootView: RootView): View {
-        return mockk()
-    }
+interface BeagleTypeAdapter<T> {
+    fun fromJson(json: String) : T
+    fun toJson(type: T) : String
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/generic/ParameterizedTypeFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/generic/ParameterizedTypeFactory.kt
@@ -14,24 +14,16 @@
  * limitations under the License.
  */
 
-package br.com.zup.beagle.android.mockdata
+package br.com.zup.beagle.android.data.serializer.adapter.generic
 
-import android.view.View
-import br.com.zup.beagle.android.widget.RootView
-import br.com.zup.beagle.android.widget.WidgetView
-import io.mockk.mockk
+import com.squareup.moshi.internal.Util
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 
-interface PersonInterface
+object ParameterizedTypeFactory {
 
-data class Person(val names: ArrayList<String>): PersonInterface
-
-class CustomWidget(
-    val arrayList: ArrayList<Person>?,
-    val pair: Pair<Person, String>?,
-    val charSequence: CharSequence?,
-    val personInterface: PersonInterface
-) : WidgetView() {
-    override fun buildView(rootView: RootView): View {
-        return mockk()
+    fun new(rawType: Type, vararg typeArguments: Type?): ParameterizedType? {
+        require(typeArguments.isNotEmpty()) { "Missing type arguments for $rawType" }
+        return Util.ParameterizedTypeImpl(null, rawType, *typeArguments)
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/generic/TypeAdapterResolver.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/generic/TypeAdapterResolver.kt
@@ -14,24 +14,10 @@
  * limitations under the License.
  */
 
-package br.com.zup.beagle.android.mockdata
+package br.com.zup.beagle.android.data.serializer.adapter.generic
 
-import android.view.View
-import br.com.zup.beagle.android.widget.RootView
-import br.com.zup.beagle.android.widget.WidgetView
-import io.mockk.mockk
+import java.lang.reflect.Type
 
-interface PersonInterface
-
-data class Person(val names: ArrayList<String>): PersonInterface
-
-class CustomWidget(
-    val arrayList: ArrayList<Person>?,
-    val pair: Pair<Person, String>?,
-    val charSequence: CharSequence?,
-    val personInterface: PersonInterface
-) : WidgetView() {
-    override fun buildView(rootView: RootView): View {
-        return mockk()
-    }
+interface TypeAdapterResolver {
+    fun <T> getAdapter(type: Type): BeagleTypeAdapter<T>?
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/setup/BeagleSdk.kt
@@ -23,6 +23,7 @@ import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.action.FormLocalActionHandler
 import br.com.zup.beagle.android.components.form.core.ValidatorHandler
 import br.com.zup.beagle.android.data.serializer.BeagleMoshi
+import br.com.zup.beagle.android.data.serializer.adapter.generic.TypeAdapterResolver
 import br.com.zup.beagle.android.logger.BeagleLogger
 import br.com.zup.beagle.android.navigation.BeagleControllerReference
 import br.com.zup.beagle.android.navigation.DeepLinkHandler
@@ -46,6 +47,7 @@ interface BeagleSdk {
     val designSystem: DesignSystem?
     val storeHandler: StoreHandler?
     val controllerReference: BeagleControllerReference?
+    val typeAdapterResolver: TypeAdapterResolver?
 
     @Deprecated(NewIntentDeprecatedConstants.BEAGLE_ACTIVITY_COMPONENT)
     val serverDrivenActivity: Class<BeagleActivity>

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/BaseTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/BaseTest.kt
@@ -40,9 +40,9 @@ abstract class BaseTest {
         MockKAnnotations.init(this)
 
         mockkObject(BeagleEnvironment)
-
         every { rootView.activity } returns mockk()
         every { BeagleEnvironment.beagleSdk } returns beagleSdk
+        every { beagleSdk.typeAdapterResolver } returns null
         every { beagleSdk.config.cache.memoryMaximumCapacity } returns 15
         every { beagleSdk.registeredWidgets() } returns listOf()
         every { beagleSdk.registeredActions() } returns listOf()

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/BeagleMoshiTest.kt
@@ -44,11 +44,14 @@ import br.com.zup.beagle.android.components.page.PageView
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.context.valueOf
+import br.com.zup.beagle.android.data.serializer.adapter.generic.BeagleGenericAdapterFactory
 import br.com.zup.beagle.android.mockdata.ComponentBinding
 import br.com.zup.beagle.android.mockdata.CustomAndroidAction
 import br.com.zup.beagle.android.mockdata.CustomInputWidget
 import br.com.zup.beagle.android.mockdata.CustomWidget
 import br.com.zup.beagle.android.mockdata.InternalObject
+import br.com.zup.beagle.android.mockdata.Person
+import br.com.zup.beagle.android.mockdata.TypeAdapterResolverImpl
 import br.com.zup.beagle.android.testutil.RandomData
 import br.com.zup.beagle.android.widget.UndefinedWidget
 import br.com.zup.beagle.android.widget.WidgetView
@@ -86,6 +89,7 @@ class BeagleMoshiTest : BaseTest() {
         every { beagleSdk.formLocalActionHandler } returns mockk(relaxed = true)
         every { beagleSdk.registeredWidgets() } returns WIDGETS
         every { beagleSdk.registeredActions() } returns ACTIONS
+        every { beagleSdk.typeAdapterResolver } returns TypeAdapterResolverImpl()
 
         moshi = BeagleMoshi.createMoshi()
     }
@@ -306,7 +310,9 @@ class BeagleMoshiTest : BaseTest() {
     @Test
     fun make_should_return_moshi_to_serialize_a_CustomWidget() {
         // Given
-        val component = CustomWidget()
+        val component = CustomWidget(arrayListOf(Person(names = arrayListOf("text"))),
+            Pair(Person(names = arrayListOf("text")), "second"), "charSequence",
+            Person(names = arrayListOf("text")))
 
         // When
         val actual = moshi.adapter(ServerDrivenComponent::class.java).toJson(component)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/serializer/serializerDataFactory.kt
@@ -116,8 +116,30 @@ fun makeTabItemJson() = """
     """
 
 fun makeCustomJson() = """
-    {
-        "_beagleComponent_": "custom:customWidget"
+     {
+          "arrayList": [
+                {
+                  "names": [
+                    "text"
+                  ]
+                }
+          ],
+          "pair": {
+                "first": {
+                  "names": [
+                    "text"
+                  ]
+                },
+                "second": "second"
+          },
+          "charSequence": "text",
+          "charArray": "text",
+          "personInterface": {
+                  "names": [
+                    "text"
+                  ]
+          },
+          "_beagleComponent_": "custom:customWidget"
     }
 """
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/PersonAdapterFactory.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/PersonAdapterFactory.kt
@@ -16,22 +16,23 @@
 
 package br.com.zup.beagle.android.mockdata
 
-import android.view.View
-import br.com.zup.beagle.android.widget.RootView
-import br.com.zup.beagle.android.widget.WidgetView
-import io.mockk.mockk
+import br.com.zup.beagle.android.data.serializer.adapter.generic.BeagleTypeAdapter
+import org.json.JSONObject
 
-interface PersonInterface
+private const val KEY = "names"
 
-data class Person(val names: ArrayList<String>): PersonInterface
+class PersonAdapter : BeagleTypeAdapter<PersonInterface> {
 
-class CustomWidget(
-    val arrayList: ArrayList<Person>?,
-    val pair: Pair<Person, String>?,
-    val charSequence: CharSequence?,
-    val personInterface: PersonInterface
-) : WidgetView() {
-    override fun buildView(rootView: RootView): View {
-        return mockk()
+    override fun fromJson(json: String): PersonInterface {
+        val rootObject = JSONObject(json)
+        val name = rootObject.getJSONArray(KEY).getString(0)
+        return Person(arrayListOf(name))
+    }
+
+    override fun toJson(type: PersonInterface): String {
+        type as Person
+        val rootObject = JSONObject()
+        rootObject.put(KEY, type.names)
+        return rootObject.toString()
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/TypeAdapterResolverImpl.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/TypeAdapterResolverImpl.kt
@@ -16,22 +16,18 @@
 
 package br.com.zup.beagle.android.mockdata
 
-import android.view.View
-import br.com.zup.beagle.android.widget.RootView
-import br.com.zup.beagle.android.widget.WidgetView
-import io.mockk.mockk
+import br.com.zup.beagle.android.data.serializer.adapter.generic.BeagleTypeAdapter
+import br.com.zup.beagle.android.data.serializer.adapter.generic.TypeAdapterResolver
+import java.lang.reflect.Type
 
-interface PersonInterface
 
-data class Person(val names: ArrayList<String>): PersonInterface
+@Suppress("UNCHECKED_CAST")
+final class TypeAdapterResolverImpl : TypeAdapterResolver {
+    override fun <T> getAdapter(type: Type): BeagleTypeAdapter<T>? = when(type) {
+        PersonInterface::class.java ->
+            PersonAdapter() as BeagleTypeAdapter<T>
 
-class CustomWidget(
-    val arrayList: ArrayList<Person>?,
-    val pair: Pair<Person, String>?,
-    val charSequence: CharSequence?,
-    val personInterface: PersonInterface
-) : WidgetView() {
-    override fun buildView(rootView: RootView): View {
-        return mockk()
+        else -> null
     }
+
 }

--- a/android/processor/src/main/java/br/com/zup/beagle/android/compiler/BeagleAnnotationProcessor.kt
+++ b/android/processor/src/main/java/br/com/zup/beagle/android/compiler/BeagleAnnotationProcessor.kt
@@ -22,6 +22,7 @@ import br.com.zup.beagle.android.annotation.RegisterValidator
 import br.com.zup.beagle.compiler.BEAGLE_CONFIG
 import br.com.zup.beagle.compiler.implementsInterface
 import br.com.zup.beagle.annotation.RegisterAction
+import br.com.zup.beagle.android.annotation.RegisterBeagleAdapter
 import br.com.zup.beagle.annotation.RegisterWidget
 import br.com.zup.beagle.compiler.error
 import com.google.auto.service.AutoService

--- a/android/processor/src/main/java/br/com/zup/beagle/android/compiler/RegisterBeagleAdapterProcessor.kt
+++ b/android/processor/src/main/java/br/com/zup/beagle/android/compiler/RegisterBeagleAdapterProcessor.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.compiler
+
+import br.com.zup.beagle.android.annotation.RegisterBeagleAdapter
+import br.com.zup.beagle.compiler.BEAGLE_CUSTOM_ADAPTER
+import br.com.zup.beagle.compiler.elementType
+import br.com.zup.beagle.compiler.error
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.asTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeSpec
+import java.io.IOException
+import java.lang.reflect.Type
+import javax.annotation.processing.ProcessingEnvironment
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.element.TypeElement
+import javax.lang.model.type.DeclaredType
+import javax.lang.model.type.TypeMirror
+import javax.lang.model.type.WildcardType
+
+const val BEAGLE_ADAPTER_REFERENCE_GENERATED = "TypeAdapterResolverImpl"
+const val JAVA_CLASS = "::class.java"
+const val BEAGLE_TYPE_ADAPTER_INTERFACE = "BeagleTypeAdapter<T>"
+const val TYPES_INSTANCE = "ParameterizedTypeFactory.new(\n"
+const val T_GENERIC = "T"
+const val BREAK_LINE = "\n"
+
+class RegisterBeagleAdapterProcessor (private val processingEnv: ProcessingEnvironment) {
+
+    fun process(packageName: String, roundEnvironment: RoundEnvironment) {
+        val typeSpec = TypeSpec.classBuilder(BEAGLE_ADAPTER_REFERENCE_GENERATED)
+            .addModifiers(KModifier.PUBLIC, KModifier.FINAL)
+            .addAnnotation(
+                AnnotationSpec.builder(Suppress::class.java)
+                    .addMember("%S", "UNCHECKED_CAST")
+                    .build()
+            )
+            .addSuperinterface(ClassName(
+                BEAGLE_CUSTOM_ADAPTER.packageName,
+                BEAGLE_CUSTOM_ADAPTER.className
+            ))
+            .addFunction(createClassForMethod(roundEnvironment))
+            .build()
+
+        try {
+            val builder = FileSpec.builder(packageName, BEAGLE_ADAPTER_REFERENCE_GENERATED)
+                .addType(typeSpec)
+                .addImport(BEAGLE_CUSTOM_ADAPTER.packageName, BEAGLE_CUSTOM_ADAPTER.className)
+            builder.build().writeTo(processingEnv.filer)
+        } catch (e: IOException) {
+            val errorMessage = "Error when trying to generate code.$BREAK_LINE${e.message!!}"
+            processingEnv.messager.error(errorMessage)
+        }
+    }
+
+    private fun createClassForMethod(roundEnvironment: RoundEnvironment): FunSpec {
+        val validatorLines = createValidatorLines(roundEnvironment, StringBuilder())
+        val returnType = ClassName(BEAGLE_CUSTOM_ADAPTER.packageName, "BeagleTypeAdapter").parameterizedBy(
+            TypeVariableName(T_GENERIC)
+        ).copy(true) as ParameterizedTypeName
+
+        val spec = FunSpec.builder("getAdapter")
+            .addModifiers(KModifier.OVERRIDE)
+            .addTypeVariable(TypeVariableName(T_GENERIC))
+            .addParameter("type", Type::class.asTypeName().copy(false))
+
+        spec.addStatement("""
+                |return when(type) {
+                |   $validatorLines
+                |   else -> null
+                |}
+            |""".trimMargin())
+
+        return spec.returns(returnType)
+            .build()
+    }
+
+    private fun createValidatorLines(roundEnvironment: RoundEnvironment, adapters: StringBuilder): String {
+        val registerAdapterAnnotatedClasses = roundEnvironment.getElementsAnnotatedWith(
+            RegisterBeagleAdapter::class.java
+        )
+
+        registerAdapterAnnotatedClasses.forEach { element ->
+            val typeElement = element as TypeElement
+            val declaredType = typeElement.interfaces[0] as DeclaredType
+            val elementParameterizedTypeName =
+                ((typeElement.interfaces[0] as DeclaredType).elementType as DeclaredType).asElement()
+
+            if (typeElement.interfaces.size == 1) {
+                if ((declaredType.elementType as DeclaredType).toTypeArguments().isEmpty()) {
+                    adapters.append(
+                        "$elementParameterizedTypeName$JAVA_CLASS -> " +
+                            "$element() as $BEAGLE_TYPE_ADAPTER_INTERFACE$BREAK_LINE"
+                    )
+                } else {
+                    createParameterizedType(adapters, (declaredType.elementType as DeclaredType), element)
+                    adapters.append(" -> $element() as $BEAGLE_TYPE_ADAPTER_INTERFACE$BREAK_LINE")
+                }
+            } else if (typeElement.interfaces.size > 1) {
+                processingEnv.messager.error("Error: $element must implement just the $BEAGLE_TYPE_ADAPTER_INTERFACE")
+            } else {
+                processingEnv.messager.error("Error: $element must implement the $BEAGLE_TYPE_ADAPTER_INTERFACE")
+            }
+        }
+
+        return adapters.toString()
+    }
+
+    private fun createParameterizedType(
+        adapters: StringBuilder,
+        item: DeclaredType,
+        element: TypeElement? = null
+    ): StringBuilder {
+        val parameterName = if (element != null) {
+            ((element.interfaces[0] as DeclaredType).elementType as DeclaredType).asElement().toString()
+        } else {
+            item.asElement().toString()
+        }
+
+        adapters.append("$TYPES_INSTANCE${parameterName.removeExtends()}$JAVA_CLASS")
+
+        val parametrizedItems = item.toTypeArguments()
+        var checkedTimes = 0
+
+        if (parametrizedItems.isNotEmpty()){
+            adapters.append(",$BREAK_LINE")
+        }
+
+        while (checkedTimes < parametrizedItems.size) {
+            createType(adapters, parametrizedItems[checkedTimes])
+
+            if (checkedTimes != parametrizedItems.lastIndex) {
+                adapters.append(",$BREAK_LINE")
+            }
+            checkedTimes++
+        }
+
+        adapters.append(")")
+
+        return adapters
+    }
+
+    private fun createType(adapters: StringBuilder, typeMirror: TypeMirror) : StringBuilder {
+        return when {
+            typeMirror is DeclaredType -> {
+                checkDeclaredType(adapters, typeMirror)
+            }
+            ((typeMirror as WildcardType).extendsBound) is DeclaredType -> {
+                checkDeclaredType(adapters, (typeMirror.extendsBound) as DeclaredType)
+            }
+            else -> {
+                adapters.append("$BREAK_LINE${typeMirror.toString().removeExtends()}$JAVA_CLASS")
+            }
+        }
+    }
+
+    private fun checkDeclaredType(adapters: StringBuilder, declaredType: DeclaredType): StringBuilder {
+        val typeArgumentsItem = declaredType.toTypeArguments()
+
+        if (typeArgumentsItem.isEmpty()) {
+            return adapters.append("${declaredType.toString().removeExtends()}$JAVA_CLASS")
+        }
+
+        return createParameterizedType(adapters, declaredType)
+    }
+}
+
+private fun DeclaredType.toTypeArguments() : List<TypeMirror> {
+    return try {
+        this.typeArguments
+    } catch (e: Exception) {
+        ArrayList()
+    }
+}
+
+private fun String.removeExtends() = this.replace("? extends ", "")

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/adapters/PersonAdapter.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/adapters/PersonAdapter.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.sample.adapters
+
+import br.com.zup.beagle.android.annotation.RegisterBeagleAdapter
+import br.com.zup.beagle.android.data.serializer.adapter.generic.BeagleTypeAdapter
+import org.json.JSONObject
+
+private const val KEY = "NAME"
+
+interface Person
+
+data class PersonImpl(val name: String) : Person
+
+@RegisterBeagleAdapter
+class PersonAdapter : BeagleTypeAdapter<Person> {
+
+    override fun fromJson(json: String): Person {
+        val rootObject = JSONObject(json)
+        return PersonImpl(rootObject.getString(KEY))
+    }
+
+    override fun toJson(type: Person): String {
+        type as PersonImpl
+        val rootObject = JSONObject()
+        rootObject.put(KEY, type.name)
+        return rootObject.toString()
+    }
+}

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/Input.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/widgets/Input.kt
@@ -27,11 +27,13 @@ import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.utils.observeBindChanges
 import br.com.zup.beagle.annotation.RegisterWidget
+import br.com.zup.beagle.sample.adapters.Person
 
 @RegisterWidget
 data class Input(
     val hint: Bind<String>,
-    val onTextChange: List<Action>? = null
+    val onTextChange: List<Action>? = null,
+    val personImpl: Person
 ) : WidgetView() {
 
     override fun buildView(rootView: RootView) = EditText(rootView.getContext()).apply {

--- a/android/sample/src/test/java/br/com/zup/beagle/sample/BeagleSetupTest.kt
+++ b/android/sample/src/test/java/br/com/zup/beagle/sample/BeagleSetupTest.kt
@@ -17,6 +17,9 @@
 package br.com.zup.beagle.sample
 
 import br.com.zup.beagle.android.setup.BeagleSdk
+import br.com.zup.beagle.sample.adapters.Person
+import br.com.zup.beagle.sample.adapters.PersonAdapter
+import br.com.zup.beagle.sample.adapters.PersonImpl
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -68,6 +71,21 @@ class BeagleSetupTest {
 
     @Test
     fun `should has valid instance when get type adapter`() {
+        //WHEN
+        val result = beagleSetup.typeAdapterResolver.getAdapter<Person>(Person::class.java)
+
+        //THEN
         assertNotNull(beagleSetup.typeAdapterResolver)
+        assertTrue(result is PersonAdapter)
+    }
+
+    @Test
+    fun `should get null when get type adapter with not has type mapped`() {
+        //WHEN
+        val result = beagleSetup.typeAdapterResolver.getAdapter<PersonImpl>(PersonImpl::class.java)
+
+        //THEN
+        assertNotNull(beagleSetup.typeAdapterResolver)
+        assertNull(result)
     }
 }

--- a/android/sample/src/test/java/br/com/zup/beagle/sample/BeagleSetupTest.kt
+++ b/android/sample/src/test/java/br/com/zup/beagle/sample/BeagleSetupTest.kt
@@ -52,11 +52,6 @@ class BeagleSetupTest {
     }
 
     @Test
-    fun designSystem_should_have_a_valid_instance() {
-        assertNotNull(beagleSetup.designSystem)
-    }
-
-    @Test
     fun validatorHandler_should_have_a_valid_instance() {
         assertNotNull(beagleSetup.validatorHandler)
     }
@@ -64,5 +59,15 @@ class BeagleSetupTest {
     @Test
     fun config_should_have_a_valid_instance() {
         assertNotNull(beagleSetup.config)
+    }
+
+    @Test
+    fun designSystem_should_have_a_valid_instance() {
+        assertNotNull(beagleSetup.designSystem)
+    }
+
+    @Test
+    fun `should has valid instance when get type adapter`() {
+        assertNotNull(beagleSetup.typeAdapterResolver)
     }
 }

--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleClasses.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/BeagleClasses.kt
@@ -72,6 +72,16 @@ val CONTROLLER_REFERENCE = BeagleClass(
     "br.com.zup.beagle.android.navigation",
     "BeagleControllerReference"
 )
+val BEAGLE_CUSTOM_ADAPTER = BeagleClass(
+    "br.com.zup.beagle.android.data.serializer.adapter.generic",
+    "TypeAdapterResolver"
+)
+
+val BEAGLE_CUSTOM_ADAPTER_IMPL = BeagleClass(
+    "br.com.zup.beagle.android.data.serializer.adapter.generic",
+    "TypeAdapterResolverImpl"
+)
+
 val BEAGLE_LOGGER = BeagleClass(
     "br.com.zup.beagle.android.logger",
     "BeagleLogger"


### PR DESCRIPTION
### Related Issues

Closes #715 

### Description and Example

This fix makes Beagle able to register custom adapters do help `Moshi` serialize/deserialize non POJO data

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
