### PR TITLE
fix: Expression is evaluating to null for specific cases

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/Bind.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/Bind.kt
@@ -53,4 +53,4 @@ inline fun <reified T> expressionOf(expressionText: String): Bind.Expression<T> 
 inline fun <reified T : Any> valueOf(value: T) = Bind.Value(value)
 inline fun <reified T : Any> valueOfNullable(value: T?) = value?.let { valueOf(it) }
 
-internal fun Any.isExpression() = this is String && this.contains(BeagleRegex.EXPRESSION_REGEX)
+internal fun Any.hasExpression() = this.toString().contains(BeagleRegex.EXPRESSION_REGEX)

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextExpressionReplacer.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextExpressionReplacer.kt
@@ -44,7 +44,8 @@ class ContextExpressionReplacer {
                     evaluatedItemsInReverseOrder
                 )
             } else {
-                joinActualMatchWithNextOne(index, listInReverseOrderOfStringsToEvaluate, actualStringToEvaluate)
+                joinActualMatchWithNextOneOrEndList(index, listInReverseOrderOfStringsToEvaluate,
+                    actualStringToEvaluate, evaluatedItemsInReverseOrder)
             }
         }
 
@@ -85,21 +86,24 @@ class ContextExpressionReplacer {
             .replace("\\@", "@")
     }
 
-    private fun joinActualMatchWithNextOne(
+    private fun joinActualMatchWithNextOneOrEndList(
         index: Int,
         listInReverseOrderOfStringsToEvaluate: MutableList<String>,
-        actualStringToEvaluate: String
+        actualStringToEvaluate: String,
+        evaluatedItemsInReverseOrder: MutableList<String>
     ) {
         if (isNotTheLastMatch(index, listInReverseOrderOfStringsToEvaluate)) {
             val nextStringItem = listInReverseOrderOfStringsToEvaluate[index + 1]
             listInReverseOrderOfStringsToEvaluate[index + 1] = nextStringItem.plus(actualStringToEvaluate)
+        }else{
+            evaluatedItemsInReverseOrder.add(actualStringToEvaluate)
         }
     }
 
     private fun isNotTheLastMatch(
         index: Int,
         listInReverseOrderOfStringsToEvaluate: MutableList<String>
-    ) = index != listInReverseOrderOfStringsToEvaluate.size
+    ) = index != listInReverseOrderOfStringsToEvaluate.size - 1
 
     private fun getQuantityOfSlashesForThisMatch(actualMatch: String) =
         BeagleRegex.QUANTITY_OF_SLASHES_REGEX.find(actualMatch)?.groups?.get(1)?.value?.length ?: 0

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/BindAdapterFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/serializer/adapter/BindAdapterFactory.kt
@@ -17,8 +17,7 @@
 package br.com.zup.beagle.android.data.serializer.adapter
 
 import br.com.zup.beagle.android.context.Bind
-import br.com.zup.beagle.android.context.isExpression
-import br.com.zup.beagle.android.context.tokenizer.ExpressionToken
+import br.com.zup.beagle.android.context.hasExpression
 import br.com.zup.beagle.android.context.tokenizer.TokenParser
 import br.com.zup.beagle.android.utils.getExpressions
 import com.squareup.moshi.JsonAdapter
@@ -26,7 +25,6 @@ import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
-import java.lang.Exception
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 
@@ -56,7 +54,7 @@ private class BindAdapter(
 
     override fun fromJson(reader: JsonReader): Bind<Any>? {
         val expressionText = reader.peekJson().readJsonValue()
-        if (expressionText != null && expressionText is String && expressionText.isExpression()) {
+        if (expressionText != null && expressionText is String && expressionText.hasExpression()) {
             reader.skipValue()
             val valueType = if (type is ParameterizedType) {
                 type.rawType

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataEvaluationTest.kt
@@ -497,16 +497,28 @@ internal class ContextDataEvaluationTest : BaseTest() {
     }
 
     @Test
-    fun evaluateMultipleStringsExpressions() {
-        val bind = expressionOf<String>("lorem ipsum \\@{'hello world, this is { beagle }!}'} lotem ipsum @{nome} , \\\\\\\\@{context.id}" +
+    fun evaluateAllContext_in_multiple_expressions() {
+        val bind = expressionOf<String>("lorem } ipsum \\@{'hello world, this is { beagle }!}'} lotem ipsum @{nome} , \\\\\\\\@{context.id}" +
             "lorem ipsum @{'hello world, this is { beagle }!}'} lotem ipsum gabriel , \\\\\\\\@{context.id}")
 
         val value = contextDataEvaluation.evaluateBindExpression(listOf(CONTEXT_DATA), bind)
 
-        val expected = "lorem ipsum @{'hello world, this is { beagle }!}'} lotem ipsum  , \\\\" +
+        val expected = "lorem } ipsum @{'hello world, this is { beagle }!}'} lotem ipsum  , \\\\" +
             "lorem ipsum hello world, this is { beagle }!} lotem ipsum gabriel , \\\\"
 
         assertEquals(expected = expected, actual = value)
+    }
+
+    @Test
+    fun evaluateAllContext_in_object_with_expressions() {
+        // Given
+        val bind = expressionOf<String>("{\"id\":\"test\",\"value\":{\"expression\":\"@{$CONTEXT_ID.a}\"}}")
+
+        // When
+        val value = contextDataEvaluation.evaluateBindExpression(listOf(CONTEXT_DATA), bind)
+
+        // Then
+        assertEquals("{\"id\":\"test\",\"value\":{\"expression\":\"a\"}}", value)
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ActionExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ActionExtensionsKtTest.kt
@@ -77,7 +77,31 @@ class ActionExtensionsKtTest : BaseTest() {
     }
 
     @Test
-    fun evaluateExpression_should_evaluate_bind_of_type_String_with_multiple_expressions2() {
+    fun evaluateExpression_should_evaluate_raw_JSONObject() {
+        // Given
+        val value = JSONObject("""{"type":"LOADING"}""")
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, bindView, value)
+
+        // Then
+        assertEquals(value.toString(), actualValue.toString())
+    }
+
+    @Test
+    fun evaluateExpression_should_evaluate_raw_JSONArray() {
+        // Given
+        val value = JSONArray("""["hello1", "hello2"]""")
+
+        // When
+        val actualValue = action.evaluateExpression(rootView, bindView, value)
+
+        // Then
+        assertEquals(value.toString(), actualValue.toString())
+    }
+
+    @Test
+    fun evaluateExpression_should_evaluate_bind_with_string_and_operation() {
         // Given
         val bind = expressionOf<String>("Hello @{sum(context1, context2)}")
         val contextValue = 1


### PR DESCRIPTION
### Related Issues
Closes: #892

### Description and Example

When these given values is set as a string or expression, we are evaluating to null.
Case 1: When context value is type of string and has a closing curly brace. Ex.: "test } @{context}"
Case 2: When the root of SetContext is a JSONArray or JSONObject. Ex.: {"key": "value"}

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
