### PR TITLE
fix: call removeAllViews before addView

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -152,8 +152,8 @@ private fun loadView(
         loadView(screenRequest)
     }
     view.loadCompletedListener = {
+        viewGroup.removeAllViews()
         viewGroup.addView(view)
-
     }
     view.listenerOnViewDetachedFromWindow = {
         viewModel.setViewCreated(rootView.getParentId())

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/utils/ViewExtensionsKtTest.kt
@@ -39,15 +39,9 @@ import br.com.zup.beagle.android.view.custom.OnLoadCompleted
 import br.com.zup.beagle.android.view.custom.OnStateChanged
 import br.com.zup.beagle.android.view.viewmodel.GenerateIdViewModel
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
-import io.mockk.Runs
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
-import io.mockk.just
-import io.mockk.mockkStatic
-import io.mockk.slot
-import io.mockk.verify
-import io.mockk.verifySequence
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -140,7 +134,7 @@ class ViewExtensionsKtTest : BaseTest() {
     }
 
     @Test
-    fun `loadView should addView when load complete`() {
+    fun `loadView should removeAllViews and addView when load complete`() {
         // Given
         val slot = slot<OnLoadCompleted>()
         every { beagleView.loadCompletedListener = capture(slot) } just Runs
@@ -151,7 +145,10 @@ class ViewExtensionsKtTest : BaseTest() {
 
         // Then
         assertEquals(beagleView, viewSlot.captured)
-        verify(exactly = once()) { viewGroup.addView(beagleView) }
+        verifyOrder {
+            viewGroup.removeAllViews()
+            viewGroup.addView(beagleView)
+        }
     }
 
 


### PR DESCRIPTION
### Related Issues

Fixes: #904

### Description and Example

Whenever loadView is called, we should clear all views from the ViewGroup before loading the components.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
