### PR TITLE
fix: send request bindable fields

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
@@ -21,23 +21,34 @@ import BeagleSchema
 import UIKit
 
 let sendRequestDeclarativeScreen: Screen = {
+    let containerStyle = Style().size(Size().width(100%).height(50%)).flex(Flex().alignItems(.center).justifyContent(.spaceEvenly))
+ 
     return Screen(
         navigationBar: NavigationBar(title: "Send Request", showBackButton: true),
         context: Context(id: "myContext", value: "initial value")
     ) {
-        Container {
+        Container(widgetProperties: .init(style: containerStyle)) {
+            Button(
+                text: "SendRequest Context on header",
+                styleId: "DesignSystem.Stylish.ButtonAndAppearance",
+                onPress: [
+                    Navigate.pushView(.remote(.init(url: "https://run.mocky.io/v3/5f028242-dfb7-43af-8b55-bac79d7332c6")))
+                ],
+                widgetProperties: .init(style: Style().backgroundColor(.salmonButton).size(Size().width(80%)).cornerRadius(.init(radius: 10)))
+            )
             Button(
                 text: "do request",
+                styleId: "DesignSystem.Stylish.ButtonAndAppearance",
                 onPress: [
                     SendRequest(
                         url: "https://httpbin.org/post",
-                        method: .post,
+                        method: .value(.post),
                         data: "@{myContext}",
-                        headers: [
+                        headers: .value([
                             "Content-Type": "application/json",
                             "sample-header-1": "HeaderContent1",
                             "Sample-Header-2": "HeaderContent2"
-                        ],
+                        ]),
                         onSuccess: [
                             Alert(
                                 title: "Success!",
@@ -60,7 +71,8 @@ let sendRequestDeclarativeScreen: Screen = {
                             CustomConsoleLogAction()
                         ]
                     )
-                ]
+                ],
+                widgetProperties: .init(style: Style().backgroundColor(.blueButton).size(Size().width(60%)).cornerRadius(.init(radius: 10)))
             )
         }
     }

--- a/iOS/Schema/Sources/Action/Types/SendRequest.swift
+++ b/iOS/Schema/Sources/Action/Types/SendRequest.swift
@@ -28,9 +28,9 @@ public struct SendRequest: RawAction, AutoInitiableAndDecodable {
     }
     
     public let url: Expression<String>
-    public let method: SendRequest.HTTPMethod?
+    public let method: Expression<SendRequest.HTTPMethod>?
     public let data: DynamicObject?
-    public let headers: [String: String]?
+    public let headers: Expression<[String: String]>?
     public let onSuccess: [RawAction]?
     public let onError: [RawAction]?
     public let onFinish: [RawAction]?
@@ -38,9 +38,9 @@ public struct SendRequest: RawAction, AutoInitiableAndDecodable {
 // sourcery:inline:auto:SendRequest.Init
     public init(
         url: Expression<String>,
-        method: SendRequest.HTTPMethod? = nil,
+        method: Expression<SendRequest.HTTPMethod>? = nil,
         data: DynamicObject? = nil,
-        headers: [String: String]? = nil,
+        headers: Expression<[String: String]>? = nil,
         onSuccess: [RawAction]? = nil,
         onError: [RawAction]? = nil,
         onFinish: [RawAction]? = nil
@@ -54,4 +54,23 @@ public struct SendRequest: RawAction, AutoInitiableAndDecodable {
         self.onFinish = onFinish
     }
 // sourcery:end
+    
+    @available(*, deprecated, message: "Since version 1.3, we allow expressions in the parameters method and headers, please consider using the new init instead.")
+    public init(
+        url: Expression<String>,
+        method: SendRequest.HTTPMethod? = nil,
+        data: DynamicObject? = nil,
+        headers: [String: String]? = nil,
+        onSuccess: [RawAction]? = nil,
+        onError: [RawAction]? = nil,
+        onFinish: [RawAction]? = nil
+    ) {
+        self.url = url
+        self.method = .value(method ?? .get)
+        self.data = data
+        self.headers = .value(headers ?? ["": ""])
+        self.onSuccess = onSuccess
+        self.onError = onError
+        self.onFinish = onFinish
+    }
 }

--- a/iOS/Schema/Sources/Action/Types/SendRequest.swift
+++ b/iOS/Schema/Sources/Action/Types/SendRequest.swift
@@ -55,7 +55,7 @@ public struct SendRequest: RawAction, AutoInitiableAndDecodable {
     }
 // sourcery:end
     
-    @available(*, deprecated, message: "Since version 1.3, we allow expressions in the parameters method and headers, please consider using the new init instead.")
+    @available(*, deprecated, message: "Since version 1.3, we allow expressions in the parameters method and headers, please consider using the new method for initialization instead.")
     public init(
         url: Expression<String>,
         method: SendRequest.HTTPMethod? = nil,

--- a/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
+++ b/iOS/Schema/Sources/CodeGeneration/Generated/AutoDecodable.generated.swift
@@ -348,9 +348,9 @@ extension SendRequest {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         url = try container.decode(Expression<String>.self, forKey: .url)
-        method = try container.decodeIfPresent(SendRequest.HTTPMethod.self, forKey: .method)
+        method = try container.decodeIfPresent(Expression<SendRequest.HTTPMethod>.self, forKey: .method)
         data = try container.decodeIfPresent(DynamicObject.self, forKey: .data)
-        headers = try container.decodeIfPresent([String: String].self, forKey: .headers)
+        headers = try container.decodeIfPresent(Expression<[String: String]>.self, forKey: .headers)
         onSuccess = try container.decodeIfPresent(forKey: .onSuccess)
         onError = try container.decodeIfPresent(forKey: .onError)
         onFinish = try container.decodeIfPresent(forKey: .onFinish)

--- a/iOS/Sources/Beagle/Sources/Action/Types/SendRequest.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/SendRequest.swift
@@ -24,9 +24,13 @@ extension SendRequest: Action {
         guard let url = controller.dependencies.urlBuilder.build(path: url.evaluate(with: origin) ?? "") else {
             return
         }
+        
+        let methodValue = method?.evaluate(with: origin)
+        let headersValue = headers?.evaluate(with: origin)
+
         let requestData = Request.RequestData(
-            method: method?.rawValue,
-            headers: headers,
+            method: methodValue?.rawValue,
+            headers: headersValue,
             body: data?.evaluate(with: origin).asAny()
         )
         let request = Request(url: url, type: .rawRequest(requestData), additionalData: nil)

--- a/iOS/Sources/Beagle/Sources/Action/Types/Tests/SendRequestTests.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Tests/SendRequestTests.swift
@@ -26,7 +26,7 @@ final class SendRequestTests: XCTestCase {
         // Given
         let sendRequest = SendRequest(
             url: "http://mock",
-            method: .post,
+            method: .value(.post),
             data: .string("data")
         )
         let view = UIView()
@@ -60,7 +60,7 @@ final class SendRequestTests: XCTestCase {
         let url = "http://mock"
         let sendRequest = SendRequest(
             url: "\(url)",
-            method: .get
+            method: .value(.get)
         )
         let view = UIView()
         let controller = BeagleControllerSpy()


### PR DESCRIPTION
### Related Issues - #920 

### Description and Example

- Altered the method and headers parameters to be bindable fields.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.
