### PR TITLE
fix: adding deprecated constructor to navigate

### DIFF
--- a/iOS/Schema/Sources/Action/Types/Navigate/Navigate.swift
+++ b/iOS/Schema/Sources/Action/Types/Navigate/Navigate.swift
@@ -101,6 +101,13 @@ extension Route {
             self.shouldPrefetch = shouldPrefetch
             self.fallback = fallback
         }
+        
+        @available(*, deprecated, message: "It was deprecated in version 1.2.2 and will be removed in a future version. Please use constructor with bind")
+        public init(url: String, shouldPrefetch: Bool = false, fallback: Screen? = nil) {
+            self.url = .value(url)
+            self.shouldPrefetch = shouldPrefetch
+            self.fallback = fallback
+        }
     }
 }
 

--- a/iOS/Schema/Sources/Action/Types/Navigate/Navigate.swift
+++ b/iOS/Schema/Sources/Action/Types/Navigate/Navigate.swift
@@ -104,7 +104,7 @@ extension Route {
         
         @available(*, deprecated, message: "It was deprecated in version 1.2.2 and will be removed in a future version. Please use constructor with bind")
         public init(url: String, shouldPrefetch: Bool = false, fallback: Screen? = nil) {
-            self.url = .value(url)
+            self.url = "\(url)"
             self.shouldPrefetch = shouldPrefetch
             self.fallback = fallback
         }

--- a/iOS/Schema/Sources/ContextExpression/Expression.swift
+++ b/iOS/Schema/Sources/ContextExpression/Expression.swift
@@ -140,3 +140,22 @@ extension String {
         return result.replacingOccurrences(of: "\\@{", with: "@{")
     }
 }
+
+// MARK: ExpressibleByLiteral
+extension Expression: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        let escaped = value.escapeExpressions()
+        if let expression = SingleExpression(rawValue: value) {
+            self = .expression(.single(expression))
+        } else if let multiple = MultipleExpression(rawValue: value) {
+            self = .expression(.multiple(multiple))
+        } else if let value = escaped as? T {
+            self = .value(value)
+        } else {
+            assertionFailure("Error: invalid Expression syntax \(value)")
+            self = .expression(.multiple(MultipleExpression(nodes: [])))
+        }
+    }
+}
+
+extension Expression: ExpressibleByStringInterpolation {}

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Expression.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Expression.swift
@@ -44,26 +44,6 @@ public extension Expression {
     }
 }
 
-// MARK: ExpressibleByLiteral
-extension Expression: ExpressibleByStringLiteral {
-    public init(stringLiteral value: String) {
-        let escaped = value.escapeExpressions()
-        if let expression = SingleExpression(rawValue: value) {
-            self = .expression(.single(expression))
-        } else if let multiple = MultipleExpression(rawValue: value) {
-            self = .expression(.multiple(multiple))
-        } else if let value = escaped as? T {
-            self = .value(value)
-        } else {
-            assertionFailure("Error: invalid Expression syntax \(value)")
-            Beagle.dependencies.logger.log(Log.expression(.invalidSyntax))
-            self = .expression(.multiple(MultipleExpression(nodes: [])))
-        }
-    }
-}
-
-extension Expression: ExpressibleByStringInterpolation {}
-
 extension Expression: ExpressibleByIntegerLiteral where T == Int {
     public init(integerLiteral value: Int) {
         self = .value(value)


### PR DESCRIPTION
### Description and Example

- The new navigate constructor allows strings but doesn't allow constants with strings, this is causing old applications to break. 

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.
