### PR TITLE
fix: Xcode 12 compiling issues

### DIFF
--- a/iOS/Beagle.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/Beagle.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,17 +6,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream.git",
         "state": {
           "branch": null,
-          "revision": "cfc7b7b8dc98df3f7bef8aa068bbaec13d9ceb1b",
-          "version": "4.0.3"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+          "version": "4.0.4"
         }
       },
       {

--- a/iOS/Example/BeagleDemo/BeagleDemo.xcodeproj/project.pbxproj
+++ b/iOS/Example/BeagleDemo/BeagleDemo.xcodeproj/project.pbxproj
@@ -548,7 +548,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1210;
 				ORGANIZATIONNAME = "Zup IT";
 				TargetAttributes = {
 					932925AD2327E0E400A61F01 = {

--- a/iOS/Example/BeagleDemo/BeagleDemo.xcodeproj/xcshareddata/xcschemes/BeagleDemo.xcscheme
+++ b/iOS/Example/BeagleDemo/BeagleDemo.xcodeproj/xcshareddata/xcschemes/BeagleDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Libraries/YogaKit/YogaKit.xcodeproj/project.pbxproj
+++ b/iOS/Libraries/YogaKit/YogaKit.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 		E535244D23310EA100D1A0C9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1210;
 				ORGANIZATIONNAME = "Zup IT";
 				TargetAttributes = {
 					93C36E572333C15900B5940B = {

--- a/iOS/Libraries/YogaKit/YogaKit.xcodeproj/xcshareddata/xcschemes/YogaKit.xcscheme
+++ b/iOS/Libraries/YogaKit/YogaKit.xcodeproj/xcshareddata/xcschemes/YogaKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Schema/BeagleSchema.xcodeproj/xcshareddata/xcschemes/Schema.xcscheme
+++ b/iOS/Schema/BeagleSchema.xcodeproj/xcshareddata/xcschemes/Schema.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Schema/Sources/ServerDrivenComponent/ListView/ListView.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/ListView/ListView.swift
@@ -77,6 +77,7 @@ public struct ListView: RawWidget, HasContext, InitiableComponent, AutoInitiable
         )
     }
 
+    #if swift(<5.3)
     @available(*, deprecated, message: "use the dataSource and template instead of children")
     public init(
         direction: Direction = .vertical,
@@ -85,6 +86,7 @@ public struct ListView: RawWidget, HasContext, InitiableComponent, AutoInitiable
     ) {
         self.init(children: [children()], direction: direction)
     }
+    #endif
 
     @available(*, deprecated, message: "use the dataSource and template instead of children")
     public init(

--- a/iOS/Schema/Sources/ServerDrivenComponent/PageView/PageView.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/PageView/PageView.swift
@@ -50,6 +50,7 @@ public struct PageView: RawComponent, AutoDecodable, HasContext {
         self.currentPage = currentPage
     }
     
+    #if swift(<5.3)
     public init(
         context: Context? = nil,
         onPageChange: [RawAction]? = nil,
@@ -59,6 +60,7 @@ public struct PageView: RawComponent, AutoDecodable, HasContext {
     ) {
         self.init(children: [children()], context: context, onPageChange: onPageChange, currentPage: currentPage)
     }
+    #endif
     
     public init(
         context: Context? = nil,

--- a/iOS/Schema/Sources/ServerDrivenComponent/Scroll/ScrollView.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/Scroll/ScrollView.swift
@@ -37,6 +37,7 @@ public struct ScrollView: RawComponent, AutoInitiableAndDecodable, HasContext {
     }
 // sourcery:end
     
+    #if swift(<5.3)
     public init(
         scrollBarEnabled: Bool? = nil,
         scrollDirection: ScrollAxis? = nil,
@@ -46,6 +47,7 @@ public struct ScrollView: RawComponent, AutoInitiableAndDecodable, HasContext {
     ) {
         self.init(children: [children()], scrollDirection: scrollDirection, scrollBarEnabled: scrollBarEnabled, context: context)
     }
+    #endif
     
     public init(
         scrollBarEnabled: Bool? = nil,

--- a/iOS/Schema/Sources/ServerDrivenComponent/TabView/TabView.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/TabView/TabView.swift
@@ -84,7 +84,8 @@ public struct TabView: RawComponent, AutoInitiable, HasContext {
     ) {
         self.init(children: children(), styleId: styleId, context: context)
     }
-
+    
+    #if swift(<5.3)
     public init(
         context: Context? = nil,
         styleId: String? = nil,
@@ -93,4 +94,5 @@ public struct TabView: RawComponent, AutoInitiable, HasContext {
     ) {
         self.init(children: [children()], styleId: styleId, context: context)
     }
+    #endif
 }

--- a/iOS/Schema/Sources/Widgets/Container/Container.swift
+++ b/iOS/Schema/Sources/Widgets/Container/Container.swift
@@ -45,6 +45,7 @@ public struct Container: RawWidget, HasContext, InitiableComponent, AutoDecodabl
         self.init(children: children(), widgetProperties: widgetProperties, context: context, onInit: onInit)
     }
     
+    #if swift(<5.3)
     public init(
         context: Context? = nil,
         onInit: [RawAction]? = nil,
@@ -54,4 +55,5 @@ public struct Container: RawWidget, HasContext, InitiableComponent, AutoDecodabl
     ) {
         self.init(children: [children()], widgetProperties: widgetProperties, context: context, onInit: onInit)
     }
+    #endif
 }

--- a/iOS/Schema/Sources/Widgets/SimpleForm/SimpleForm.swift
+++ b/iOS/Schema/Sources/Widgets/SimpleForm/SimpleForm.swift
@@ -48,6 +48,7 @@ public struct SimpleForm: RawComponent, HasContext, AutoInitiableAndDecodable {
         self.init(context: context, onSubmit: onSubmit, children: children(), widgetProperties: widgetProperties)
     }
     
+    #if swift(<5.3)
     public init(
         context: Context? = nil,
         onSubmit: [RawAction]? = nil,
@@ -57,4 +58,5 @@ public struct SimpleForm: RawComponent, HasContext, AutoInitiableAndDecodable {
     ) {
         self.init(context: context, onSubmit: onSubmit, children: [children()], widgetProperties: widgetProperties)
     }
+    #endif
 }

--- a/iOS/Sources/Beagle/Beagle.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/iOS/Sources/Beagle/Beagle.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1210"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Sources/Beagle/Beagle.xcodeproj/xcshareddata/xcschemes/Beagle.xcscheme
+++ b/iOS/Sources/Beagle/Beagle.xcodeproj/xcshareddata/xcschemes/Beagle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -43,15 +43,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "932925CE2327E11000A61F01"
-            BuildableName = "BeagleUI.framework"
-            BlueprintName = "BeagleUI"
-            ReferencedContainer = "container:BeagleUI.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/iOS/Sources/Preview/BeaglePreview.xcodeproj/project.pbxproj
+++ b/iOS/Sources/Preview/BeaglePreview.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 			repositoryURL = "https://github.com/daltoniam/Starscream.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.0.3;
+				version = 4.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/iOS/Sources/Preview/BeaglePreview.xcodeproj/xcshareddata/xcschemes/BeaglePreview.xcscheme
+++ b/iOS/Sources/Preview/BeaglePreview.xcodeproj/xcshareddata/xcschemes/BeaglePreview.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Tests/AutomatedTests.xcodeproj/xcshareddata/xcschemes/AutomatedTests.xcscheme
+++ b/iOS/Tests/AutomatedTests.xcodeproj/xcshareddata/xcschemes/AutomatedTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS/Tests/AutomatedTests.xcodeproj/xcshareddata/xcschemes/AutomatedTestsUITests.xcscheme
+++ b/iOS/Tests/AutomatedTests.xcodeproj/xcshareddata/xcschemes/AutomatedTestsUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
### Important

We added a `#if swift(<5.3)` compiler condition in some `init` that used **Function Builders**, because in swift _5.3_ we don't need to have `ChildrenBuilder` _and_ `ChildBuilder`, now with only `ChildrenBuilder` we can handle both _single_ parameter and _multiple_ parameters.
So, to still make our code compatible with previous swift versions, we will include that if statement in our code.

### Related Issues

Closes #931 

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
