### PR TITLE
fix: add focus in component text input

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
@@ -93,8 +93,6 @@ data class TextInput(
         styleManagerFactory.getInputTextStyle(styleId)
     ).apply {
         textInputView = this
-        isFocusable = true
-        isFocusableInTouchMode = true
         setData(this@TextInput, rootView)
         setUpOnTextChange(rootView)
         if (onFocus != null || onBlur != null) setUpOnFocusChange(rootView)
@@ -158,6 +156,8 @@ data class TextInput(
     }
 
     private fun EditText.setData(textInput: TextInput, rootView: RootView) {
+        isFocusable = true
+        isFocusableInTouchMode = true
         textInput.placeholder?.let { bind -> observeBindChanges(rootView, this, bind) { it?.let { hint = it } } }
         textInput.value?.let { bind ->
             observeBindChanges(rootView, this, bind) { it?.let { setValue(it, rootView) } }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/TextInput.kt
@@ -93,6 +93,8 @@ data class TextInput(
         styleManagerFactory.getInputTextStyle(styleId)
     ).apply {
         textInputView = this
+        isFocusable = true
+        isFocusableInTouchMode = true
         setData(this@TextInput, rootView)
         setUpOnTextChange(rootView)
         if (onFocus != null || onBlur != null) setUpOnFocusChange(rootView)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/InputTextTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/InputTextTest.kt
@@ -105,5 +105,7 @@ class TextInputTest : BaseComponentTest() {
         verify(exactly = once()) { editText.isEnabled = DISABLED }
         verify(exactly = once()) { editText.visibility = View.INVISIBLE }
         verify(exactly = once()) { editText.inputType = InputType.TYPE_CLASS_NUMBER }
+        verify(exactly = once()) { editText.isFocusable = true }
+        verify(exactly = once()) { editText.isFocusableInTouchMode = true }
     }
 }


### PR DESCRIPTION
### Related Issues

Closes #936 

### Description and Example

In some applications, the component `TextInput` didn't has focusing, set programmatically the possible to component has a focus

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
