### PR TITLE
fix: iOS - multiple expression binding when using cache

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/OperationsScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/OperationsScreen.swift
@@ -51,12 +51,22 @@ let operationsScreen: Screen = {
                 Text("@{sum(context1, 4)}")
                 Text("@{sum(context1, context2)}")
                 Text("@{sum(context1, context2)} teste: \\@{sum(context1, context2)}, 4: @{sum(2, 2)}")
+                Text("@{context1} + @{context2}")
                 Button(
-                    text: "update",
+                    text: "update 1",
                     onPress: [
                         SetContext(
                             contextId: "context1",
                             value: 3
+                        )
+                    ]
+                )
+                Button(
+                    text: "update 2",
+                    onPress: [
+                        SetContext(
+                            contextId: "context2",
+                            value: 4
                         )
                     ]
                 )

--- a/iOS/Sources/Beagle/Sources/Components/TabView+Renderable/TabViewUIComponent.swift
+++ b/iOS/Sources/Beagle/Sources/Components/TabView+Renderable/TabViewUIComponent.swift
@@ -27,7 +27,7 @@ extension TabViewUIComponent {
         var unselectedIconColor: UIColor?
 
 // sourcery:inline:auto:TabViewUIComponent.Model.Init
-    init(
+     init(
         tabIndex: Int,
         tabViewItems: [TabItem],
         selectedTextColor: UIColor? = nil,

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Tests/UIView+ContextTests.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Tests/UIView+ContextTests.swift
@@ -119,8 +119,9 @@ final class UIViewContextTests: XCTestCase {
         leaf.contextMap = ["leaf": contextObservableLeaf]
 
         let singleExpression = SingleExpression.value(.binding(.init(context: "context", path: .init(nodes: [.key("a")]))))
+        let leafExpression = SingleExpression.value(.binding(.init(context: "leaf", path: .init(nodes: [.index(0)]))))
         let exp = ContextExpression.single(singleExpression)
-        let multipleExpression = ContextExpression.multiple(.init(nodes: [.string("exp: "), .expression(singleExpression)]))
+        let multipleExpression = ContextExpression.multiple(.init(nodes: [.string("exp: "), .expression(singleExpression), .string(", leaf: "), .expression(leafExpression)]))
 
         leaf.configBinding(for: exp) {
             leaf.text = $0
@@ -131,11 +132,11 @@ final class UIViewContextTests: XCTestCase {
         
         contextObservableRoot.value = Context(id: "context", value: ["a": "updated", "b": "2"])
         XCTAssertEqual(leaf.text, "updated")
-        XCTAssertEqual(leaf.placeholder, "exp: updated")
+        XCTAssertEqual(leaf.placeholder, "exp: updated, leaf: test")
         
         contextObservableRoot.value = Context(id: "context", value: ["a": 2])
         XCTAssertEqual(leaf.text, "2")
-        XCTAssertEqual(leaf.placeholder, "exp: 2")
+        XCTAssertEqual(leaf.placeholder, "exp: 2, leaf: test")
     }
     
     func testConfigBindingShouldNotRetainTheView() {

--- a/iOS/Sources/Beagle/Sources/ContextExpression/UIView+Context.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/UIView+Context.swift
@@ -226,11 +226,11 @@ extension UIView {
     private func evaluateWithCache<T: Decodable>(for expression: SingleExpression, contextId: String? = nil) -> T? {
         switch expression {
         case let .value(.binding(binding)):
-//            if contextId == nil || contextId == binding.context {
+            if contextId == nil || contextId == binding.context {
                 return evaluate(for: expression)
-//            } else {
-//                return transform(expressionLastValueMap[expression.rawValue] ?? .empty)
-//            }
+            } else {
+                return transform(expressionLastValueMap[binding.rawValue] ?? .empty)
+            }
         case let .value(.literal(literal)):
             return transform(literal.evaluate())
         case let .operation(operation):

--- a/iOS/Sources/Beagle/Sources/ContextExpression/UIView+Context.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/UIView+Context.swift
@@ -226,11 +226,11 @@ extension UIView {
     private func evaluateWithCache<T: Decodable>(for expression: SingleExpression, contextId: String? = nil) -> T? {
         switch expression {
         case let .value(.binding(binding)):
-            if contextId == nil || contextId == binding.context {
+//            if contextId == nil || contextId == binding.context {
                 return evaluate(for: expression)
-            } else {
-                return transform(expressionLastValueMap[expression.rawValue] ?? .empty)
-            }
+//            } else {
+//                return transform(expressionLastValueMap[expression.rawValue] ?? .empty)
+//            }
         case let .value(.literal(literal)):
             return transform(literal.evaluate())
         case let .operation(operation):


### PR DESCRIPTION
Related Issues

Closes #906

### Description and Example

Binding with multiple expression was not working correctly when using cache 

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.