### PR TITLE
fix: jacoco error on windows

### DIFF
--- a/android/beagle/src/test/java/br/com/zup/beagle/android/action/FormValidationTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/action/FormValidationTest.kt
@@ -17,35 +17,24 @@
 package br.com.zup.beagle.android.action
 
 import android.view.View
+import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.components.form.FormInput
 import br.com.zup.beagle.android.components.form.InputWidget
-import br.com.zup.beagle.android.components.utils.beagleComponent
 import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.testutil.RandomData
-import br.com.zup.beagle.android.widget.RootView
-import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
-import org.junit.Before
 import org.junit.Test
 
-class FormValidationTest {
+class FormValidationTest : BaseTest(){
 
-    @MockK
-    private lateinit var rootView: RootView
     @RelaxedMockK
     private lateinit var view: View
     @RelaxedMockK
     private lateinit var formInput: FormInput
     @RelaxedMockK
     private lateinit var inputWidget: InputWidget
-
-    @Before
-    fun setUp() {
-        MockKAnnotations.init(this)
-    }
 
     @Test
     fun `execute should iterate over errors and call onErrorMessage for errorFields`() {
@@ -57,7 +46,6 @@ class FormValidationTest {
                 FieldError(inputName, validationMessage)
             )
         )
-        every { view.beagleComponent } returns formInput
         every { formInput.name } returns inputName
         every { formInput.child } returns inputWidget
         formValidation.formInputs = listOf(formInput)


### PR DESCRIPTION
### Related Issues

#678 

### Description and Example

the command jacocoTestReport was failing on Windows, FormValidationTest had an every that was given a result to extension fun (View.beagleComponent), this extension fun was not used on FormValidation

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
