### PR TITLE
fix: resize view when inside the scroll layout

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/WebView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/WebView.kt
@@ -26,7 +26,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.expressionOrValueOf
-import br.com.zup.beagle.android.context.valueOf
 import br.com.zup.beagle.android.utils.observeBindChanges
 import br.com.zup.beagle.android.view.BeagleActivity
 import br.com.zup.beagle.android.view.ServerDrivenState

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/ScrollView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/layout/ScrollView.kt
@@ -63,10 +63,12 @@ data class ScrollView(
                     addChildrenViews(this, children, rootView, styleChild)
                 }
             } else {
+
                 viewFactory.makeScrollView(context).apply {
                     isVerticalScrollBarEnabled = scrollBarEnabled
                     addChildrenViews(this, children, rootView, styleChild)
                 }
+
             }, styleParent)
         }
     }
@@ -78,9 +80,12 @@ data class ScrollView(
         styleChild: Style
     ) {
         val viewGroup = viewFactory.makeBeagleFlexView(rootView, styleChild)
+
         children.forEach { component ->
-            viewGroup.addServerDrivenComponent(component)
+            viewGroup.addServerDrivenComponent(component, false)
         }
+
         scrollView.addView(viewGroup)
+        viewGroup.setHeightAutoAndDirtyAllViews()
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/YogaLayout.java
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/YogaLayout.java
@@ -34,6 +34,7 @@ import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
 import com.facebook.yoga.YogaNode;
+import com.facebook.yoga.YogaNodeJNIBase;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -106,10 +107,9 @@ public class YogaLayout extends ViewGroup {
             index = mYogaNode.getChildCount();
 
         mYogaNode.addChildAt(childNode, index);
-
     }
 
-    public void addView(View child, @Nullable YogaNode node){
+    public void addView(View child, @Nullable YogaNode node) {
         addView(child, node, -1);
     }
 
@@ -122,7 +122,7 @@ public class YogaLayout extends ViewGroup {
     @Override
     public void addView(View child, int index) {
         YogaNode node = null;
-        addView(child, node,index);
+        addView(child, node, index);
     }
 
     @Override
@@ -373,5 +373,16 @@ public class YogaLayout extends ViewGroup {
                 return MeasureSpec.UNSPECIFIED;
             }
         }
+    }
+
+    public void setHeightAutoAndDirtyAllViews() {
+
+        addOnLayoutChangeListener(new OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View view, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                mYogaNode.setHeightAuto();
+                ((YogaNodeJNIBase) mYogaNode).dirtyAllDescendants();
+            }
+        });
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/YogaLayout.java
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/YogaLayout.java
@@ -376,7 +376,6 @@ public class YogaLayout extends ViewGroup {
     }
 
     public void setHeightAutoAndDirtyAllViews() {
-
         addOnLayoutChangeListener(new OnLayoutChangeListener() {
             @Override
             public void onLayoutChange(View view, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
@@ -28,6 +28,7 @@ import br.com.zup.beagle.core.GhostComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.core.StyleComponent
+import com.facebook.yoga.YogaNodeJNIBase
 
 @SuppressLint("ViewConstructor")
 internal open class BeagleFlexView(
@@ -61,7 +62,7 @@ internal open class BeagleFlexView(
         val view = viewRendererFactory.make(serverDrivenComponent).build(rootView)
         if (addLayoutChangeListener) {
             view.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                invalidate(view)
+                (yogaNode as YogaNodeJNIBase).dirtyAllDescendants()
             }
         }
         super.addView(view, flexMapper.makeYogaNode(style))

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleFlexView.kt
@@ -17,7 +17,6 @@
 package br.com.zup.beagle.android.view.custom
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.view.View
 import br.com.zup.beagle.android.engine.mapper.FlexMapper
 import br.com.zup.beagle.android.engine.renderer.ViewRendererFactory
@@ -47,10 +46,12 @@ internal open class BeagleFlexView(
     var listenerOnViewDetachedFromWindow: (() -> Unit)? = null
 
     fun addView(child: View, style: Style) {
+
         super.addView(child, flexMapper.makeYogaNode(style))
     }
 
-    fun addServerDrivenComponent(serverDrivenComponent: ServerDrivenComponent) {
+    fun addServerDrivenComponent(serverDrivenComponent: ServerDrivenComponent,
+                                 addLayoutChangeListener: Boolean = true) {
         val component = if (serverDrivenComponent is GhostComponent) {
             serverDrivenComponent.child
         } else {
@@ -58,7 +59,11 @@ internal open class BeagleFlexView(
         }
         val style = (component as? StyleComponent)?.style ?: Style()
         val view = viewRendererFactory.make(serverDrivenComponent).build(rootView)
-        view.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> invalidate(view) }
+        if (addLayoutChangeListener) {
+            view.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                invalidate(view)
+            }
+        }
         super.addView(view, flexMapper.makeYogaNode(style))
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ScrollViewTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ScrollViewTest.kt
@@ -100,8 +100,11 @@ class ScrollViewTest : BaseComponentTest() {
         verify {
             anyConstructed<ViewFactory>().makeBeagleFlexView(rootView, style.first())
         }
-        verify(exactly = once()) { anyConstructed<ViewFactory>().makeHorizontalScrollView(context) }
-        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(components[0], false) }
+        verify(exactly = once()) {
+            anyConstructed<ViewFactory>().makeHorizontalScrollView(context)
+            beagleFlexView.addServerDrivenComponent(components[0], false)
+            beagleFlexView.setHeightAutoAndDirtyAllViews()
+        }
         assertEquals(false, scrollBarEnabled.captured)
         assertEquals(1.0, style[0].flex?.grow)
         assertEquals(FlexDirection.ROW, style[1].flex?.flexDirection)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ScrollViewTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/layout/ScrollViewTest.kt
@@ -56,7 +56,7 @@ class ScrollViewTest : BaseComponentTest() {
         every { scrollView.addView(any()) } just Runs
         every { horizontalScrollView.addView(any()) } just Runs
         every { anyConstructed<ViewFactory>().makeBeagleFlexView(any(), capture(style)) } returns beagleFlexView
-        every { beagleFlexView.addServerDrivenComponent(any()) } just Runs
+        every { beagleFlexView.addServerDrivenComponent(any(), false) } just Runs
         every { beagleFlexView.context } returns context
         every { anyConstructed<ViewFactory>().makeScrollView(any()) } returns scrollView
         every { anyConstructed<ViewFactory>().makeHorizontalScrollView(any()) } returns horizontalScrollView
@@ -101,7 +101,7 @@ class ScrollViewTest : BaseComponentTest() {
             anyConstructed<ViewFactory>().makeBeagleFlexView(rootView, style.first())
         }
         verify(exactly = once()) { anyConstructed<ViewFactory>().makeHorizontalScrollView(context) }
-        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(components[0]) }
+        verify(exactly = once()) { beagleFlexView.addServerDrivenComponent(components[0], false) }
         assertEquals(false, scrollBarEnabled.captured)
         assertEquals(1.0, style[0].flex?.grow)
         assertEquals(FlexDirection.ROW, style[1].flex?.flexDirection)


### PR DESCRIPTION
### Related Issues

Closes #929 

### Description and Example

When putting some views inside the scroll view with some layout height change the view not recalculate, create the strategy to inside the scroll view always layout change put the height to auto and dirty all the views.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
