### PR TITLE
refactor: remove deprecated from constructor

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -38,11 +38,7 @@ import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 
 @RegisterWidget
-data class Image
-@Deprecated("It was deprecated in version 1.2.2 and will" +
-    " be removed in a future version. Use constructor without bind",
-    replaceWith = ReplaceWith("Image(path, null)"))
-constructor(
+data class Image constructor(
     val path: Bind<ImagePath>,
     val mode: ImageContentMode? = null
 ) : WidgetView() {


### PR DESCRIPTION
### Related Issues

Closes #907 

### Description and Example

Actually, the new fields attribute was created to help more people and the actual constructor doesn't need to be deprecated.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
