### PR TITLE
fix: app crash when use a JSON without ScreenComponent on startActivity

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/ComponentRequester.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/ComponentRequester.kt
@@ -22,6 +22,7 @@ import br.com.zup.beagle.android.exception.BeagleException
 import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.android.view.mapper.toRequestData
 import br.com.zup.beagle.core.ServerDrivenComponent
+import kotlin.jvm.Throws
 
 internal class ComponentRequester(
     private val beagleApi: BeagleApi = BeagleApi(),

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
@@ -16,7 +16,6 @@
 
 package br.com.zup.beagle.android.view
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -32,13 +31,13 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import br.com.zup.beagle.R
 import br.com.zup.beagle.android.components.layout.Screen
-import br.com.zup.beagle.android.components.layout.ScreenComponent
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.utils.BeagleRetry
 import br.com.zup.beagle.android.utils.DeprecationMessages.DEPRECATED_STATE_LOADING
 import br.com.zup.beagle.android.utils.NewIntentDeprecatedConstants
 import br.com.zup.beagle.android.utils.toComponent
+import br.com.zup.beagle.android.utils.tryToDeserialize
 import br.com.zup.beagle.android.view.viewmodel.BeagleViewModel
 import br.com.zup.beagle.android.view.viewmodel.ViewState
 import br.com.zup.beagle.core.ServerDrivenComponent
@@ -219,7 +218,7 @@ abstract class BeagleActivity : AppCompatActivity() {
             screen?.let { screen ->
                 fetch(
                     ScreenRequest(""),
-                    beagleSerializer.deserializeComponent(screen) as ScreenComponent
+                    beagleSerializer.deserializeComponent(screen)
                 )
             } ?: run {
                 screenRequest?.let { request -> fetch(request) }
@@ -241,7 +240,7 @@ abstract class BeagleActivity : AppCompatActivity() {
         fetch(screenRequest, screen?.toComponent())
     }
 
-    private fun fetch(screenRequest: ScreenRequest, screenComponent: ScreenComponent? = null) {
+    private fun fetch(screenRequest: ScreenRequest, screenComponent: ServerDrivenComponent? = null) {
         val liveData = viewModel.fetchComponent(screenRequest, screenComponent)
         handleLiveData(liveData)
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
@@ -27,6 +27,7 @@ import br.com.zup.beagle.android.logger.BeagleLoggerProxy
 import br.com.zup.beagle.android.utils.BeagleRetry
 import br.com.zup.beagle.android.utils.CoroutineDispatchers
 import br.com.zup.beagle.android.view.ScreenRequest
+import br.com.zup.beagle.core.IdentifierComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -45,7 +46,7 @@ internal class BeagleViewModel(
     private val componentRequester: ComponentRequester = ComponentRequester()
 ) : ViewModel() {
 
-    fun fetchComponent(screenRequest: ScreenRequest, screen: ScreenComponent? = null): LiveData<ViewState> {
+    fun fetchComponent(screenRequest: ScreenRequest, screen: ServerDrivenComponent? = null): LiveData<ViewState> {
         return FetchComponentLiveData(screenRequest, screen, componentRequester,
             viewModelScope, ioDispatcher)
     }
@@ -60,7 +61,7 @@ internal class BeagleViewModel(
 
     private class FetchComponentLiveData(
         private val screenRequest: ScreenRequest,
-        private val screen: ScreenComponent?,
+        private val screen: ServerDrivenComponent?,
         private val componentRequester: ComponentRequester,
         private val coroutineScope: CoroutineScope,
         private val ioDispatcher: CoroutineDispatcher) : LiveData<ViewState>() {
@@ -75,6 +76,7 @@ internal class BeagleViewModel(
 
         private fun fetchComponents() {
             coroutineScope.launch(ioDispatcher) {
+                val identifier = getScreenIdentifier()
                 if (screenRequest.url.isNotEmpty()) {
                     try {
                         setLoading(true)
@@ -82,16 +84,18 @@ internal class BeagleViewModel(
                         postLiveDataResponse(ViewState.DoRender(screenRequest.url, component))
                     } catch (exception: BeagleException) {
                         if (screen != null) {
-                            postLiveDataResponse(ViewState.DoRender(screen.identifier, screen))
+                            postLiveDataResponse(ViewState.DoRender(identifier, screen))
                         } else {
                             postLiveDataResponse(ViewState.Error(exception) { fetchComponents() })
                         }
                     }
                 } else if (screen != null) {
-                    postLiveDataResponse(ViewState.DoRender(screen.identifier, screen))
+                    postLiveDataResponse(ViewState.DoRender(identifier, screen))
                 }
             }
         }
+
+        private fun getScreenIdentifier() = (screen as? IdentifierComponent)?.id
 
         private suspend fun postLiveDataResponse(viewState: ViewState) {
             postValue(viewState)

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import br.com.zup.beagle.android.components.layout.ScreenComponent
 import br.com.zup.beagle.android.data.ComponentRequester
-import br.com.zup.beagle.android.exception.BeagleApiException
 import br.com.zup.beagle.android.exception.BeagleException
 import br.com.zup.beagle.android.logger.BeagleLoggerProxy
 import br.com.zup.beagle.android.utils.BeagleRetry
@@ -76,7 +75,7 @@ internal class BeagleViewModel(
 
         private fun fetchComponents() {
             coroutineScope.launch(ioDispatcher) {
-                val identifier = getScreenIdentifier()
+                val identifier = getComponentIdentifier()
                 if (screenRequest.url.isNotEmpty()) {
                     try {
                         setLoading(true)
@@ -95,7 +94,9 @@ internal class BeagleViewModel(
             }
         }
 
-        private fun getScreenIdentifier() = (screen as? IdentifierComponent)?.id
+        private fun getComponentIdentifier() = (screen as? ScreenComponent)?.identifier ?: getIdentifierComponentId()
+
+        private fun getIdentifierComponentId() = (screen as? IdentifierComponent)?.id
 
         private suspend fun postLiveDataResponse(viewState: ViewState) {
             postValue(viewState)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModelTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModelTest.kt
@@ -87,7 +87,7 @@ class BeagleViewModelTest {
 
     @Test
     @Suppress("UNCHECKED_CAST")
-    fun `fetch should return render ViewState`() {
+    fun `GIVEN a screenRequest WHEN fetch SHOULD return render ViewState`() {
         // Given
         val screenRequest = ScreenRequest(RandomData.httpUrl())
 
@@ -103,7 +103,7 @@ class BeagleViewModelTest {
     }
 
     @Test
-    fun `fetch should return a error ViewState`() {
+    fun `GIVEN a screenRequest throws exception WHEN fetch SHOULD return a error ViewState`() {
         // Given
         val screenRequest = ScreenRequest(RandomData.httpUrl())
         val exception = BeagleException("Error")
@@ -121,7 +121,7 @@ class BeagleViewModelTest {
     }
 
     @Test
-    fun `fetch should return a error ViewState retry`() {
+    fun `GIVEN a screenRequest throws exception WHEN fetch SHOULD return a error ViewState retry`() {
         // Given
         val screenRequest = ScreenRequest(RandomData.httpUrl())
         val exception = BeagleException("Error")


### PR DESCRIPTION
### Related Issues

#973 

### Description and Example

Crash app when startActivity is called using a JSON without a ScreenComponent, this happen because in the method onResume on BeagleActivity, before call the fetch was doing a cast to ScreenComponent 

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
