### PR TITLE
fix: make extendsFromClass check all super classes in hierarchy

### DIFF
--- a/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/KotlinPoetExtensions.kt
+++ b/common/processor-utils/src/main/kotlin/br/com/zup/beagle/compiler/KotlinPoetExtensions.kt
@@ -26,6 +26,8 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import javax.lang.model.element.TypeElement
 import javax.lang.model.type.DeclaredType
+import javax.lang.model.type.TypeKind
+import javax.lang.model.type.TypeMirror
 
 internal val TypeName.kotlin: TypeName get() = JAVA_TO_KOTLIN[this] ?: this
 
@@ -50,9 +52,14 @@ fun TypeElement.implementsInterface(interfaceName: String): Boolean {
 }
 
 fun TypeElement.extendsFromClass(className: String): Boolean {
-    val typeMirror = ((this.superclass as DeclaredType)).asElement()
-    if (typeMirror.toString() == className) {
-        return true
+    var currentClass: TypeMirror = this.superclass
+    while (currentClass.kind != TypeKind.NONE) {
+        val typeMirror = (currentClass as DeclaredType).asElement()
+        if (typeMirror.toString() == className) {
+            return true
+        }
+        currentClass = (typeMirror as TypeElement).superclass
     }
+
     return false
 }


### PR DESCRIPTION
### Related Issues

Closes #964

### Description and Example

`extendsFromClass` should check all the class inheritance rather than just checking the first class of the inheritance.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.