### PR TITLE
fix: iOS DynamicObject set(value: with path:) behaviour

### DIFF
--- a/iOS/Sources/Beagle/Sources/Action/Types/SetContext.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/SetContext.swift
@@ -23,9 +23,8 @@ extension SetContext: Action {
         let valueEvaluated = value.evaluate(with: origin)
         let contextObserver = origin.getContext(with: contextId)
 
-        if var contextValue = contextObserver?.value.value, let path = path {
-            contextValue.set(valueEvaluated, forPath: path)
-            contextObserver?.value = Context(id: contextId, value: contextValue)
+        if let contextValue = contextObserver?.value.value, let path = path {
+            contextObserver?.value = Context(id: contextId, value: contextValue.set(valueEvaluated, with: path))
         } else {
             contextObserver?.value = Context(id: contextId, value: valueEvaluated)
         }

--- a/iOS/Sources/Beagle/Sources/ContextExpression/DynamicObject.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/DynamicObject.swift
@@ -128,77 +128,47 @@ extension DynamicObject {
 // MARK: Set value with Path
 
 extension DynamicObject {
-
-    mutating func set(_ value: DynamicObject, forPath path: Path) {
-        let object = compilePath(path, in: value)
-        self = mergeDynamicObjects(self, object)
-    }
-}
-
-private func compilePath(_ path: Path, in value: DynamicObject) -> DynamicObject {
-    guard let current = path.nodes.first else {
-        return value
+    func set(_ value: DynamicObject, with path: Path) -> DynamicObject {
+        return set(value, with: path.nodes[...])
     }
     
-    let remainingPath = Path(nodes: Array(path.nodes[1..<path.nodes.count]))
-    
-    switch current {
-    case .key(let name):
-        return .dictionary([name: compilePath(remainingPath, in: value)])
-    
-    case .index(let index):
-        var array = [DynamicObject].init(
-            repeating: .empty,
-            count: index + 1
-        )
+    private func set(_ value: DynamicObject, with path: ArraySlice<Path.Node>) -> DynamicObject {
+        guard let node = path.first else { return value }
+        let newPath = path.dropFirst()
         
-        array[index] = compilePath(remainingPath, in: value)
-        
-        return .array(array)
-    }
-}
-
-private func mergeDynamicObjects(_ object1: DynamicObject, _ object2: DynamicObject) -> DynamicObject {
-    switch(object1, object2) {
-        
-    case let (.array(array1), .array(array2)):
-        return mergeArrays(array1, array2)
-    
-    case let (.dictionary(dict1), .dictionary(dict2)):
-        return mergeDictionaries(dict1, dict2)
-        
-    default:
-        return object2
-    }
-}
-
-private func mergeArrays(_ arrray1: [DynamicObject], _ array2: [DynamicObject]) -> DynamicObject {
-    func _select(_ e1: DynamicObject?, _ e2: DynamicObject?) -> DynamicObject? {
-        switch e2 {
-        case nil, .empty: return e1
-        default: return e2
+        switch node {
+        case let .key(key):
+            if case var .dictionary(dictionary) = self {
+                if let old = dictionary[key] {
+                    dictionary[key] = old.set(value, with: newPath)
+                    return .dictionary(dictionary)
+                }
+                dictionary[key] = DynamicObject.empty.set(value, with: newPath)
+                return .dictionary(dictionary)
+            }
+            return .dictionary([key: DynamicObject.empty.set(value, with: newPath)])
+        case let .index(index):
+            if case var .array(array) = self {
+                if let old = array[safe: index] {
+                    array[index] = old.set(value, with: newPath)
+                    return .array(array)
+                }
+                var newArray = dynamicArray(count: index + 1, with: array)
+                newArray[index] = DynamicObject.empty.set(value, with: newPath)
+                return .array(newArray)
+            }
+            var newArray = dynamicArray(count: index + 1)
+            newArray[index] = DynamicObject.empty.set(value, with: newPath)
+            return .array(newArray)
         }
     }
     
-    let size = max(arrray1.count, array2.count)
-    var array = [DynamicObject](repeating: .empty, count: size)
-    for i in 0..<size {
-        if let element = _select(arrray1[safe: i], array2[safe: i]) {
-            array[i] = element
+    private func dynamicArray(count: Int, with array: [DynamicObject]? = nil) -> [DynamicObject] {
+        var result: [DynamicObject] = .init(repeating: .empty, count: count)
+        guard let array = array, array.count < count else { return result }
+        for (index, element) in array.enumerated() {
+            result[index] = element
         }
+        return result
     }
-    
-    return .array(array)
-}
-
-private func mergeDictionaries(
-    _ dict1: [String: DynamicObject],
-    _ dict2: [String: DynamicObject]
-) -> DynamicObject {
-    var dict = dict1
-    dict.merge(dict2, uniquingKeysWith: { obj1, obj2 in
-        mergeDynamicObjects(obj1, obj2)
-    })
-    
-    return .dictionary(dict)
 }

--- a/iOS/Sources/Beagle/Sources/ContextExpression/GlobalContext.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/GlobalContext.swift
@@ -61,9 +61,8 @@ public class DefaultGlobalContext: GlobalContext {
         guard let pathObject = path.toPath() else {
             return
         }
-        var contextValue = context.value.value
-        contextValue.set(value, forPath: pathObject)
-        context.value = Context(id: globalId, value: contextValue)
+        let contextValue = context.value.value
+        context.value = Context(id: globalId, value: contextValue.set(value, with: pathObject))
     }
     
     public func get(path: String? = nil) -> DynamicObject {

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Tests/DynamicObjectTests.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Tests/DynamicObjectTests.swift
@@ -26,7 +26,8 @@ final class DynamicObjectTests: XCTestCase {
         // Given
         let object: DynamicObject = [
             "a": "default",
-            "c": [1, 2]
+            "c": [1, 2],
+            "d": [["name": "John", "code": "123"], ["name": "Doe", "code": "321"]]
         ]
 
         let result: [Result] = [
@@ -35,16 +36,16 @@ final class DynamicObjectTests: XCTestCase {
             "c[0]",
             "c[4]",
             "",
-            "[4]"
+            "[4]",
+            "d[0].name",
+            "d[1].code",
+            "d[2].name"
         ]
         .compactMap { Path(rawValue: $0) }
 
         // When
         .map {
-            var obj = object
-            obj.set("UPDATED", forPath: $0)
-            
-            return Result(input: $0.rawValue, output: obj)
+            Result(input: $0.rawValue, output: object.set("UPDATED", with: $0))
         }
 
         // Then

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Tests/__Snapshots__/DynamicObjectTests/testSetObjectWithVariousPaths.1.json
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Tests/__Snapshots__/DynamicObjectTests/testSetObjectWithVariousPaths.1.json
@@ -6,6 +6,16 @@
       "c" : [
         1,
         2
+      ],
+      "d" : [
+        {
+          "code" : "123",
+          "name" : "John"
+        },
+        {
+          "code" : "321",
+          "name" : "Doe"
+        }
       ]
     }
   },
@@ -17,6 +27,16 @@
       "c" : [
         1,
         2
+      ],
+      "d" : [
+        {
+          "code" : "123",
+          "name" : "John"
+        },
+        {
+          "code" : "321",
+          "name" : "Doe"
+        }
       ]
     }
   },
@@ -27,6 +47,16 @@
       "c" : [
         "UPDATED",
         2
+      ],
+      "d" : [
+        {
+          "code" : "123",
+          "name" : "John"
+        },
+        {
+          "code" : "321",
+          "name" : "Doe"
+        }
       ]
     }
   },
@@ -40,6 +70,16 @@
         null,
         null,
         "UPDATED"
+      ],
+      "d" : [
+        {
+          "code" : "123",
+          "name" : "John"
+        },
+        {
+          "code" : "321",
+          "name" : "Doe"
+        }
       ]
     }
   },
@@ -52,5 +92,68 @@
       null,
       "UPDATED"
     ]
+  },
+  {
+    "input" : "d[0].name",
+    "output" : {
+      "a" : "default",
+      "c" : [
+        1,
+        2
+      ],
+      "d" : [
+        {
+          "code" : "123",
+          "name" : "UPDATED"
+        },
+        {
+          "code" : "321",
+          "name" : "Doe"
+        }
+      ]
+    }
+  },
+  {
+    "input" : "d[1].code",
+    "output" : {
+      "a" : "default",
+      "c" : [
+        1,
+        2
+      ],
+      "d" : [
+        {
+          "code" : "123",
+          "name" : "John"
+        },
+        {
+          "code" : "UPDATED",
+          "name" : "Doe"
+        }
+      ]
+    }
+  },
+  {
+    "input" : "d[2].name",
+    "output" : {
+      "a" : "default",
+      "c" : [
+        1,
+        2
+      ],
+      "d" : [
+        {
+          "code" : "123",
+          "name" : "John"
+        },
+        {
+          "code" : "321",
+          "name" : "Doe"
+        },
+        {
+          "name" : "UPDATED"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
### Related Issues

Closes #986 

### Description and Example

Fixes a wrong behaviour in set(value: with path:) method in DynamicObject. Example:

```json
{
    "d": [
        {
            "name": "John", 
            "code": "123"
        }
    ]
}

set "UPDATED" with path "d[0].name" returns
{
    "d": [
        {
            "name": "UPDATED"
        }
    ]
}

expected was
{
    "d": [
        {
            "name": "UPDATED",
            "code": "123"
        }
    ]
}
```


### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
