### PR TITLE
fix: fragment transition toolbar glitch

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
@@ -97,7 +97,7 @@ private val beagleSerializer: BeagleSerializer = BeagleSerializer()
 private const val FIRST_SCREEN_REQUEST_KEY = "FIRST_SCREEN_REQUEST_KEY"
 private const val FIRST_SCREEN_KEY = "FIRST_SCREEN_KEY"
 
-abstract class BeagleActivity : AppCompatActivity() {
+abstract class BeagleActivity : AppCompatActivity(), OnFragmentCallback {
 
     private val viewModel by lazy { ViewModelProvider(this).get(BeagleViewModel::class.java) }
     private val screenRequest by lazy { intent.extras?.getParcelable<ScreenRequest>(FIRST_SCREEN_REQUEST_KEY) }
@@ -245,19 +245,23 @@ abstract class BeagleActivity : AppCompatActivity() {
         handleLiveData(liveData)
     }
 
+    override fun fragmentResume() {
+        onServerDrivenContainerStateChanged(ServerDrivenState.Success)
+        onServerDrivenContainerStateChanged(ServerDrivenState.Finished)
+    }
+
     private fun handleLiveData(state: LiveData<ViewState>) {
         state.observe(this, Observer {
             when (it) {
                 is ViewState.Error -> {
                     onServerDrivenContainerStateChanged(ServerDrivenState.Error(it.throwable, it.retry))
+                    onServerDrivenContainerStateChanged(ServerDrivenState.Finished)
                 }
                 is ViewState.Loading -> {
                     onServerDrivenContainerStateChanged(ServerDrivenState.Loading(it.value))
 
                     if (it.value) {
                         onServerDrivenContainerStateChanged(ServerDrivenState.Started)
-                    } else {
-                        onServerDrivenContainerStateChanged(ServerDrivenState.Finished)
                     }
                 }
                 is ViewState.DoRender -> {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
@@ -265,7 +265,6 @@ abstract class BeagleActivity : AppCompatActivity(), OnFragmentCallback {
                     }
                 }
                 is ViewState.DoRender -> {
-                    onServerDrivenContainerStateChanged(ServerDrivenState.Success)
                     showScreen(it.screenId, it.component)
                 }
             }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleFragment.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleFragment.kt
@@ -61,8 +61,7 @@ internal class BeagleFragment : Fragment() {
         if (context is OnFragmentCallback) {
             mListener = context
         } else {
-            throw ClassCastException(context.toString()
-                .toString() + " must implement OnFragmentCallback")
+            throw ClassCastException(context.toString() +" must implement OnFragmentCallback")
         }
     }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleFragment.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleFragment.kt
@@ -16,6 +16,7 @@
 
 package br.com.zup.beagle.android.view
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -35,6 +36,8 @@ internal class BeagleFragment : Fragment() {
         beagleSerializer.deserializeComponent(json)
     }
 
+    private lateinit var mListener: OnFragmentCallback
+
     companion object {
 
         @JvmStatic
@@ -53,6 +56,21 @@ internal class BeagleFragment : Fragment() {
         private const val JSON_SCREEN_KEY = "JSON_SCREEN_KEY"
     }
 
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        if (context is OnFragmentCallback) {
+            mListener = context
+        } else {
+            throw ClassCastException(context.toString()
+                .toString() + " must implement OnFragmentCallback")
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        mListener.fragmentResume()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -65,4 +83,8 @@ internal class BeagleFragment : Fragment() {
             }
         }
     }
+}
+
+interface OnFragmentCallback {
+    fun fragmentResume()
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleFragment.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleFragment.kt
@@ -61,7 +61,7 @@ internal class BeagleFragment : Fragment() {
         if (context is OnFragmentCallback) {
             mListener = context
         } else {
-            throw ClassCastException(context.toString() +" must implement OnFragmentCallback")
+            throw ClassCastException("$context must implement OnFragmentCallback")
         }
     }
 


### PR DESCRIPTION
### Related Issues

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->
Closes #839 
### Description and Example
Create a interface to communicate between BeagleFragment and BeagleActivity to send event when fragment is created, this way we can resend this event in BeagleActivity through onServerDrivenContainerStateChanged callback and avoid user to animate toolbar in wrong states.
<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most imporant thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
