### PR TITLE
fix: parse color when is RGB size

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ColorUtils.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ColorUtils.kt
@@ -21,11 +21,13 @@ import android.graphics.Color
 internal object ColorUtils {
 
     fun hexColor(hexColor: String): Int {
-        return when (hexColor.count()){
-            9-> Color.parseColor(formatHexColorAlpha(hexColor))
+        return when (hexColor.getColorLength()) {
+            8 -> Color.parseColor(formatHexColorAlpha(hexColor))
             else -> Color.parseColor(formatHexColor(hexColor))
         }
     }
+
+    private fun String.getColorLength() = removePrefix("#").length
 
     private fun formatHexColorAlpha(color: String): String {
         return "^#([0-9A-F]{6})([0-9A-F]{2})$"
@@ -34,9 +36,25 @@ internal object ColorUtils {
     }
 
     private fun formatHexColor(color: String): String {
-        return "^#([0-9A-F])([0-9A-F])([0-9A-F])([0-9A-F])?$"
+        val colorLength = color.getColorLength()
+        return generateRegexString(colorLength)
             .toRegex(RegexOption.IGNORE_CASE)
-            .replace(color,"#\$4\$4\$1\$1\$2\$2\$3\$3")
+            .replace(color, generateReplacement(colorLength))
     }
 
+    private fun generateRegexString(colorLength: Int): String {
+        return if (colorLength == 3) {
+            "^#([0-9A-F])([0-9A-F])([0-9A-F])?$"
+        } else {
+            "^#([0-9A-F])([0-9A-F])([0-9A-F])([0-9A-F])?$"
+        }
+    }
+
+    private fun generateReplacement(colorLength: Int): String {
+        return if (colorLength == 3) {
+            "#\$1\$1\$2\$2\$3\$3"
+        } else {
+            "#\$4\$4\$1\$1\$2\$2\$3\$3"
+        }
+    }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ColorUtils.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ColorUtils.kt
@@ -21,13 +21,12 @@ import android.graphics.Color
 internal object ColorUtils {
 
     fun hexColor(hexColor: String): Int {
-        return when (hexColor.getColorLength()) {
-            8 -> Color.parseColor(formatHexColorAlpha(hexColor))
-            else -> Color.parseColor(formatHexColor(hexColor))
+        return when (hexColor.length) {
+            4 -> Color.parseColor(formatHexRGBColor(hexColor))
+            9 -> Color.parseColor(formatHexColorAlpha(hexColor))
+            else -> Color.parseColor(formatHexRGBAColor(hexColor))
         }
     }
-
-    private fun String.getColorLength() = removePrefix("#").length
 
     private fun formatHexColorAlpha(color: String): String {
         return "^#([0-9A-F]{6})([0-9A-F]{2})$"
@@ -35,26 +34,15 @@ internal object ColorUtils {
             .replace(color, "#\$2\$1")
     }
 
-    private fun formatHexColor(color: String): String {
-        val colorLength = color.getColorLength()
-        return generateRegexString(colorLength)
+    private fun formatHexRGBColor(color: String): String {
+        return "^#([0-9A-F])([0-9A-F])([0-9A-F])?$"
             .toRegex(RegexOption.IGNORE_CASE)
-            .replace(color, generateReplacement(colorLength))
+            .replace(color, "#\$1\$1\$2\$2\$3\$3")
     }
 
-    private fun generateRegexString(colorLength: Int): String {
-        return if (colorLength == 3) {
-            "^#([0-9A-F])([0-9A-F])([0-9A-F])?$"
-        } else {
-            "^#([0-9A-F])([0-9A-F])([0-9A-F])([0-9A-F])?$"
-        }
-    }
-
-    private fun generateReplacement(colorLength: Int): String {
-        return if (colorLength == 3) {
-            "#\$1\$1\$2\$2\$3\$3"
-        } else {
-            "#\$4\$4\$1\$1\$2\$2\$3\$3"
-        }
+    private fun formatHexRGBAColor(color: String): String {
+        return "^#([0-9A-F])([0-9A-F])([0-9A-F])([0-9A-F])?$"
+            .toRegex(RegexOption.IGNORE_CASE)
+            .replace(color, "#\$4\$4\$1\$1\$2\$2\$3\$3")
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ColorUtilsTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ColorUtilsTest.kt
@@ -23,6 +23,8 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkStatic
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -33,9 +35,13 @@ class ColorUtilsTest {
 
     @Before
     fun setUp() {
-        mockkObject(ColorUtils)
         mockkStatic(Color::class)
         every { Color.parseColor(capture(colorSlot)) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Color::class)
     }
 
     @Test
@@ -47,12 +53,11 @@ class ColorUtilsTest {
         ColorUtils.hexColor(colorRgb)
 
         // Then
-        assertEquals("#11BB33",colorSlot.captured)
-
+        assertEquals("#11BB33", colorSlot.captured)
     }
 
     @Test
-    fun hexColor_should_return_AA55CC_when_A5C_is_given() {
+    fun hexColor_should_return_22FF33_when_2F3_is_given() {
         // Given
         val colorRgb = "#2f3"
 
@@ -60,8 +65,7 @@ class ColorUtilsTest {
         ColorUtils.hexColor(colorRgb)
 
         // Then
-        assertEquals("#22ff33",colorSlot.captured)
-
+        assertEquals("#22ff33", colorSlot.captured)
     }
 
     @Test
@@ -73,8 +77,7 @@ class ColorUtilsTest {
         ColorUtils.hexColor(colorRgba)
 
         // Then
-        assertEquals("#2266EEFF",colorSlot.captured)
-
+        assertEquals("#2266EEFF", colorSlot.captured)
     }
 
     @Test
@@ -86,8 +89,7 @@ class ColorUtilsTest {
         ColorUtils.hexColor(colorRgba)
 
         // Then
-        assertEquals("#cc9900bb",colorSlot.captured)
-
+        assertEquals("#cc9900bb", colorSlot.captured)
     }
 
     @Test
@@ -99,8 +101,7 @@ class ColorUtilsTest {
         ColorUtils.hexColor(colorRgb)
 
         // Then
-        assertEquals("#A3D256",colorSlot.captured)
-
+        assertEquals("#A3D256", colorSlot.captured)
     }
 
     @Test
@@ -112,8 +113,7 @@ class ColorUtilsTest {
         ColorUtils.hexColor(colorRgb)
 
         // Then
-        assertEquals("#584bcd",colorSlot.captured)
-
+        assertEquals("#584bcd", colorSlot.captured)
     }
 
     @Test
@@ -125,8 +125,7 @@ class ColorUtilsTest {
         ColorUtils.hexColor(colorRgba)
 
         // Then
-        assertEquals("#2018FAE3",colorSlot.captured)
-
+        assertEquals("#2018FAE3", colorSlot.captured)
     }
 
     @Test
@@ -138,7 +137,6 @@ class ColorUtilsTest {
         ColorUtils.hexColor(colorRgba)
 
         // Then
-        assertEquals("#30abc123",colorSlot.captured)
-
+        assertEquals("#30abc123", colorSlot.captured)
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ColorUtilsTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ColorUtilsTest.kt
@@ -45,7 +45,7 @@ class ColorUtilsTest {
     }
 
     @Test
-    fun hexColor_should_return_11BB33_when_1B3_is_given() {
+    fun `GIVEN #1B3 WHEN hexColor is called THEN consider #11BB33`() {
         // Given
         val colorRgb = "#1B3"
 
@@ -57,7 +57,7 @@ class ColorUtilsTest {
     }
 
     @Test
-    fun hexColor_should_return_22FF33_when_2F3_is_given() {
+    fun `GIVEN #2F3 WHEN hexColor is called THEN consider #22FF33`() {
         // Given
         val colorRgb = "#2f3"
 
@@ -69,7 +69,7 @@ class ColorUtilsTest {
     }
 
     @Test
-    fun hexColor_should_return_66EEFF22_when_6EF2_is_given() {
+    fun `GIVEN #6EF2 WHEN hexColor is called THEN consider #2266EEFF`() {
         // Given
         val colorRgba = "#6EF2"
 
@@ -81,7 +81,7 @@ class ColorUtilsTest {
     }
 
     @Test
-    fun hexColor_should_return_cc9900bb_when_90bc_is_given() {
+    fun `GIVEN #90BC WHEN hexColor is called THEN consider #CC9900BB`() {
         // Given
         val colorRgba = "#90bc"
 
@@ -93,7 +93,7 @@ class ColorUtilsTest {
     }
 
     @Test
-    fun hexColor_should_return_A3D256_when_A3D256_is_given() {
+    fun `GIVEN #A3D256 WHEN hexColor is called THEN consider #A3D256`() {
         // Given
         val colorRgb = "#A3D256"
 
@@ -105,7 +105,7 @@ class ColorUtilsTest {
     }
 
     @Test
-    fun hexColor_should_return_584bcd_when_584bcd_is_given() {
+    fun `GIVEN #584BCD WHEN hexColor is called THEN consider #584BCD`() {
         // Given
         val colorRgb = "#584bcd"
 
@@ -117,7 +117,7 @@ class ColorUtilsTest {
     }
 
     @Test
-    fun hexColor_should_return_2018FAE3_when_18FAE320_is_given() {
+    fun `GIVEN #18FAE320 WHEN hexColor is called THEN consider #2018FAE3`() {
         // Given
         val colorRgba = "#18FAE320"
 
@@ -129,7 +129,7 @@ class ColorUtilsTest {
     }
 
     @Test
-    fun hexColor_should_return_50ae2g5c_when_ae2g5c50_is_given() {
+    fun `GIVEN #ABC12330 WHEN hexColor is called THEN consider #30ABC123`() {
         // Given
         val colorRgba = "#abc12330"
 

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
@@ -27,6 +27,8 @@ import br.com.zup.beagle.android.components.Text
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.components.layout.Screen
 import br.com.zup.beagle.android.utils.toView
+import br.com.zup.beagle.core.Style
+import br.com.zup.beagle.ext.applyStyle
 
 class ImageViewFragment : Fragment() {
     override fun onCreateView(
@@ -42,7 +44,11 @@ class ImageViewFragment : Fragment() {
                             placeholder = ImagePath.Local("imageBeagle")
                         )
                     ),
-                    Text(text = "Opa!!!")
+                    Text(text = "Opa!!!").applyStyle(
+                        Style(
+                            backgroundColor = "#CCC"
+                        )
+                    )
                 )
             )
         )

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
@@ -44,7 +44,7 @@ class ImageViewFragment : Fragment() {
                             placeholder = ImagePath.Local("imageBeagle")
                         )
                     ),
-                    Text(text = "Opa!!!").applyStyle(
+                    Text(text = "Test!!!").applyStyle(
                         Style(
                             backgroundColor = "#CCC"
                         )


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

### Related Issues

Closes #1031 

### Description and Example

This PR fixes the error when colors in the RGB format were not parsed in the Beagle in APIs 29 and bellow.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
