### PR TITLE
fix: image and simple form test

### DIFF
--- a/android/automated-tests/src/androidTest/assets/features/SimpleFormScreen.feature
+++ b/android/automated-tests/src/androidTest/assets/features/SimpleFormScreen.feature
@@ -33,6 +33,7 @@ Feature: SimpleForm Component Validation
         And insert text <textValue>
         And I click on input with hint Street
         And hide keyboard
+        And Scroll to Enviar
         And I click on button Enviar
         Then confirm popup should appear correctly
 

--- a/android/automated-tests/src/androidTest/kotlin/br/com/zup/beagle/automatedTests/cucumber/steps/GenericSteps.kt
+++ b/android/automated-tests/src/androidTest/kotlin/br/com/zup/beagle/automatedTests/cucumber/steps/GenericSteps.kt
@@ -29,6 +29,11 @@ class GenericSteps {
             .clickOnText(string1)
     }
 
+    @When("^Scroll to (.*)$")
+    fun scrollTo(string1: String?) {
+        ScreenRobot().scrollTo(string1)
+    }
+
     @Then("^The Text should show (.*)$")
     fun textShouldShow(string1: String?) {
         ScreenRobot().checkViewContainsText(string1)

--- a/android/automated-tests/src/androidTest/kotlin/br/com/zup/beagle/automatedTests/cucumber/steps/ImageScreenSteps.kt
+++ b/android/automated-tests/src/androidTest/kotlin/br/com/zup/beagle/automatedTests/cucumber/steps/ImageScreenSteps.kt
@@ -49,7 +49,7 @@ class ImageScreenSteps {
             .checkViewContainsText(IMAGE_SCREEN_HEADER, true)
     }
 
-    @Then("^image screen should render all text attributes correctly$")
+    @Then("^image screen should render all image attributes correctly$")
     fun checkImageScreenTexts() {
         ScreenRobot()
             .checkViewContainsText(IMAGE_TEXT_1)


### PR DESCRIPTION
### Description and Example

Fix image test and simple form test, changing the value on Then of ImageScreenSteps and create a scrollTo on simpleform to scroll to button before click

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
