### PR TITLE
refactor: simpleform inherit contextComponent

### DIFF
--- a/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/form/SimpleForm.kt
+++ b/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/form/SimpleForm.kt
@@ -18,6 +18,7 @@ package br.com.zup.beagle.widget.form
 
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.widget.action.Action
+import br.com.zup.beagle.widget.context.ContextComponent
 import br.com.zup.beagle.widget.context.ContextData
 
 /**
@@ -31,7 +32,7 @@ import br.com.zup.beagle.widget.context.ContextData
  *
  */
 class SimpleForm(
-    val context: ContextData? = null,
+    override val context: ContextData? = null,
     val onSubmit: List<Action>,
     val children: List<ServerDrivenComponent>
-) : ServerDrivenComponent
+) : ServerDrivenComponent, ContextComponent


### PR DESCRIPTION
### Related Issues
Closes #1038 

### Description and Example
SimpleForm component have the context attribute, however all components must inherit from contextComponent to override context attribute

Expected: All components that have the context attribute, have to inherit from ContextComponents to override context attribute

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
