### PR TITLE
fix: http client crash when set body and request fail

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpClientDefault.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpClientDefault.kt
@@ -82,7 +82,7 @@ internal class HttpClientDefault : HttpClient, CoroutineScope {
         addRequestMethod(urlConnection, request.method)
 
         if (request.body != null) {
-            setRequestBody(urlConnection, request.body)
+            setRequestBody(urlConnection, request)
         }
 
         try {
@@ -115,9 +115,13 @@ internal class HttpClientDefault : HttpClient, CoroutineScope {
         }
     }
 
-    private fun setRequestBody(urlConnection: HttpURLConnection, data: String) {
-        urlConnection.setRequestProperty("Content-Length", data.length.toString())
-        urlConnection.outputStream.write(data.toByteArray())
+    private fun setRequestBody(urlConnection: HttpURLConnection, request: RequestData) {
+        urlConnection.setRequestProperty("Content-Length", request.body?.length.toString())
+        try {
+            urlConnection.outputStream.write(request.body?.toByteArray())
+        } catch (e: Exception) {
+            throw BeagleApiException(ResponseData(-1, data = byteArrayOf()), request)
+        }
     }
 
     private fun createResponseData(urlConnection: HttpURLConnection): ResponseData {

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/networking/HttpClientDefaultTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/networking/HttpClientDefaultTest.kt
@@ -46,6 +46,7 @@ import java.net.URL
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import java.net.UnknownServiceException
 
 private val BYTE_ARRAY_DATA = byteArrayOf()
 private const val STATUS_CODE = 200
@@ -173,6 +174,25 @@ class HttpClientDefaultTest {
             }
 
         }, onError = {})
+
+    }
+
+    @Test
+    fun `Given request with method type POST and with body content WHEN call execute request should return error`() = runBlockingTest {
+        // Given
+        val data = RandomData.string()
+        val requestData = RequestData(
+            uri = uri,
+            body = data,
+            method = HttpMethod.POST
+        )
+        every { httpURLConnection.outputStream } throws UnknownServiceException()
+
+        // When
+        urlRequestDispatchingDefault.execute(requestData, onSuccess = {
+        }, onError = {
+            assertEquals(ResponseData(-1, data = byteArrayOf()), it)
+        })
 
     }
 


### PR DESCRIPTION
### Description and Example

this code crashing the application: Container(
            onInit = listOf(SendRequest(url = "http://localhost:8081/loan/25/simulate",
                method = RequestActionMethod.POST,
                data = "test"))) 
add in requestbody try catch to handle exception

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
