### PR TITLE
fix: maxSize cache of ContextBinding

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextBinding.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextBinding.kt
@@ -39,6 +39,6 @@ internal data class ContextBinding(
     val cache: LruCache<String, Any> = LruCache(MAX_SIZE_LRU_CACHE)
 ) {
     companion object {
-        const val MAX_SIZE_LRU_CACHE = 300
+        private const val MAX_SIZE_LRU_CACHE = 300
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextBinding.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextBinding.kt
@@ -17,7 +17,6 @@
 package br.com.zup.beagle.android.context
 
 import androidx.collection.LruCache
-import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.utils.Observer
 
 internal data class Binding<T>(
@@ -37,8 +36,9 @@ internal data class Binding<T>(
 internal data class ContextBinding(
     var context: ContextData,
     val bindings: MutableSet<Binding<*>> = mutableSetOf(),
-    val cache: LruCache<String, Any> = LruCache(
-        BeagleEnvironment.beagleSdk.config.cache.memoryMaximumCapacity.takeIf { it > 0 }
-            ?: BeagleEnvironment.beagleSdk.config.cache.size
-    )
-)
+    val cache: LruCache<String, Any> = LruCache(MAX_SIZE_LRU_CACHE)
+) {
+    companion object {
+        const val MAX_SIZE_LRU_CACHE = 300
+    }
+}


### PR DESCRIPTION
### Related Issues

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

https://github.com/ZupIT/beagle/issues/1047

### Description and Example

When starting the beagleconfig with Cache (enabled = false, maxAge = 0), it started ContextBinding using the value 0 for the stack size of your LRU cache. Soon, it threw an exception: IllegalArgumentException ("maxSize <= 0").

<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most imporant thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
