### PR TITLE
fix: iOS - Fix Path Parser

### DIFF
--- a/iOS/Schema/Sources/ContextExpression/Parser.swift
+++ b/iOS/Schema/Sources/ContextExpression/Parser.swift
@@ -80,7 +80,7 @@ let pathIndexNode: Parser<Path.Node> = zip(
     .index(int)
 }
 
-let pathKeyNode: Parser<Path.Node> = prefix(with: #"^(?!true|false|null|\d)\w+\b(?!\()"#).map { .key($0) }
+let pathKeyNode: Parser<Path.Node> = prefix(with: #"^\w+\b(?!\()"#).map { .key($0) }
 
 let pathHeadNodes: Parser<[Path.Node]> = zip(
     zeroOrOne(pathKeyNode),
@@ -133,8 +133,8 @@ let literal: Parser<Literal> = oneOf(
 // MARK: Value
 
 let value: Parser<Value> = oneOf(
-    binding.map { .binding($0) },
-    literal.map { .literal($0) }
+    literal.map { .literal($0) },
+    binding.map { .binding($0) }
 )
 
 // MARK: Operation

--- a/iOS/Schema/Sources/ContextExpression/Tests/ExpressionTests.swift
+++ b/iOS/Schema/Sources/ContextExpression/Tests/ExpressionTests.swift
@@ -28,6 +28,7 @@ final class ExpressionTests: XCTestCase {
             "@{client}",
             "@{client2.name}",
             "@{client_[2].matrix[1][1]}",
+            "@{2client.phones[0]}",
             simple,
             "@{3.5}",
             "@{true}",
@@ -51,7 +52,6 @@ final class ExpressionTests: XCTestCase {
         // Given
         [
             "2",
-            "@{2client.phones[0]}",
             "@{}",
             "@{[2]}",
             "@{client.[2]}",
@@ -82,7 +82,9 @@ final class ExpressionTests: XCTestCase {
         let data = [
             "name: \(simple), phone: \(simple)",
             "name@name\\@name@\(simple)",
-            "\\\\@\(simple)"
+            "\\\\@\(simple)",
+            "Operation: @{condition(lt(sum(counter, 2), 5), '#FF0000', '#00FF00')}",
+            "Operation1: @{sum(1, counter, null)} and @{sum(2, 'counter', 2count)}"
         ]
         
         // When
@@ -97,7 +99,9 @@ final class ExpressionTests: XCTestCase {
         [
           "name: @{42}, phone: @{42}",
           "name@name\\@name@@{42}",
-          "\\@@{42}"
+          "\\@@{42}",
+          "Operation: @{condition(lt(sum(counter, 2), 5), '#FF0000', '#00FF00')}",
+          "Operation1: @{sum(1, counter, null)} and @{sum(2, 'counter', 2count)}"
         ]
         """#)
     }

--- a/iOS/Schema/Sources/ContextExpression/Tests/PathTests.swift
+++ b/iOS/Schema/Sources/ContextExpression/Tests/PathTests.swift
@@ -27,8 +27,12 @@ final class PathTests: XCTestCase {
             "client",
             "client2.name",
             "client_[2].matrix[1][1]",
+            "2client.2phones[0]",
+            "_2client._2phones_[0]",
             "[2]",
-            "[2][2]"
+            "[2][2]",
+            "2",
+            "_"
         ]
         
         // When
@@ -45,10 +49,10 @@ final class PathTests: XCTestCase {
         // Given
         [
             "",
-            "2client.phones[0]",
             "client.[2]",
             "client[2].[2]",
-            "client[a]"
+            "client[a]",
+            "client[2.2]"
         ]
         
         // When

--- a/iOS/Schema/Sources/ContextExpression/Tests/__Snapshots__/ExpressionTests/testValidMultipleExpressions.1.txt
+++ b/iOS/Schema/Sources/ContextExpression/Tests/__Snapshots__/ExpressionTests/testValidMultipleExpressions.1.txt
@@ -1,4 +1,4 @@
-▿ 3 elements
+▿ 5 elements
   ▿ MultipleExpression
     ▿ nodes: 4 elements
       ▿ Node
@@ -33,3 +33,85 @@
           ▿ value: Value
             ▿ literal: Literal
               - int: 42
+  ▿ MultipleExpression
+    ▿ nodes: 2 elements
+      ▿ Node
+        - string: "Operation: "
+      ▿ Node
+        ▿ expression: SingleExpression
+          ▿ operation: Operation
+            - name: Name.condition
+            ▿ parameters: 3 elements
+              ▿ Parameter
+                ▿ operation: Operation
+                  - name: Name.lt
+                  ▿ parameters: 2 elements
+                    ▿ Parameter
+                      ▿ operation: Operation
+                        - name: Name.sum
+                        ▿ parameters: 2 elements
+                          ▿ Parameter
+                            ▿ value: Value
+                              ▿ binding: Binding
+                                - context: "counter"
+                                ▿ path: Path
+                                  - nodes: 0 elements
+                          ▿ Parameter
+                            ▿ value: Value
+                              ▿ literal: Literal
+                                - int: 2
+                    ▿ Parameter
+                      ▿ value: Value
+                        ▿ literal: Literal
+                          - int: 5
+              ▿ Parameter
+                ▿ value: Value
+                  ▿ literal: Literal
+                    - string: "#FF0000"
+              ▿ Parameter
+                ▿ value: Value
+                  ▿ literal: Literal
+                    - string: "#00FF00"
+  ▿ MultipleExpression
+    ▿ nodes: 4 elements
+      ▿ Node
+        - string: "Operation1: "
+      ▿ Node
+        ▿ expression: SingleExpression
+          ▿ operation: Operation
+            - name: Name.sum
+            ▿ parameters: 3 elements
+              ▿ Parameter
+                ▿ value: Value
+                  ▿ literal: Literal
+                    - int: 1
+              ▿ Parameter
+                ▿ value: Value
+                  ▿ binding: Binding
+                    - context: "counter"
+                    ▿ path: Path
+                      - nodes: 0 elements
+              ▿ Parameter
+                ▿ value: Value
+                  - literal: Literal.null
+      ▿ Node
+        - string: " and "
+      ▿ Node
+        ▿ expression: SingleExpression
+          ▿ operation: Operation
+            - name: Name.sum
+            ▿ parameters: 3 elements
+              ▿ Parameter
+                ▿ value: Value
+                  ▿ literal: Literal
+                    - int: 2
+              ▿ Parameter
+                ▿ value: Value
+                  ▿ literal: Literal
+                    - string: "counter"
+              ▿ Parameter
+                ▿ value: Value
+                  ▿ binding: Binding
+                    - context: "2count"
+                    ▿ path: Path
+                      - nodes: 0 elements

--- a/iOS/Schema/Sources/ContextExpression/Tests/__Snapshots__/ExpressionTests/testValidSingleExpression.1.txt
+++ b/iOS/Schema/Sources/ContextExpression/Tests/__Snapshots__/ExpressionTests/testValidSingleExpression.1.txt
@@ -1,4 +1,4 @@
-▿ 9 elements
+▿ 10 elements
   ▿ SingleExpression
     ▿ value: Value
       ▿ binding: Binding
@@ -27,6 +27,16 @@
               - index: 1
             ▿ Node
               - index: 1
+  ▿ SingleExpression
+    ▿ value: Value
+      ▿ binding: Binding
+        - context: "2client"
+        ▿ path: Path
+          ▿ nodes: 2 elements
+            ▿ Node
+              - key: "phones"
+            ▿ Node
+              - index: 0
   ▿ SingleExpression
     ▿ value: Value
       ▿ literal: Literal


### PR DESCRIPTION
### Related Issues

Fixes #1059 

### Description and Example

Fixes a problem with path parser when a path key starts with digit. Sample: "2"

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
