### PR TITLE
ci: changed workflow to enable release from any branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
                 COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
                 TAG_NAME: ${{ github.REF }}
                 REPO: ${{ github.repository }}
-                COMMITISG: ${{ github.after }}
+                COMMITISH: ${{ github.after }}
               run: bundle exec fastlane deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,5 @@ jobs:
                 COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
                 TAG_NAME: ${{ github.REF }}
                 REPO: ${{ github.repository }}
+                COMMITISG: ${{ github.after }}
               run: bundle exec fastlane deploy

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -312,6 +312,10 @@ error do |lane, exception, options|
   end
 end
 
+# input: 1.2.0; output: 1.1.0
+# input: 1.2.2; output: 1.2.1
+# input: 1.2.3-iOS; output: 1.2.2-iOS
+# input: 3.0.0; output: 2.0.0
 lane :lastExpectedVersion do |params|
   platform = params[:newVersion].split("-")
   releaseNumberArray = platform.first.split(".")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -147,19 +147,12 @@ lane :deploy do
   sh "git fetch"
 
   tagName = ENV["TAG_NAME"].split("/").last
-  isHotFix = tagName.index("-")
 
-  if isHotFix
-    branchName = "release/" + tagName
-    (versionNumber, platformHotfix) = tagName.split("-")
-  else
-    versionNumber = last_git_tag(pattern: "*[0-9]")
-    branchName = "master"
-  end
+  (versionNumber, platformHotfix) = tagName.split("-")
 
   ENV["VERSION_DEPLOY"] = versionNumber
 
-  sh "git checkout #{branchName}"
+  sh "git checkout tags/#{tagName} -b newReleaseFromTag#{tagName}"
 
   if platformHotfix == "iOS"
     puts "iOS Hotfix release"
@@ -185,7 +178,7 @@ lane :deploy do
     name: tagName,
     tag_name: tagName,
     description: releaseNotes,
-    commitish: branchName
+    commitish: ENV["COMMITISG"]
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -178,7 +178,7 @@ lane :deploy do
     name: tagName,
     tag_name: tagName,
     description: releaseNotes,
-    commitish: ENV["COMMITISG"]
+    commitish: ENV["COMMITISH"]
   )
 end
 


### PR DESCRIPTION
### Description and Example

This enables the CI to generate releases from any branch(not only master).

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
