### PR TITLE
fix: alert parameter's default value

### DIFF
--- a/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/action/Alert.kt
+++ b/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/action/Alert.kt
@@ -31,13 +31,13 @@ import br.com.zup.beagle.widget.context.valueOfNullable
  *
  */
 data class Alert(
-    val title: Bind<String>?,
+    val title: Bind<String>? = null,
     val message: Bind<String>,
     val onPressOk: Action? = null,
     val labelOk: String? = null
 ) : Action {
     constructor(
-        title: String?,
+        title: String? = null,
         message: String,
         onPressOk: Action? = null,
         labelOk: String? = null


### PR DESCRIPTION
### Related Issues
closes #1108 

### Description and Example
Added default value for alert's parameter title

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
