### PR TITLE
fix: adjust crash in cache manager

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/cache/CacheManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/cache/CacheManager.kt
@@ -209,7 +209,7 @@ internal class CacheManager(
         }
     }
 
-    private fun isCacheEnabled(): Boolean = beagleEnvironment.beagleSdk.config.cache.enabled || storeHandler == null
+    private fun isCacheEnabled(): Boolean = beagleEnvironment.beagleSdk.config.cache.enabled && storeHandler != null
 
     private fun String.toBeagleHashKey(): String = "$this$CACHE_KEY_DELIMITER$CACHE_HASH_KEY"
     private fun String.toBeagleJsonKey(): String = "$this$CACHE_KEY_DELIMITER$CACHE_JSON_KEY"

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/cache/CacheManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/cache/CacheManagerTest.kt
@@ -323,6 +323,46 @@ class CacheManagerTest {
     }
 
     @Test
+    fun `GIVEN cache manager WHEN call handle response with storeHandle null and cache enabled THEN should not call cache`() {
+        // Given
+        every { beagleEnvironment.beagleSdk.config.cache.enabled } returns true
+        cacheManager = CacheManager(
+            null,
+            beagleEnvironment,
+            memoryCacheStore
+        )
+
+        // When
+        cacheManager.handleResponseData(URL, null, responseData)
+
+
+        // Then
+        verify(exactly = 0) { storeHandler.save(StoreType.DATABASE, any()) }
+        verify(exactly = 0) { memoryCacheStore.save(any(), any()) }
+    }
+
+
+    @Test
+    fun `GIVEN cache manager WHEN call restore beagle with storeHandle null and cache enabled THEN should not call cache`() {
+        // Given
+        every { beagleEnvironment.beagleSdk.config.cache.enabled } returns true
+        cacheManager = CacheManager(
+            null,
+            beagleEnvironment,
+            memoryCacheStore
+        )
+
+        // When
+        val actual = cacheManager.restoreBeagleCacheForUrl(URL)
+
+
+        // Then
+        verify(exactly = 0) { memoryCacheStore.restore(any()) }
+        assertNull(actual)
+    }
+
+
+    @Test
     fun `handleResponseData should not call store cache if beagleCache header is not present`() {
         // Given
         val headers = mapOf<String, String>()


### PR DESCRIPTION
Description and Example
When cache enabled and the handle is null the app crashing.
Adjust this logic and create unit test.

Checklist
Please, check if these important points are met using [x]:

 I read the PR Guide and followed the process outlined there for submitting this PR.
 I avoided breaking changes by not changing public APIs that people rely on.
 I am willing to follow-up on review comments in a timely manner.