### PR TITLE
fix: rename ListView property scrollThreshold to scrollEndThreshold

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/ListViewScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/ListViewScreen.swift
@@ -288,7 +288,7 @@ struct ListViewScreen: DeeplinkScreen {
                     ]
                 )
             ],
-            scrollThreshold: 80
+            scrollEndThreshold: 80
         )
     }
     
@@ -375,7 +375,7 @@ struct ListViewScreen: DeeplinkScreen {
                             ]
                         )
                     ],
-                    scrollThreshold: 80
+                    scrollEndThreshold: 80
                 )
             },
             iteratorName: "category"

--- a/iOS/Schema/Sources/ServerDrivenComponent/ListView/ListView.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/ListView/ListView.swift
@@ -24,7 +24,7 @@ public struct ListView: RawWidget, HasContext, InitiableComponent, AutoInitiable
     public let template: RawComponent
     public let iteratorName: String?
     public let onScrollEnd: [RawAction]?
-    public let scrollThreshold: Int?
+    public let scrollEndThreshold: Int?
     public var widgetProperties: WidgetProperties
     
 // sourcery:inline:auto:ListView.Init
@@ -37,7 +37,7 @@ public struct ListView: RawWidget, HasContext, InitiableComponent, AutoInitiable
         template: RawComponent,
         iteratorName: String? = nil,
         onScrollEnd: [RawAction]? = nil,
-        scrollThreshold: Int? = nil,
+        scrollEndThreshold: Int? = nil,
         widgetProperties: WidgetProperties = WidgetProperties()
     ) {
         self.context = context
@@ -48,7 +48,7 @@ public struct ListView: RawWidget, HasContext, InitiableComponent, AutoInitiable
         self.template = template
         self.iteratorName = iteratorName
         self.onScrollEnd = onScrollEnd
-        self.scrollThreshold = scrollThreshold
+        self.scrollEndThreshold = scrollEndThreshold
         self.widgetProperties = widgetProperties
     }
 // sourcery:end
@@ -109,7 +109,7 @@ extension ListView: Decodable {
         case template
         case iteratorName
         case onScrollEnd
-        case scrollThreshold
+        case scrollEndThreshold
     }
 
     public init(from decoder: Decoder) throws {
@@ -123,7 +123,7 @@ extension ListView: Decodable {
         context = try container.decodeIfPresent(Context.self, forKey: .context)
         onInit = try container.decodeIfPresent(forKey: .onInit)
         onScrollEnd = try container.decodeIfPresent(forKey: .onScrollEnd)
-        scrollThreshold = try container.decodeIfPresent(Int.self, forKey: .scrollThreshold)
+        scrollEndThreshold = try container.decodeIfPresent(Int.self, forKey: .scrollEndThreshold)
         widgetProperties = try WidgetProperties(listFrom: decoder)
         
         if container.contains(.children) {

--- a/iOS/Schema/Sources/ServerDrivenComponent/ListView/Tests/ListViewTests.swift
+++ b/iOS/Schema/Sources/ServerDrivenComponent/ListView/Tests/ListViewTests.swift
@@ -36,7 +36,7 @@ class ListViewTests: XCTestCase {
           - key: Optional<String>.none
           - onInit: Optional<Array<RawAction>>.none
           - onScrollEnd: Optional<Array<RawAction>>.none
-          - scrollThreshold: Optional<Int>.none
+          - scrollEndThreshold: Optional<Int>.none
           ▿ template: Container
             ▿ children: 3 elements
               ▿ UnknownComponent

--- a/iOS/Sources/Beagle/Sources/Components/ListView+Renderable/ListView+Renderable.swift
+++ b/iOS/Sources/Beagle/Sources/Components/ListView+Renderable/ListView+Renderable.swift
@@ -34,7 +34,7 @@ extension ListView: ServerDrivenComponent {
                 template: template,
                 iteratorName: iteratorName ?? "item",
                 onScrollEnd: onScrollEnd,
-                scrollThreshold: CGFloat(scrollThreshold ?? 100)
+                scrollEndThreshold: CGFloat(scrollEndThreshold ?? 100)
             ),
             renderer: renderer
         )

--- a/iOS/Sources/Beagle/Sources/Components/ListView+Renderable/ListViewUIComponent.swift
+++ b/iOS/Sources/Beagle/Sources/Components/ListView+Renderable/ListViewUIComponent.swift
@@ -203,7 +203,7 @@ final class ListViewUIComponent: UIView {
         let contentOffset = collection.contentOffset[keyPath: model.direction.pointKeyPath]
         let offset = contentOffset + frame.size[keyPath: model.direction.sizeKeyPath]
         
-        return (contentSize > 0) && (offset / contentSize * 100 >= model.scrollThreshold)
+        return (contentSize > 0) && (offset / contentSize * 100 >= model.scrollEndThreshold)
     }
 }
 
@@ -216,7 +216,7 @@ extension ListViewUIComponent {
         var template: RawComponent
         var iteratorName: String
         var onScrollEnd: [RawAction]?
-        var scrollThreshold: CGFloat
+        var scrollEndThreshold: CGFloat
     }
 }
 


### PR DESCRIPTION
Fix ListView property to match other platforms.