### PR TITLE
feat: add OnInitViewModel to handle onInit status on Android

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
@@ -89,13 +89,13 @@ constructor(
      * @param direction define the list direction.
      * @param context define the contextData that be set to component.
      * @param onInit allows to define a list of actions to be performed when the Widget is displayed.
-     * @param dataSource it's an expression that points to a list of values used to populate the Widget
-     * @param template represents each cell in the list through a ServerDrivenComponent
-     * @param onScrollEnd list of actions performed when the list is scrolled to the end
-     * @param scrollEndThreshold sets the scrolled percentage of the list to trigger onScrollEnd
-     * @param iteratorName is the context identifier of each cell
+     * @param dataSource it's an expression that points to a list of values used to populate the Widget.
+     * @param template represents each cell in the list through a ServerDrivenComponent.
+     * @param onScrollEnd list of actions performed when the list is scrolled to the end.
+     * @param scrollEndThreshold sets the scrolled percentage of the list to trigger onScrollEnd.
+     * @param iteratorName is the context identifier of each cell.
      * @param key points to a unique value present in each dataSource item
-     * used as a suffix in the component ids within the Widget
+     * used as a suffix in the component ids within the Widget.
      */
     constructor(
         direction: ListDirection,
@@ -105,7 +105,7 @@ constructor(
         template: ServerDrivenComponent,
         onScrollEnd: List<Action>? = null,
         scrollEndThreshold: Int? = null,
-        iteratorName: String,
+        iteratorName: String = "item",
         key: String? = null
     ) : this(
         null,

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextActionExecutor.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextActionExecutor.kt
@@ -51,7 +51,7 @@ internal object ContextActionExecutor {
         viewModel.addImplicitContext(context.normalize(), sender, actions)
     }
 
-    fun executeActions(rootView: RootView, origin: View, actions: List<Action>?) {
+    private fun executeActions(rootView: RootView, origin: View, actions: List<Action>?) {
         actions?.forEach {  action ->
             if (action is AsyncAction) {
                 val viewModel = rootView.generateViewModelInstance<AsyncActionViewModel>()

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModel.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModel.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.view.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+internal class OnInitViewModel : ViewModel() {
+
+    private val onInitStatusByComponent: MutableMap<Int, Boolean> = mutableMapOf()
+
+    fun setOnInitActionStatus(onInitiableComponentId: Int, onInitCalled: Boolean) {
+        onInitStatusByComponent[onInitiableComponentId] = onInitCalled
+    }
+
+    fun getOnInitActionStatus(onInitiableComponentId: Int) = onInitStatusByComponent[onInitiableComponentId] ?: false
+}

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextActionExecutorTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextActionExecutorTest.kt
@@ -146,6 +146,7 @@ class ContextActionExecutorTest : BaseAsyncActionTest() {
     @Test
     fun `GIVEN an AsyncAction WHEN executed THEN should call onActionStarted and onAsyncActionExecuted`() {
         // Given
+        val context = null
         val asyncActionViewModel = mockk<AsyncActionViewModel>()
         prepareViewModelMock(asyncActionViewModel)
         val asyncActionSlot = slot<AsyncActionData>()
@@ -154,7 +155,7 @@ class ContextActionExecutorTest : BaseAsyncActionTest() {
         every { asyncActionViewModel.onAsyncActionExecuted(capture(asyncActionSlot)) } just Runs
 
         // When
-        contextActionExecutor.executeActions(rootView, view, listOf(asyncAction))
+        contextActionExecutor.executeActions(rootView, view, sender, listOf(asyncAction), context)
 
         // Then
         assertEquals(asyncActionSlot.captured.asyncAction, asyncAction)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModelTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModelTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.view.viewmodel
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class OnInitViewModelTest {
+
+    private val onInitViewModel = OnInitViewModel()
+
+    @Test
+    fun `GIVEN onInitiableComponentId WHEN setOnInitActionStatus THEN should set to onInitStatusByComponent id the given value`() {
+        // Given
+        val onInitiableComponentId = 10
+        val onInitCalled = true
+
+        // When
+        onInitViewModel.setOnInitActionStatus(onInitiableComponentId, onInitCalled)
+        val result = onInitViewModel.getOnInitActionStatus(onInitiableComponentId)
+
+        // Then
+        assertEquals(onInitCalled, result)
+    }
+
+    @Test
+    fun `GIVEN onInitiableComponentId not found WHEN getOnInitActionStatus THEN should return false`() {
+        // Given
+        val onInitiableComponentId = 10
+
+        // When
+        val result = onInitViewModel.getOnInitActionStatus(onInitiableComponentId)
+
+        // Then
+        assertFalse(result)
+    }
+}

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModelTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModelTest.kt
@@ -18,35 +18,50 @@ package br.com.zup.beagle.android.view.viewmodel
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@DisplayName("Given OnInit ViewModel")
 class OnInitViewModelTest {
 
     private val onInitViewModel = OnInitViewModel()
 
-    @Test
-    fun `GIVEN onInitiableComponentId WHEN setOnInitActionStatus THEN should set to onInitStatusByComponent id the given value`() {
-        // Given
-        val onInitiableComponentId = 10
-        val onInitCalled = true
+    @DisplayName("When set OnInit action status")
+    @Nested
+    inner class SetOnInitStatus {
 
-        // When
-        onInitViewModel.setOnInitActionStatus(onInitiableComponentId, onInitCalled)
-        val result = onInitViewModel.getOnInitActionStatus(onInitiableComponentId)
+        @DisplayName("Then should set to onInitStatusByComponent id the given value")
+        @Test
+        fun setOnInitActionStatus() {
+            // Given
+            val onInitiableComponentId = 10
+            val onInitCalled = true
 
-        // Then
-        assertEquals(onInitCalled, result)
+            // When
+            onInitViewModel.setOnInitActionStatus(onInitiableComponentId, onInitCalled)
+            val result = onInitViewModel.getOnInitActionStatus(onInitiableComponentId)
+
+            // Then
+            assertEquals(onInitCalled, result)
+        }
     }
 
-    @Test
-    fun `GIVEN onInitiableComponentId not found WHEN getOnInitActionStatus THEN should return false`() {
-        // Given
-        val onInitiableComponentId = 10
+    @DisplayName("When get OnInit action status not found")
+    @Nested
+    inner class GetOnInitStatus {
 
-        // When
-        val result = onInitViewModel.getOnInitActionStatus(onInitiableComponentId)
+        @DisplayName("Then should return false")
+        @Test
+        fun getOnInitActionStatus() {
+            // Given
+            val onInitiableComponentId = 10
 
-        // Then
-        assertFalse(result)
+            // When
+            val result = onInitViewModel.getOnInitActionStatus(onInitiableComponentId)
+
+            // Then
+            assertFalse(result)
+        }
     }
 }

--- a/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/ListView.kt
+++ b/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/ListView.kt
@@ -41,7 +41,7 @@ data class ListView(
     val dataSource: Bind<List<Any>>? = null,
     val template: ServerDrivenComponent? = null,
     val onScrollEnd: List<Action>? = null,
-    val scrollThreshold: Int? = null,
+    val scrollEndThreshold: Int? = null,
     val iteratorName: String = "item",
     val key: String? = null
 ) : Widget(), ContextComponent {
@@ -67,15 +67,15 @@ data class ListView(
 
     /**
      * @param direction define the list direction.
-     * @param context define the contextData that be set to container.
+     * @param context define the contextData that be set to component.
      * @param onInit allows to define a list of actions to be performed when the Widget is displayed.
-     * @param dataSource it's an expression that points to a list of values used to populate the Widget
-     * @param template represents each cell in the list through a ServerDrivenComponent
-     * @param onScrollEnd list of actions performed when the list is scrolled to the end
-     * @param scrollThreshold sets the scrolled percentage of the list to trigger onScrollEnd
-     * @param iteratorName is the context identifier of each cell
+     * @param dataSource it's an expression that points to a list of values used to populate the Widget.
+     * @param template represents each cell in the list through a ServerDrivenComponent.
+     * @param onScrollEnd list of actions performed when the list is scrolled to the end.
+     * @param scrollEndThreshold sets the scrolled percentage of the list to trigger onScrollEnd.
+     * @param iteratorName is the context identifier of each cell.
      * @param key points to a unique value present in each dataSource item
-     * used as a suffix in the component ids within the Widget
+     * used as a suffix in the component ids within the Widget.
      */
     constructor(
         direction: ListDirection,
@@ -84,7 +84,7 @@ data class ListView(
         dataSource: Bind<List<Any>>,
         template: ServerDrivenComponent,
         onScrollEnd: List<Action>? = null,
-        scrollThreshold: Int? = null,
+        scrollEndThreshold: Int? = null,
         iteratorName: String = "item",
         key: String? = null
     ) : this(
@@ -95,7 +95,7 @@ data class ListView(
         dataSource,
         template,
         onScrollEnd,
-        scrollThreshold,
+        scrollEndThreshold,
         iteratorName,
         key
     )


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

### Description and Example

This PR adds the `OnInitViewModel` class to handle the execution status of the `onInit` actions of the `OnInitiableComponent`s when the device is rotated.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
