### PR TITLE
feat: handle config changes for onInit calls

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/OnInitiableComponent.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/OnInitiableComponent.kt
@@ -17,7 +17,10 @@
 package br.com.zup.beagle.android.components
 
 import android.view.View
+import androidx.lifecycle.Observer
 import br.com.zup.beagle.android.action.Action
+import br.com.zup.beagle.android.action.AsyncAction
+import br.com.zup.beagle.android.action.AsyncActionStatus
 import br.com.zup.beagle.android.utils.generateViewModelInstance
 import br.com.zup.beagle.android.utils.handleEvent
 import br.com.zup.beagle.android.view.viewmodel.OnInitViewModel
@@ -42,6 +45,7 @@ interface OnInitiableComponent {
     /**
      * Method responsible for releasing the execution of all actions present in the onInit property
      * regardless of whether they have already been executed.
+     * It is rarely appropriate to use this method.
      */
     fun markToRerunOnInit()
 }
@@ -49,6 +53,8 @@ interface OnInitiableComponent {
 /**
  * Class that implements onInitiableComponent behavior
  * @property onInitViewModel manages the onInit called status
+ * @property origin represents the view that triggered the action
+ * @property observer listens to the FINISHED status of the async actions present on onInit informing the ViewModel
  */
 class OnInitiableComponentImpl(override val onInit: List<Action>?) : OnInitiableComponent {
 
@@ -57,6 +63,13 @@ class OnInitiableComponentImpl(override val onInit: List<Action>?) : OnInitiable
 
     @Transient
     private lateinit var origin: View
+
+    @Transient
+    private val observer = Observer<AsyncActionStatus> { actionStatus ->
+        if (actionStatus == AsyncActionStatus.FINISHED) {
+            onInitViewModel.setOnInitFinished(origin.id, true)
+        }
+    }
 
     /**
      * Execute the actions present in the onInit property as soon as the component is attached to window.
@@ -73,11 +86,12 @@ class OnInitiableComponentImpl(override val onInit: List<Action>?) : OnInitiable
     private fun addListenerToExecuteOnInit(rootView: RootView) {
         origin.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
             override fun onViewAttachedToWindow(v: View?) {
-                if (!onInitViewModel.getOnInitActionStatus(origin.id)) {
-                    onInit?.forEach {
-                        it.handleEvent(rootView, origin, it)
+                if (!onInitViewModel.isOnInitCalled(origin.id)) {
+                    onInit?.forEach { action ->
+                        (action as? AsyncAction)?.status?.observe(rootView.getLifecycleOwner(), observer)
+                        action.handleEvent(rootView, origin, action)
                     }
-                    onInitViewModel.setOnInitActionStatus(origin.id, true)
+                    onInitViewModel.setOnInitCalled(origin.id, true)
                 }
             }
 
@@ -86,10 +100,10 @@ class OnInitiableComponentImpl(override val onInit: List<Action>?) : OnInitiable
     }
 
     /**
-     * Method responsible for releasing the execution of all actions present in the onInit property
-     * regardless of whether they have already been executed.
+     * Method responsible for marking the onInitCalled status of all actions in a view as false.
+     * It is rarely appropriate to use this method.
      */
     override fun markToRerunOnInit() {
-        onInitViewModel.setOnInitActionStatus(origin.id, false)
+        onInitViewModel.setOnInitCalled(origin.id, false)
     }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListItem.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListItem.kt
@@ -22,7 +22,6 @@ internal data class ListItem(
     var viewIds: LinkedList<Int> = LinkedList(),
     val data: Any,
     var itemSuffix: String = "",
-    var completelyInitialized: Boolean = false,
     var firstTimeBinding: Boolean = true,
     val directNestedAdapters: LinkedList<ListAdapter> = LinkedList(),
     var isRecycled: Boolean = false

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
@@ -53,7 +53,7 @@ internal class ListViewHolder(
     val directNestedImageViews = mutableListOf<ImageView>()
     val directNestedTextViews = mutableListOf<TextView>()
     private val contextComponents = mutableListOf<ContextData>()
-    val initiableComponents = mutableListOf<OnInitiableComponent>()
+    private val initiableComponents = mutableListOf<OnInitiableComponent>()
     var observer: Observer<AsyncActionStatus>? = null
 
     init {
@@ -249,7 +249,7 @@ internal class ListViewHolder(
             if (viewPreviousId == View.NO_ID) {
                 listViewModels.contextViewModel.setIdToViewWithContext(view)
             } else {
-                listViewModels.contextViewModel.onViewIdChanged(viewPreviousId, view.id)
+                listViewModels.contextViewModel.onViewIdChanged(viewPreviousId, view.id, view)
             }
         }
     }
@@ -316,8 +316,7 @@ internal class ListViewHolder(
     }
 
     private fun restoreAdapters(listItem: ListItem) {
-        val temporaryNestedAdapters: LinkedList<ListAdapter> =
-            LinkedList(listItem.directNestedAdapters)
+        val temporaryNestedAdapters: LinkedList<ListAdapter> = LinkedList(listItem.directNestedAdapters)
         directNestedRecyclers.forEach {
             it.swapAdapter(temporaryNestedAdapters.pollFirst(), false)
         }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewModels.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewModels.kt
@@ -20,6 +20,7 @@ import br.com.zup.beagle.android.utils.generateViewModelInstance
 import br.com.zup.beagle.android.view.viewmodel.AsyncActionViewModel
 import br.com.zup.beagle.android.view.viewmodel.GenerateIdViewModel
 import br.com.zup.beagle.android.view.viewmodel.ListViewIdViewModel
+import br.com.zup.beagle.android.view.viewmodel.OnInitViewModel
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
 import br.com.zup.beagle.android.widget.RootView
 
@@ -28,5 +29,6 @@ internal data class ListViewModels(
     val asyncActionViewModel: AsyncActionViewModel = rootView.generateViewModelInstance(),
     val contextViewModel: ScreenContextViewModel = rootView.generateViewModelInstance(),
     val listViewIdViewModel: ListViewIdViewModel = rootView.generateViewModelInstance(),
-    val generateIdViewModel: GenerateIdViewModel = rootView.generateViewModelInstance()
+    val generateIdViewModel: GenerateIdViewModel = rootView.generateViewModelInstance(),
+    val onInitViewModel: OnInitViewModel = rootView.generateViewModelInstance()
 )

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -68,9 +68,15 @@ internal class ContextDataManager(
         }
     }
 
-    fun onViewIdChanged(oldId: Int, newId: Int) {
-        contexts[oldId]?.let { context ->
-            contexts.put(newId, context)
+    fun onViewIdChanged(oldId: Int, newId: Int, view: View) {
+        contexts[oldId]?.let { contextBinding ->
+            if (!contexts.containsKey(newId)) {
+                contexts.put(newId, contextBinding)
+            } else {
+                contexts[newId]?.let {
+                    updateContextAndReference(view, it.context)
+                }
+            }
         }
         contexts.remove(oldId)
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/GenerateIdManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/GenerateIdManager.kt
@@ -20,6 +20,7 @@ import android.view.View
 import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.android.view.viewmodel.GenerateIdViewModel
 import br.com.zup.beagle.android.view.viewmodel.ListViewIdViewModel
+import br.com.zup.beagle.android.view.viewmodel.OnInitViewModel
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.WidgetView
 import br.com.zup.beagle.core.IdentifierComponent
@@ -34,7 +35,8 @@ internal const val COMPONENT_NO_ID = "-1"
 internal class GenerateIdManager(
     private val rootView: RootView,
     private val generateIdViewModel: GenerateIdViewModel = rootView.generateViewModelInstance(),
-    private val listViewIdViewModel: ListViewIdViewModel = rootView.generateViewModelInstance()
+    private val listViewIdViewModel: ListViewIdViewModel = rootView.generateViewModelInstance(),
+    private val onInitViewModel: OnInitViewModel = rootView.generateViewModelInstance()
 ) {
 
     fun createSingleManagerByRootViewId() {
@@ -44,6 +46,7 @@ internal class GenerateIdManager(
     fun onViewDetachedFromWindow(view: View) {
         generateIdViewModel.setViewCreated(rootView.getParentId())
         listViewIdViewModel.prepareToReuseIds(view)
+        onInitViewModel.markToRerun()
     }
 
     fun manageId(component: ServerDrivenComponent, view: BeagleFlexView) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModel.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModel.kt
@@ -18,13 +18,42 @@ package br.com.zup.beagle.android.view.viewmodel
 
 import androidx.lifecycle.ViewModel
 
+internal data class OnInitStatus(
+    var onInitCalled: Boolean = false,
+    var onInitFinished: Boolean = false
+)
+
 internal class OnInitViewModel : ViewModel() {
 
-    private val onInitStatusByComponent: MutableMap<Int, Boolean> = mutableMapOf()
+    private val onInitStatusByViewId: MutableMap<Int, OnInitStatus> = mutableMapOf()
 
-    fun setOnInitActionStatus(onInitiableComponentId: Int, onInitCalled: Boolean) {
-        onInitStatusByComponent[onInitiableComponentId] = onInitCalled
+    fun setOnInitCalled(onInitiableViewId: Int, onInitCalled: Boolean) {
+        val onInitStatus = onInitStatusByViewId[onInitiableViewId]
+        onInitStatus?.let {
+            it.onInitCalled = onInitCalled
+        } ?: run {
+            onInitStatusByViewId[onInitiableViewId] = OnInitStatus(onInitCalled = onInitCalled)
+        }
     }
 
-    fun getOnInitActionStatus(onInitiableComponentId: Int) = onInitStatusByComponent[onInitiableComponentId] ?: false
+    fun setOnInitFinished(onInitiableViewId: Int, onInitFinished: Boolean) {
+        val onInitStatus = onInitStatusByViewId[onInitiableViewId]
+        onInitStatus?.let {
+            it.onInitFinished = onInitFinished
+        } ?: run {
+            onInitStatusByViewId[onInitiableViewId] = OnInitStatus(onInitFinished = onInitFinished)
+        }
+    }
+
+    fun isOnInitCalled(onInitiableViewId: Int) = onInitStatusByViewId[onInitiableViewId]?.onInitCalled ?: false
+
+    fun isOnInitFinished(onInitiableViewId: Int) = onInitStatusByViewId[onInitiableViewId]?.onInitFinished ?: false
+
+    fun markToRerun() {
+        onInitStatusByViewId.values.forEach {
+            if (!it.onInitFinished) {
+                it.onInitCalled = false
+            }
+        }
+    }
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/ScreenContextViewModel.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/ScreenContextViewModel.kt
@@ -51,8 +51,8 @@ internal class ScreenContextViewModel(
         contextDataManager.updateContext(originView, setContextInternal)
     }
 
-    fun onViewIdChanged(oldId: Int, newId: Int) {
-        contextDataManager.onViewIdChanged(oldId, newId)
+    fun onViewIdChanged(oldId: Int, newId: Int, view: View) {
+        contextDataManager.onViewIdChanged(oldId, newId, view)
     }
 
     fun <T> addBindingToContext(view: View, bind: Bind.Expression<T>, observer: Observer<T?>) {

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/OnInitiableComponentTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/OnInitiableComponentTest.kt
@@ -39,9 +39,12 @@ import io.mockk.unmockkConstructor
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
+@DisplayName("Given an OnInitiableComponent")
 @ExtendWith(InstantExecutorExtension::class)
 class OnInitiableComponentTest {
 
@@ -65,122 +68,144 @@ class OnInitiableComponentTest {
         unmockkConstructor(ViewModelProvider::class)
     }
 
-    @Test
-    fun `GIVEN a initiableWidget without onInit actions WHEN handleOnInit THEN shouldn't call addOnAttachStateChangeListener`() {
-        // Given
-        val initiableWidget = Container(children = listOf())
+    @DisplayName("When handleOnInit")
+    @Nested
+    inner class HandleOnInit {
 
-        // When
-        initiableWidget.handleOnInit(rootView, origin)
+        @DisplayName("Then shouldn't call addOnAttachStateChangeListener without onInit")
+        @Test
+        fun handleEmptyOnInit() {
+            // Given
+            val initiableWidget = Container(children = listOf())
 
-        // Then
-        verify(exactly = 0) { origin.addOnAttachStateChangeListener(any()) }
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+
+            // Then
+            verify(exactly = 0) { origin.addOnAttachStateChangeListener(any()) }
+        }
+
+        @DisplayName("Then should call addOnAttachStateChangeListener")
+        @Test
+        fun handleOnInit() {
+            // Given
+            val initiableWidget = Container(children = listOf(), onInit = listOf(Navigate.PopView()))
+
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+
+            // Then
+            verify(exactly = 1) { origin.addOnAttachStateChangeListener(listenerSlot.captured) }
+        }
     }
 
-    @Test
-    fun `GIVEN a initiableWidget WHEN handleOnInit THEN should add listener`() {
-        // Given
-        val initiableWidget = Container(children = listOf(), onInit = listOf(Navigate.PopView()))
+    @DisplayName("When onViewAttachedToWindow")
+    @Nested
+    inner class OnViewAttached {
 
-        // When
-        initiableWidget.handleOnInit(rootView, origin)
+        @DisplayName("Then should setOnInitActionStatus true")
+        @Test
+        fun onViewAttachedToWindow() {
+            // Given
+            val action = Navigate.PopView()
+            val initiableWidget = Container(children = listOf(), onInit = listOf(action))
 
-        // Then
-        verify(exactly = 1) { origin.addOnAttachStateChangeListener(listenerSlot.captured) }
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+            listenerSlot.captured.onViewAttachedToWindow(origin)
+
+            // Then
+            verify(exactly = 1) { onInitViewModel.setOnInitCalled(id, true) }
+        }
+
+        @DisplayName("Then should observe the action")
+        @Test
+        fun onViewAttachedToWindowObserve() {
+            // Given
+            val status = mockk<LiveData<AsyncActionStatus>>(relaxed = true)
+            val action = mockk<SendRequest>(relaxed = true)
+            every { action.status } returns status
+            val initiableWidget = Container(children = listOf(), onInit = listOf(action))
+
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+            listenerSlot.captured.onViewAttachedToWindow(origin)
+
+            // Then
+            verify(exactly = 1) { status.observe(rootView.getLifecycleOwner(), any()) }
+        }
+
+        @DisplayName("Then should executeActions only once")
+        @Test
+        fun onViewAttachedToWindowExecute() {
+            // Given
+            val action = Navigate.PopView()
+            val initiableWidget = Container(children = listOf(), onInit = listOf(action))
+
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+            listenerSlot.captured.onViewAttachedToWindow(origin)
+            listenerSlot.captured.onViewAttachedToWindow(origin)
+
+            // Then
+            verify(exactly = 1) { action.handleEvent(rootView, origin, action) }
+        }
+
+        @DisplayName("Then should setOnInitFinished true to FINISHED AsyncAction")
+        @Test
+        fun onViewAttachedToWindowActionStatus() {
+            // Given
+            val status = mockk<LiveData<AsyncActionStatus>>(relaxed = true)
+            val action = mockk<SendRequest>(relaxed = true)
+            every { action.status } returns status
+            val observerSlot = slot<Observer<AsyncActionStatus>>()
+            every { status.observe(rootView.getLifecycleOwner(), capture(observerSlot)) } just Runs
+            val initiableWidget = Container(children = listOf(), onInit = listOf(action))
+
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+            listenerSlot.captured.onViewAttachedToWindow(origin)
+            observerSlot.captured.onChanged(AsyncActionStatus.FINISHED)
+
+            // Then
+            verify(exactly = 1) { onInitViewModel.setOnInitFinished(id, true) }
+        }
     }
 
-    @Test
-    fun `GIVEN a initiableWidget WHEN onViewAttachedToWindow THEN should setOnInitActionStatus true`() {
-        // Given
-        val action = Navigate.PopView()
-        val initiableWidget = Container(children = listOf(), onInit = listOf(action))
+    @DisplayName("When markToRerunOnInit")
+    @Nested
+    inner class MarkToRerun {
 
-        // When
-        initiableWidget.handleOnInit(rootView, origin)
-        listenerSlot.captured.onViewAttachedToWindow(origin)
+        @DisplayName("Then should setOnInitActionStatus false")
+        @Test
+        fun markToRerunOnInit() {
+            // Given
+            val action = Navigate.PopView()
+            val initiableWidget = Container(children = listOf(), onInit = listOf(action))
 
-        // Then
-        verify(exactly = 1) { onInitViewModel.setOnInitCalled(id, true) }
-    }
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+            initiableWidget.markToRerunOnInit()
 
-    @Test
-    fun `GIVEN a initiableWidget with AsyncAction WHEN onViewAttachedToWindow THEN should observe the action`() {
-        // Given
-        val status = mockk<LiveData<AsyncActionStatus>>(relaxed = true)
-        val action = mockk<SendRequest>(relaxed = true)
-        every { action.status } returns status
-        val initiableWidget = Container(children = listOf(), onInit = listOf(action))
+            // Then
+            verify(exactly = 1) { onInitViewModel.setOnInitCalled(id, false) }
+        }
 
-        // When
-        initiableWidget.handleOnInit(rootView, origin)
-        listenerSlot.captured.onViewAttachedToWindow(origin)
+        @DisplayName("Then should be able to executeActions again")
+        @Test
+        fun markToRerunOnInitAgain() {
+            // Given
+            val action = Navigate.PopView()
+            val initiableWidget = Container(children = listOf(), onInit = listOf(action))
 
-        // Then
-        verify(exactly = 1) { status.observe(rootView.getLifecycleOwner(), any()) }
-        verify(exactly = 1) { onInitViewModel.setOnInitCalled(id, true) }
-    }
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+            listenerSlot.captured.onViewAttachedToWindow(origin)
+            initiableWidget.markToRerunOnInit()
+            listenerSlot.captured.onViewAttachedToWindow(origin)
 
-    @Test
-    fun `GIVEN a initiableWidget with AsyncAction WHEN actionStatus is FINISHED THEN should setOnInitFinished true`() {
-        // Given
-        val status = mockk<LiveData<AsyncActionStatus>>(relaxed = true)
-        val action = mockk<SendRequest>(relaxed = true)
-        every { action.status } returns status
-        val observerSlot = slot<Observer<AsyncActionStatus>>()
-        every { status.observe(rootView.getLifecycleOwner(), capture(observerSlot)) } just Runs
-        val initiableWidget = Container(children = listOf(), onInit = listOf(action))
-
-        // When
-        initiableWidget.handleOnInit(rootView, origin)
-        listenerSlot.captured.onViewAttachedToWindow(origin)
-        observerSlot.captured.onChanged(AsyncActionStatus.FINISHED)
-
-        // Then
-        verify(exactly = 1) { onInitViewModel.setOnInitFinished(id, true) }
-    }
-
-    @Test
-    fun `GIVEN a initiableWidget WHEN onViewAttachedToWindow THEN should executeActions only once`() {
-        // Given
-        val action = Navigate.PopView()
-        val initiableWidget = Container(children = listOf(), onInit = listOf(action))
-
-        // When
-        initiableWidget.handleOnInit(rootView, origin)
-        listenerSlot.captured.onViewAttachedToWindow(origin)
-        listenerSlot.captured.onViewAttachedToWindow(origin)
-
-        // Then
-        verify(exactly = 1) { action.handleEvent(rootView, origin, action) }
-    }
-
-    @Test
-    fun `GIVEN a initiableWidget WHEN markToRerunOnInit THEN should setOnInitActionStatus false`() {
-        // Given
-        val action = Navigate.PopView()
-        val initiableWidget = Container(children = listOf(), onInit = listOf(action))
-
-        // When
-        initiableWidget.handleOnInit(rootView, origin)
-        initiableWidget.markToRerunOnInit()
-
-        // Then
-        verify(exactly = 1) { onInitViewModel.setOnInitCalled(id, false) }
-    }
-
-    @Test
-    fun `GIVEN a initiableWidget witch already called onInit WHEN markToRerunOnInit THEN should be able to executeActions again`() {
-        // Given
-        val action = Navigate.PopView()
-        val initiableWidget = Container(children = listOf(), onInit = listOf(action))
-
-        // When
-        initiableWidget.handleOnInit(rootView, origin)
-        listenerSlot.captured.onViewAttachedToWindow(origin)
-        initiableWidget.markToRerunOnInit()
-        listenerSlot.captured.onViewAttachedToWindow(origin)
-
-        // Then
-        verify(exactly = 2) { action.handleEvent(rootView, origin, action) }
+            // Then
+            verify(exactly = 2) { action.handleEvent(rootView, origin, action) }
+        }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/list/ListViewHolderTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/list/ListViewHolderTest.kt
@@ -22,6 +22,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.action.Navigate
+import br.com.zup.beagle.android.components.OnInitiableComponent
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
@@ -81,9 +82,10 @@ class ListViewHolderTest : BaseTest() {
 
         // When
         listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+        val initiableComponents = listViewHolder.getPrivateField<MutableList<OnInitiableComponent>>("initiableComponents")
 
         // Then
-        assertEquals(template, listViewHolder.initiableComponents[0])
+        assertEquals(template, initiableComponents[0])
     }
 
     @Test
@@ -289,7 +291,7 @@ class ListViewHolderTest : BaseTest() {
         listViewHolder.onBind(null, null, listItem, position, recyclerId)
 
         // Then
-        verify(exactly = 1) { viewModel.onViewIdChanged(bffId, newIdSlot.captured) }
+        verify(exactly = 1) { viewModel.onViewIdChanged(bffId, newIdSlot.captured, itemView) }
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/list/ListViewHolderTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/list/ListViewHolderTest.kt
@@ -46,10 +46,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.LinkedList
 
+@DisplayName("Given a ListViewHolder")
 @ExtendWith(InstantExecutorExtension::class)
 class ListViewHolderTest : BaseTest() {
 
@@ -75,427 +78,462 @@ class ListViewHolderTest : BaseTest() {
         listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
     }
 
-    @Test
-    fun `GIVEN a template with onInit WHEN init THEN should add to initiableComponents`() {
-        // Given
-        val template = Container(children = listOf(), onInit = listOf(Navigate.PopView()))
+    @DisplayName("When create the holder")
+    @Nested
+    inner class Init {
 
-        // When
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-        val initiableComponents = listViewHolder.getPrivateField<MutableList<OnInitiableComponent>>("initiableComponents")
+        @DisplayName("Then should add template with onInit to initiableComponents")
+        @Test
+        fun initiableComponents() {
+            // Given
+            val template = Container(children = listOf(), onInit = listOf(Navigate.PopView()))
 
-        // Then
-        assertEquals(template, initiableComponents[0])
-    }
+            // When
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+            val initiableComponents = listViewHolder.getPrivateField<MutableList<OnInitiableComponent>>("initiableComponents")
 
-    @Test
-    fun `GIVEN a template with id WHEN init THEN should add to viewsWithId`() {
-        // Given
-        val id = "10"
-        val template = Container(children = listOf()).setId(id)
-        val view = mockk<View>()
-        every { itemView.findViewById<View>(id.toAndroidId()) } returns view
-
-        // When
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-        val viewsWithId = listViewHolder.getPrivateField<MutableMap<String, View>>("viewsWithId")
-
-        // Then
-        verify(exactly = 1) { itemView.findViewById<View>(id.toAndroidId()) }
-        assertEquals(view, viewsWithId[id])
-    }
-
-    @Test
-    fun `GIVEN a view with context WHEN init THEN should add to viewsWithContext`() {
-        // Given
-        every { itemView.getContextBinding() } returns mockk {
-            every { context } returns ContextData("id", "value")
+            // Then
+            assertEquals(template, initiableComponents[0])
         }
 
-        // When
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-        val viewsWithContext = listViewHolder.getPrivateField<MutableList<View>>("viewsWithContext")
+        @DisplayName("Then should add view with id to viewsWithId")
+        @Test
+        fun viewsWithId() {
+            // Given
+            val id = "10"
+            val template = Container(children = listOf()).setId(id)
+            val view = mockk<View>()
+            every { itemView.findViewById<View>(id.toAndroidId()) } returns view
 
-        // Then
-        assertEquals(itemView, viewsWithContext[0])
-    }
+            // When
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+            val viewsWithId = listViewHolder.getPrivateField<MutableMap<String, View>>("viewsWithId")
 
-    @Test
-    fun `GIVEN a imageView WHEN init THEN should add to directNestedImageViews`() {
-        // Given
-        val itemView = mockk<ImageView>(relaxed = true)
-
-        // When
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-
-        // Then
-        assertEquals(itemView, listViewHolder.directNestedImageViews[0])
-    }
-
-    @Test
-    fun `GIVEN a textView WHEN init THEN should add to directNestedTextViews`() {
-        // Given
-        val itemView = mockk<TextView>(relaxed = true)
-
-        // When
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-
-        // Then
-        assertEquals(itemView, listViewHolder.directNestedTextViews[0])
-    }
-
-    @Test
-    fun `GIVEN a recyclerView WHEN init THEN should add to directNestedRecyclers`() {
-        // Given
-        val itemView = mockk<RecyclerView>(relaxed = true)
-
-        // When
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-        val directNestedRecyclers = listViewHolder.getPrivateField<MutableList<RecyclerView>>("directNestedRecyclers")
-
-        // Then
-        assertEquals(itemView, directNestedRecyclers[0])
-    }
-
-    @Test
-    fun `GIVEN an item WHEN onBind THEN should clear contextComponents`() {
-        // Given
-        val contexts = listViewHolder.getPrivateField<MutableList<ContextData>>("contextComponents")
-        contexts.add(mockk())
-
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
-
-        // Then
-        assertTrue { contexts.isEmpty() }
-    }
-
-    @Test
-    fun `GIVEN a recycled item WHEN onBind THEN should call deserializeComponent`() {
-        // Given
-        every { listItem.isRecycled } returns true
-
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
-
-        // Then
-        verify(exactly = 1) { serializer.deserializeComponent(jsonTemplate) }
-    }
-
-    @Test
-    fun `GIVEN a contextComponent WHEN onBind THEN should add to contextComponents`() {
-        // Given
-        val context = ContextData("id", "value")
-        val template = Container(children = listOf(), context = context)
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
-        val contexts = listViewHolder.getPrivateField<MutableList<ContextData>>("contextComponents")
-
-        // Then
-        assertEquals(context, contexts[0])
-    }
-
-    @Test
-    fun `GIVEN a firstTimeBinding item WHEN onBind THEN should generateItemSuffix`() {
-        // Given
-        every { listItem.firstTimeBinding } returns true
-        val itemSuffixSlot = slot<String>()
-        every { listItem.itemSuffix = capture(itemSuffixSlot) } just Runs
-        val position = 0
-        val listIdByItemKey = position.toString()
-
-        // When
-        listViewHolder.onBind(null, null, listItem, position, 0)
-
-        // Then
-        assertEquals(listIdByItemKey, itemSuffixSlot.captured)
-    }
-
-    @Test
-    fun `GIVEN a firstTimeBinding item with parent WHEN onBind THEN should generateItemSuffix`() {
-        // Given
-        every { listItem.firstTimeBinding } returns true
-        val itemSuffixSlot = slot<String>()
-        every { listItem.itemSuffix = capture(itemSuffixSlot) } just Runs
-        val parentListViewSuffix = "identifier"
-        val position = 0
-        val listIdByItemKey = "$parentListViewSuffix:$position"
-
-        // When
-        listViewHolder.onBind(parentListViewSuffix, null, listItem, position, 0)
-
-        // Then
-        assertEquals(listIdByItemKey, itemSuffixSlot.captured)
-    }
-
-    @Test
-    fun `GIVEN a firstTimeBinding item with key WHEN onBind THEN should generateItemSuffix`() {
-        // Given
-        every { listItem.firstTimeBinding } returns true
-        val itemSuffixSlot = slot<String>()
-        every { listItem.itemSuffix = capture(itemSuffixSlot) } just Runs
-        val data = JSONObject(""" { id: 10, name: Item } """.trimIndent())
-        every { listItem.data } returns data
-        val listIdByItemKey = "10"
-
-        // When
-        listViewHolder.onBind(null, "id", listItem, 0, 0)
-
-        // Then
-        assertEquals(listIdByItemKey, itemSuffixSlot.captured)
-    }
-
-    @Test
-    fun `GIVEN a firstTimeBinding item WHEN onBind THEN should updateIdToEachSubView`() {
-        // Given
-        every { listItem.firstTimeBinding } returns true
-        every { itemView.id } returns View.NO_ID
-        val recyclerId = 0
-        val position = 0
-        val generatedId = 100
-        every { listViewIdViewModel.getViewId(recyclerId, position) } returns generatedId
-        val idSlot = slot<Int>()
-        every { listItem.viewIds } returns mockk {
-            every { add(capture(idSlot)) } returns true
+            // Then
+            verify(exactly = 1) { itemView.findViewById<View>(id.toAndroidId()) }
+            assertEquals(view, viewsWithId[id])
         }
-        val viewIdSlot = slot<Int>()
-        every { itemView.id = capture(viewIdSlot) } just Runs
 
-        // When
-        listViewHolder.onBind(null, null, listItem, position, recyclerId)
+        @DisplayName("Then should add view with context to viewsWithContext")
+        @Test
+        fun viewsWithContext() {
+            // Given
+            every { itemView.getContextBinding() } returns mockk {
+                every { context } returns ContextData("id", "value")
+            }
 
-        // Then
-        assertEquals(generatedId, viewIdSlot.captured)
-        assertEquals(generatedId, idSlot.captured)
-        verify(exactly = 1) { viewModel.setIdToViewWithContext(itemView) }
-    }
+            // When
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+            val viewsWithContext = listViewHolder.getPrivateField<MutableList<View>>("viewsWithContext")
 
-    @Test
-    fun `GIVEN a firstTimeBinding item with bff id WHEN onBind THEN should updateIdToEachSubView`() {
-        // Given
-        val bffId = "idFromBff".toAndroidId()
-        every { listItem.firstTimeBinding } returns true
-        val newIdSlot = slot<Int>()
-        every { itemView.id = capture(newIdSlot) } just Runs
-        every { itemView.id } answers {
-            if (newIdSlot.isCaptured) newIdSlot.captured else bffId
+            // Then
+            assertEquals(itemView, viewsWithContext[0])
         }
-        val recyclerId = 0
-        val position = 0
-        val generatedId = 100
-        every { listViewIdViewModel.setViewId(recyclerId, position, bffId) } returns generatedId
 
-        // When
-        listViewHolder.onBind(null, null, listItem, position, recyclerId)
+        @DisplayName("Then should add imageView to directNestedImageViews")
+        @Test
+        fun directNestedImageViews() {
+            // Given
+            val itemView = mockk<ImageView>(relaxed = true)
 
-        // Then
-        verify(exactly = 1) { viewModel.onViewIdChanged(bffId, newIdSlot.captured, itemView) }
-    }
+            // When
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
 
-    @Test
-    fun `GIVEN a firstTimeBinding item with id WHEN onBind THEN should updateIdToEachSubView`() {
-        // Given
-        val previousId = 100
-        every { listItem.firstTimeBinding } returns true
-        every { itemView.id } returns previousId
-        val recyclerId = 0
-        val position = 0
-        every { listViewIdViewModel.setViewId(recyclerId, position, previousId) } returns previousId
-        val idSlot = slot<Int>()
-        every { listItem.viewIds } returns mockk {
-            every { add(capture(idSlot)) } returns true
+            // Then
+            assertEquals(itemView, listViewHolder.directNestedImageViews[0])
         }
-        val viewIdSlot = slot<Int>()
-        every { itemView.id = capture(viewIdSlot) } just Runs
 
-        // When
-        listViewHolder.onBind(null, null, listItem, position, recyclerId)
+        @DisplayName("Then should add textView to directNestedTextViews")
+        @Test
+        fun directNestedTextViews() {
+            // Given
+            val itemView = mockk<TextView>(relaxed = true)
 
-        // Then
-        assertEquals(previousId, viewIdSlot.captured)
-        assertEquals(previousId, idSlot.captured)
-        verify(exactly = 1) { listViewIdViewModel.setViewId(recyclerId, position, previousId) }
-    }
+            // When
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
 
-    @Test
-    fun `GIVEN a firstTimeBinding recycled item WHEN onBind THEN should setDefaultContextToEachContextView`() {
-        // Given
-        every { listItem.firstTimeBinding } returns true
-        every { listItem.isRecycled } returns true
-        every { itemView.getContextBinding() } returns mockk {
-            every { context } returns ContextData("id", "value")
+            // Then
+            assertEquals(itemView, listViewHolder.directNestedTextViews[0])
         }
-        val context = mockk<ContextData>()
-        every { viewModel.getContextData(itemView) } returns context
 
-        val contextSlot = mutableListOf<ContextData>()
-        every { viewModel.addContext(itemView, capture(contextSlot), shouldOverrideExistingContext = true) } just Runs
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+        @DisplayName("Then should add recyclerView to directNestedRecyclers")
+        @Test
+        fun directNestedRecyclers() {
+            // Given
+            val itemView = mockk<RecyclerView>(relaxed = true)
 
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
+            // When
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+            val directNestedRecyclers = listViewHolder.getPrivateField<MutableList<RecyclerView>>("directNestedRecyclers")
 
-        // Then
-        assertEquals(context, contextSlot[0])
-    }
-
-    @Test
-    fun `GIVEN a firstTimeBinding recycled item with savedContext WHEN onBind THEN should setDefaultContextToEachContextView`() {
-        // Given
-        every { listItem.firstTimeBinding } returns true
-        every { listItem.isRecycled } returns true
-        every { itemView.getContextBinding() } returns mockk {
-            every { context } returns ContextData("id", "otherContext")
+            // Then
+            assertEquals(itemView, directNestedRecyclers[0])
         }
-        every { viewModel.getContextData(itemView) } returns null
-
-        val context = ContextData("id", "savedContext")
-        val template = Container(children = listOf(), context = context)
-        every { serializer.deserializeComponent(jsonTemplate) } returns template
-
-        val contextSlot = mutableListOf<ContextData>()
-        every { viewModel.addContext(itemView, capture(contextSlot), shouldOverrideExistingContext = true) } just Runs
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
-
-        // Then
-        assertEquals(context, contextSlot[0])
     }
 
-    @Test
-    fun `GIVEN a firstTimeBinding recycled item with recycler WHEN onBind THEN should generateAdapterToEachDirectNestedRecycler`() {
-        // Given
-        every { listItem.firstTimeBinding } returns true
-        every { listItem.isRecycled } returns true
-        val itemView = mockk<RecyclerView>(relaxed = true)
-        every { itemView.adapter } returns mockk<ListAdapter>(relaxed = true)
-        val jsonTemplate = """{ "_beagleComponent_": "beagle:button", "text": "Test" }""".trimIndent()
-        every { anyConstructed<BeagleSerializer>().serializeComponent(any()) } returns jsonTemplate
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+    @DisplayName("When onBind is called")
+    @Nested
+    inner class OnBind {
 
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
+        @DisplayName("Then should clear contextComponents")
+        @Test
+        fun contextComponents() {
+            // Given
+            val contexts = listViewHolder.getPrivateField<MutableList<ContextData>>("contextComponents")
+            contexts.add(mockk())
 
-        // Then
-        verify(exactly = 1) { itemView.swapAdapter(any(), false) }
-        assertTrue(listItem.directNestedAdapters.isNotEmpty())
-    }
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
 
-    @Test
-    fun `GIVEN a firstTimeBinding not recycled item with recycler WHEN onBind THEN should saveCreatedAdapterToEachDirectNestedRecycler`() {
-        // Given
-        val listItem = ListItem(data = "stub")
-        val itemView = mockk<RecyclerView>(relaxed = true)
-        val adapter = mockk<ListAdapter>(relaxed = true)
-        every { itemView.adapter } returns adapter
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
-
-        // Then
-        assertEquals(adapter, listItem.directNestedAdapters[0])
-    }
-
-    @Test
-    fun `GIVEN a firstTimeBinding item with recycler WHEN onBind THEN should updateDirectNestedAdaptersSuffix`() {
-        // Given
-        val suffix = "suffix"
-        val listItem = ListItem(data = "stub", itemSuffix = suffix)
-        val itemView = mockk<RecyclerView>(relaxed = true)
-        val itemSuffixSlot = slot<String>()
-        val adapter = mockk<ListAdapter>(relaxed = true) {
-            every { setParentSuffix(capture(itemSuffixSlot)) } just Runs
+            // Then
+            assertTrue { contexts.isEmpty() }
         }
-        every { itemView.adapter } returns adapter
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
 
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
+        @DisplayName("Then should call deserializeComponent to a recycled item")
+        @Test
+        fun deserializeComponent() {
+            // Given
+            every { listItem.isRecycled } returns true
 
-        // Then
-        assertEquals(suffix, itemSuffixSlot.captured)
-    }
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
 
-    @Test
-    fun `GIVEN a not firstTimeBinding item WHEN onBind THEN should restoreIds`() {
-        // Given
-        val viewIds = LinkedList<Int>().apply {
-            add(100)
+            // Then
+            verify(exactly = 1) { serializer.deserializeComponent(jsonTemplate) }
         }
-        every { listItem.viewIds } returns viewIds
-        val idSlot = slot<Int>()
-        every { itemView.id = capture(idSlot) } just Runs
 
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
+        @DisplayName("Then should add to contextComponents to a contextComponent")
+        @Test
+        fun contextComponent() {
+            // Given
+            val context = ContextData("id", "value")
+            val template = Container(children = listOf(), context = context)
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
 
-        // Then
-        assertEquals(viewIds[0], idSlot.captured)
-    }
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+            val contexts = listViewHolder.getPrivateField<MutableList<ContextData>>("contextComponents")
 
-    @Test
-    fun `GIVEN a not firstTimeBinding item WHEN onBind THEN should restoreAdapters`() {
-        // Given
-        val itemView = mockk<RecyclerView>(relaxed = true)
-        val adapter = mockk<ListAdapter>(relaxed = true)
-        val adapters = LinkedList<ListAdapter>().apply {
-            add(adapter)
+            // Then
+            assertEquals(context, contexts[0])
         }
-        every { listItem.directNestedAdapters } returns adapters
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
 
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
+        @DisplayName("Then should generateItemSuffix to a firstTimeBinding item")
+        @Test
+        fun generateItemSuffix() {
+            // Given
+            every { listItem.firstTimeBinding } returns true
+            val itemSuffixSlot = slot<String>()
+            every { listItem.itemSuffix = capture(itemSuffixSlot) } just Runs
+            val position = 0
+            val listIdByItemKey = position.toString()
 
-        // Then
-        verify(exactly = 1) { itemView.swapAdapter(adapter, false) }
-    }
+            // When
+            listViewHolder.onBind(null, null, listItem, position, 0)
 
-    @Test
-    fun `GIVEN a not firstTimeBinding item WHEN onBind THEN should restoreContexts`() {
-        // Given
-        every { itemView.getContextBinding() } returns mockk {
-            every { context } returns ContextData("id", "value")
+            // Then
+            assertEquals(listIdByItemKey, itemSuffixSlot.captured)
         }
-        listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
 
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
+        @DisplayName("Then should generateItemSuffix to a firstTimeBinding item with parent")
+        @Test
+        fun generateItemSuffixWithParent() {
+            // Given
+            every { listItem.firstTimeBinding } returns true
+            val itemSuffixSlot = slot<String>()
+            every { listItem.itemSuffix = capture(itemSuffixSlot) } just Runs
+            val parentListViewSuffix = "identifier"
+            val position = 0
+            val listIdByItemKey = "$parentListViewSuffix:$position"
 
-        // Then
-        verify(exactly = 1) { viewModel.restoreContext(itemView) }
-    }
+            // When
+            listViewHolder.onBind(parentListViewSuffix, null, listItem, position, 0)
 
-    @Test
-    fun `GIVEN an item WHEN onBind THEN should setContext`() {
-        // Given
-        val data = "data"
-        every { listItem.data } returns data
-        val contextSlot = slot<ContextData>()
-        every { viewModel.addContext(itemView, capture(contextSlot), true) } just Runs
+            // Then
+            assertEquals(listIdByItemKey, itemSuffixSlot.captured)
+        }
 
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
+        @DisplayName("Then should generateItemSuffix to a firstTimeBinding item with key")
+        @Test
+        fun generateItemSuffixWithKey() {
+            // Given
+            every { listItem.firstTimeBinding } returns true
+            val itemSuffixSlot = slot<String>()
+            every { listItem.itemSuffix = capture(itemSuffixSlot) } just Runs
+            val data = JSONObject(""" { id: 10, name: Item } """.trimIndent())
+            every { listItem.data } returns data
+            val listIdByItemKey = "10"
 
-        // Then
-        assertEquals(iteratorName, contextSlot.captured.id)
-        assertEquals(data, contextSlot.captured.value)
-    }
+            // When
+            listViewHolder.onBind(null, "id", listItem, 0, 0)
 
-    @Test
-    fun `GIVEN an item WHEN onBind THEN should set firstTimeBinding to false`() {
-        // Given
-        val listItem = ListItem(data = "stub")
+            // Then
+            assertEquals(listIdByItemKey, itemSuffixSlot.captured)
+        }
 
-        // When
-        listViewHolder.onBind(null, null, listItem, 0, 0)
+        @DisplayName("Then should updateIdToEachSubView to a firstTimeBinding item")
+        @Test
+        fun updateIdToEachSubView() {
+            // Given
+            every { listItem.firstTimeBinding } returns true
+            every { itemView.id } returns View.NO_ID
+            val recyclerId = 0
+            val position = 0
+            val generatedId = 100
+            every { listViewIdViewModel.getViewId(recyclerId, position) } returns generatedId
+            val idSlot = slot<Int>()
+            every { listItem.viewIds } returns mockk {
+                every { add(capture(idSlot)) } returns true
+            }
+            val viewIdSlot = slot<Int>()
+            every { itemView.id = capture(viewIdSlot) } just Runs
 
-        // Then
-        assertFalse(listItem.firstTimeBinding)
+            // When
+            listViewHolder.onBind(null, null, listItem, position, recyclerId)
+
+            // Then
+            assertEquals(generatedId, viewIdSlot.captured)
+            assertEquals(generatedId, idSlot.captured)
+            verify(exactly = 1) { viewModel.setIdToViewWithContext(itemView) }
+        }
+
+        @DisplayName("Then should updateIdToEachSubView to a firstTimeBinding item with bff id")
+        @Test
+        fun updateIdToEachSubViewWithBffId() {
+            // Given
+            val bffId = "idFromBff".toAndroidId()
+            every { listItem.firstTimeBinding } returns true
+            val newIdSlot = slot<Int>()
+            every { itemView.id = capture(newIdSlot) } just Runs
+            every { itemView.id } answers {
+                if (newIdSlot.isCaptured) newIdSlot.captured else bffId
+            }
+            val recyclerId = 0
+            val position = 0
+            val generatedId = 100
+            every { listViewIdViewModel.setViewId(recyclerId, position, bffId) } returns generatedId
+
+            // When
+            listViewHolder.onBind(null, null, listItem, position, recyclerId)
+
+            // Then
+            verify(exactly = 1) { viewModel.onViewIdChanged(bffId, newIdSlot.captured, itemView) }
+        }
+
+        @DisplayName("Then should updateIdToEachSubView to a firstTimeBinding item with id")
+        @Test
+        fun updateIdToEachSubViewWithId() {
+            // Given
+            val previousId = 100
+            every { listItem.firstTimeBinding } returns true
+            every { itemView.id } returns previousId
+            val recyclerId = 0
+            val position = 0
+            every { listViewIdViewModel.setViewId(recyclerId, position, previousId) } returns previousId
+            val idSlot = slot<Int>()
+            every { listItem.viewIds } returns mockk {
+                every { add(capture(idSlot)) } returns true
+            }
+            val viewIdSlot = slot<Int>()
+            every { itemView.id = capture(viewIdSlot) } just Runs
+
+            // When
+            listViewHolder.onBind(null, null, listItem, position, recyclerId)
+
+            // Then
+            assertEquals(previousId, viewIdSlot.captured)
+            assertEquals(previousId, idSlot.captured)
+            verify(exactly = 1) { listViewIdViewModel.setViewId(recyclerId, position, previousId) }
+        }
+
+        @DisplayName("Then should setDefaultContextToEachContextView to a firstTimeBinding recycled item")
+        @Test
+        fun setDefaultContextToEachContextView() {
+            // Given
+            every { listItem.firstTimeBinding } returns true
+            every { listItem.isRecycled } returns true
+            every { itemView.getContextBinding() } returns mockk {
+                every { context } returns ContextData("id", "value")
+            }
+            val context = mockk<ContextData>()
+            every { viewModel.getContextData(itemView) } returns context
+
+            val contextSlot = mutableListOf<ContextData>()
+            every { viewModel.addContext(itemView, capture(contextSlot), shouldOverrideExistingContext = true) } just Runs
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            assertEquals(context, contextSlot[0])
+        }
+
+        @DisplayName("Then should setDefaultContextToEachContextView to a firstTimeBinding recycled item with savedContext")
+        @Test
+        fun setDefaultContextToEachContextViewWithContext() {
+            // Given
+            every { listItem.firstTimeBinding } returns true
+            every { listItem.isRecycled } returns true
+            every { itemView.getContextBinding() } returns mockk {
+                every { context } returns ContextData("id", "otherContext")
+            }
+            every { viewModel.getContextData(itemView) } returns null
+
+            val context = ContextData("id", "savedContext")
+            val template = Container(children = listOf(), context = context)
+            every { serializer.deserializeComponent(jsonTemplate) } returns template
+
+            val contextSlot = mutableListOf<ContextData>()
+            every { viewModel.addContext(itemView, capture(contextSlot), shouldOverrideExistingContext = true) } just Runs
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            assertEquals(context, contextSlot[0])
+        }
+
+        @DisplayName("Then should generateAdapterToEachDirectNestedRecycler to a firstTimeBinding recycled item with recycler")
+        @Test
+        fun generateAdapterToEachDirectNestedRecycler() {
+            // Given
+            every { listItem.firstTimeBinding } returns true
+            every { listItem.isRecycled } returns true
+            val itemView = mockk<RecyclerView>(relaxed = true)
+            every { itemView.adapter } returns mockk<ListAdapter>(relaxed = true)
+            val jsonTemplate = """{ "_beagleComponent_": "beagle:button", "text": "Test" }""".trimIndent()
+            every { anyConstructed<BeagleSerializer>().serializeComponent(any()) } returns jsonTemplate
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            verify(exactly = 1) { itemView.swapAdapter(any(), false) }
+            assertTrue(listItem.directNestedAdapters.isNotEmpty())
+        }
+
+        @DisplayName("Then should saveCreatedAdapterToEachDirectNestedRecycler to a firstTimeBinding not recycled item with recycler")
+        @Test
+        fun saveCreatedAdapterToEachDirectNestedRecycler() {
+            // Given
+            val listItem = ListItem(data = "stub")
+            val itemView = mockk<RecyclerView>(relaxed = true)
+            val adapter = mockk<ListAdapter>(relaxed = true)
+            every { itemView.adapter } returns adapter
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            assertEquals(adapter, listItem.directNestedAdapters[0])
+        }
+
+        @DisplayName("Then should updateDirectNestedAdaptersSuffix to a firstTimeBinding item with recycler")
+        @Test
+        fun updateDirectNestedAdaptersSuffix() {
+            // Given
+            val suffix = "suffix"
+            val listItem = ListItem(data = "stub", itemSuffix = suffix)
+            val itemView = mockk<RecyclerView>(relaxed = true)
+            val itemSuffixSlot = slot<String>()
+            val adapter = mockk<ListAdapter>(relaxed = true) {
+                every { setParentSuffix(capture(itemSuffixSlot)) } just Runs
+            }
+            every { itemView.adapter } returns adapter
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            assertEquals(suffix, itemSuffixSlot.captured)
+        }
+
+        @DisplayName("Then should restoreIds to a not firstTimeBinding item")
+        @Test
+        fun restoreIds() {
+            // Given
+            val viewIds = LinkedList<Int>().apply {
+                add(100)
+            }
+            every { listItem.viewIds } returns viewIds
+            val idSlot = slot<Int>()
+            every { itemView.id = capture(idSlot) } just Runs
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            assertEquals(viewIds[0], idSlot.captured)
+        }
+
+        @DisplayName("Then should restoreAdapters to a not firstTimeBinding item")
+        @Test
+        fun restoreAdapters() {
+            // Given
+            val itemView = mockk<RecyclerView>(relaxed = true)
+            val adapter = mockk<ListAdapter>(relaxed = true)
+            val adapters = LinkedList<ListAdapter>().apply {
+                add(adapter)
+            }
+            every { listItem.directNestedAdapters } returns adapters
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            verify(exactly = 1) { itemView.swapAdapter(adapter, false) }
+        }
+
+        @DisplayName("Then should restoreContexts to a not firstTimeBinding item")
+        @Test
+        fun restoreContexts() {
+            // Given
+            every { itemView.getContextBinding() } returns mockk {
+                every { context } returns ContextData("id", "value")
+            }
+            listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            verify(exactly = 1) { viewModel.restoreContext(itemView) }
+        }
+
+        @DisplayName("Then should setContext to every item")
+        @Test
+        fun setContext() {
+            // Given
+            val data = "data"
+            every { listItem.data } returns data
+            val contextSlot = slot<ContextData>()
+            every { viewModel.addContext(itemView, capture(contextSlot), true) } just Runs
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            assertEquals(iteratorName, contextSlot.captured.id)
+            assertEquals(data, contextSlot.captured.value)
+        }
+
+        @DisplayName("Then should set firstTimeBinding to false to every item")
+        @Test
+        fun firstTimeBinding() {
+            // Given
+            val listItem = ListItem(data = "stub")
+
+            // When
+            listViewHolder.onBind(null, null, listItem, 0, 0)
+
+            // Then
+            assertFalse(listItem.firstTimeBinding)
+        }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -553,10 +553,43 @@ class ContextDataManagerTest : BaseTest() {
         val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
 
         // When
-        contextDataManager.onViewIdChanged(oldId, newId)
+        contextDataManager.onViewIdChanged(oldId, newId, viewWithId)
 
         // Then
         assertEquals(contexts[newId], viewWithId.getContextBinding())
+        assertNull(contexts[oldId])
+    }
+
+    @Test
+    fun `GIVEN a view with oldId and context with newId WHEN onViewIdChanged THEN should update new and remove old`() {
+        // Given
+        val oldId = 0
+        val newId = 1
+        val oldContextData = ContextData("old", true)
+        val oldViewWithId = mockk<View>(relaxed = true) {
+            every { id } returns oldId
+            every { getContextBinding() } returns mockk(relaxed = true) {
+                every { context } returns oldContextData
+            }
+        }
+        contextDataManager.addContext(oldViewWithId, oldContextData)
+
+        val newContextData = ContextData("new", true)
+        val newViewWithId = mockk<View>(relaxed = true) {
+            every { id } returns newId
+            every { getContextBinding() } returns mockk(relaxed = true) {
+                every { context } returns newContextData
+            }
+        }
+        contextDataManager.addContext(newViewWithId, newContextData)
+
+        val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
+
+        // When
+        contextDataManager.onViewIdChanged(oldId, newId, newViewWithId)
+
+        // Then
+        assertEquals(contexts[newId], newViewWithId.getContextBinding())
         assertNull(contexts[oldId])
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/ContextDataManagerTest.kt
@@ -33,24 +33,27 @@ import br.com.zup.beagle.android.utils.setContextBinding
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
-import io.mockk.verify
 import io.mockk.mockk
-import io.mockk.verifyOrder
-import io.mockk.spyk
-import io.mockk.slot
 import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyOrder
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
 private val CONTEXT_ID = RandomData.string()
 
+@DisplayName("Given a ContextDataManager")
 class ContextDataManagerTest : BaseTest() {
 
     private lateinit var contextDataManager: ContextDataManager
@@ -77,519 +80,599 @@ class ContextDataManagerTest : BaseTest() {
         viewBinding = contextDataManager.getPrivateField("viewBinding")
     }
 
-    @Test
-    fun init_should_add_observer_to_GlobalContext() {
-        // Given
-        every { GlobalContext.observeGlobalContextChange(any()) } just Runs
+    @DisplayName("When create the ContextDataManager")
+    @Nested
+    inner class Init {
 
-        // When
-        val contextDataManager = ContextDataManager()
+        @DisplayName("Then should add observer to GlobalContext")
+        @Test
+        fun globalContext() {
+            // Given
+            every { GlobalContext.observeGlobalContextChange(any()) } just Runs
 
-        // Then
-        val contexts = contextDataManager.getPrivateField<Map<Int, ContextBinding>>("contexts")
-        assertNotNull(contexts[Int.MAX_VALUE])
-        verify { GlobalContext.observeGlobalContextChange(any()) }
-    }
+            // When
+            val contextDataManager = ContextDataManager()
 
-    @Test
-    fun addContext_should_add_new_context() {
-        // Given
-        val contextData = ContextData(CONTEXT_ID, true)
-
-        // When
-        contextDataManager.addContext(viewContext, contextData)
-
-        // Then
-        val contextBinding = contexts[viewContext.id]
-        assertNotNull(contextBinding)
-        assertEquals(contextBinding?.context, contextData)
-        assertEquals(0, contextBinding?.bindings?.size)
-        assertEquals(contextData, viewContext.getContextData())
-    }
-
-    @Test
-    fun addContext_should_not_add_global_context() {
-        // Given
-        val contextData = ContextData("global", true)
-        every { BeagleMessageLogs.globalKeywordIsReservedForGlobalContext() } just Runs
-
-        // When
-        contextDataManager.addContext(viewContext, contextData)
-
-        // Then
-        verify(exactly = once()) { BeagleMessageLogs.globalKeywordIsReservedForGlobalContext() }
-    }
-
-    @Test
-    fun addContext_should_not_add_new_context_when_context_already_exists() {
-        // Given
-        val contextData1 = ContextData(CONTEXT_ID, true)
-        val contextData2 = ContextData(CONTEXT_ID, false)
-
-        // When
-        contextDataManager.addContext(viewContext, contextData1)
-        contextDataManager.addContext(viewContext, contextData2)
-
-        // Then
-        assertEquals(contextData1, contexts[viewContext.id]?.context)
-        assertEquals(contextData1, viewContext.getContextData())
-    }
-
-    @Test
-    fun `GIVEN context already exists WHEN addContext again THEN should add only if flag enabled`() {
-        // Given
-        val contextData1 = ContextData(CONTEXT_ID, true)
-        val contextData2 = ContextData(CONTEXT_ID, false)
-        contextDataManager.addContext(viewContext, contextData1)
-
-        // When
-        contextDataManager.addContext(viewContext, contextData2, true)
-
-        // Then
-        assertEquals(contextData2, contexts[viewContext.id]?.context)
-        assertEquals(contextData2, viewContext.getContextData())
-    }
-
-    @Test
-    fun addContext_should_clear_bindings_when_context_already_exists() {
-        // Given
-        val contextData = ContextData(CONTEXT_ID, true)
-        contexts[viewContext.id] = ContextBinding(
-            context = contextData,
-            bindings = mutableSetOf(Binding<Boolean>(
-                observer = mockk(),
-                bind = mockk()
-            ))
-        )
-
-        // When
-        contextDataManager.addContext(viewContext, contextData)
-
-        // Then
-        assertTrue { contexts[viewContext.id]?.bindings?.isEmpty() ?: false }
-    }
-
-    @Test
-    fun addBinding_should_add_bind_to_context_to_viewBinding() {
-        // Given
-        val viewWithBind = mockk<View>()
-        val bind = Bind.Expression(listOf(), "@{$CONTEXT_ID[0]}", type = Boolean::class.java)
-        val contextData = ContextData(CONTEXT_ID, listOf(true))
-        val observer = mockk<Observer<Boolean?>>()
-        contextDataManager.addContext(viewContext, contextData)
-
-        // When
-        contextDataManager.addBinding(viewWithBind, bind, observer)
-
-        // Then
-        val binding = viewBinding[viewWithBind]?.first()
-        assertEquals(bind, binding?.bind)
-        assertEquals(observer, binding?.observer)
-    }
-
-    @Test
-    fun addBinding_should_add_binding_to_context_on_top_of_stack() {
-        // Given
-        val viewWithBind = createViewForContext(viewContext)
-        val bind = expressionOf<Boolean>("@{$CONTEXT_ID}")
-        val observer = mockk<Observer<Boolean?>>(relaxed = true)
-        val contextData = ContextData(CONTEXT_ID, true)
-        contextDataManager.addContext(viewContext, contextData)
-
-        // When
-        contextDataManager.addBinding(viewWithBind, bind, observer)
-        contextDataManager.linkBindingToContextAndEvaluateThem(viewWithBind)
-
-        // Then
-        val contextBinding = contexts[viewContext.id]?.bindings?.first()
-        assertEquals(bind, contextBinding?.bind)
-        assertEquals(observer, contextBinding?.observer)
-        assertTrue { viewBinding.isEmpty() }
-    }
-
-    @Test
-    fun addBinding_should_add_binding_to_global_context() {
-        // Given
-        val viewWithBind = createViewForContext()
-        val bind = expressionOf<Boolean>("@{global}")
-        val observer = mockk<Observer<Boolean?>>(relaxed = true)
-        contextDataManager.addBinding(viewWithBind, bind, observer)
-
-        // When
-        contextDataManager.linkBindingToContextAndEvaluateThem(viewWithBind)
-
-        // Then
-        val contextBinding = contexts[Int.MAX_VALUE]?.bindings?.first()
-        assertEquals(bind, contextBinding?.bind)
-        assertEquals(observer, contextBinding?.observer)
-    }
-
-    @Test
-    fun linkBindingToContextAndEvaluateThem_should_call_notifyBindingChanges_if_view_is_not_in_viewBinding() {
-        // Given
-        val viewWithBind = createViewForContext()
-        val contextBinding = mockk<ContextBinding>(relaxed = true)
-        viewWithBind.setContextBinding(contextBinding)
-
-        // When
-        contextDataManager.linkBindingToContextAndEvaluateThem(viewWithBind)
-
-        // Then
-        verify(exactly = once()) { contextDataManager.notifyBindingChanges(contextBinding) }
-    }
-
-    @Test
-    fun updateContext_should_update_context_data_with_context_id() {
-        // Given
-        val json = JSONObject().apply {
-            put("a", true)
-        }
-        val contextData = ContextData(CONTEXT_ID, json)
-        val updateContext = SetContextInternal(CONTEXT_ID, false, "a")
-        contextDataManager.addContext(viewContext, contextData)
-
-        // When
-        contextDataManager.updateContext(viewContext, updateContext)
-
-        // Then
-        assertFalse { json.getBoolean("a") }
-    }
-
-    @Test
-    fun updateContext_should_set_value_on_context_root() {
-        // Given
-        val contextData = ContextData(CONTEXT_ID, true)
-        val updateContext = SetContextInternal(CONTEXT_ID, false, null)
-        contextDataManager.addContext(viewContext, contextData)
-
-        // When
-        contextDataManager.updateContext(viewContext, updateContext)
-
-        // Then
-        val contextBinding = contexts[viewContext.id]?.context
-        assertEquals(updateContext.contextId, contextBinding?.id)
-        assertEquals(updateContext.value, contextBinding?.value)
-    }
-
-    @Test
-    fun updateContext_should_call_global_context_when_id_is_global() {
-        // Given
-        val updateContext = SetContextInternal("global", false, null)
-
-        // When
-        contextDataManager.updateContext(viewContext, updateContext)
-
-        // Then
-        verify(exactly = once()) { GlobalContext.set(updateContext.value, updateContext.path) }
-    }
-
-    @Test
-    fun getContextsFromBind_should_filter_all_contexts_from_view_hierarchy() {
-        // Given
-        val contextId1 = RandomData.string()
-        val contextId2 = RandomData.string()
-        val bind = expressionOf<String>("@{$contextId1} @{$contextId2}")
-        val viewContext1 = createViewForContext()
-        viewContext1.setContextBinding(ContextBinding(
-            ContextData(
-                id = contextId1,
-                value = RandomData.string()
-            ))
-        )
-        val viewContext2 = createViewForContext(viewContext1)
-        viewContext2.setContextBinding(ContextBinding(
-            ContextData(
-                id = contextId2,
-                value = RandomData.string()
-            ))
-        )
-
-        // When
-        val contexts = contextDataManager.getContextsFromBind(viewContext2, bind)
-
-        // Then
-        assertEquals(2, contexts.size)
-        assertEquals(contextId2, contexts[0].id)
-        assertEquals(contextId1, contexts[1].id)
-    }
-
-    @Test
-    fun getContextsFromBind_should_return_globalContext() {
-        // Given
-        val bind = expressionOf<String>("@{global}")
-        val viewContext = createViewForContext()
-
-        // When
-        val contexts = contextDataManager.getContextsFromBind(viewContext, bind)
-
-        // Then
-        assertEquals("global", contexts.first().id)
-    }
-
-    @Test
-    fun `GIVEN contextDataManager with contexts WHEN clearContexts THEN should clear viewBindings, contexts and contextsWithoutId`() {
-        // Given
-        val bind = mockk<Bind.Expression<Boolean>>()
-        val observer = mockk<Observer<Boolean?>>()
-        val context = ContextData(id = RandomData.string(), value = RandomData.string())
-        val contextDataManager = ContextDataManager()
-        val viewWithoutId = mockk<View>(relaxed = true) {
-            every { id } returns View.NO_ID
-            every { getContextBinding() } returns mockk(relaxed = true)
-        }
-        contextDataManager.addContext(viewWithoutId, context)
-        contextDataManager.addContext(viewContext, context)
-        contextDataManager.addBinding(viewContext, bind, observer)
-        val contexts: Map<Int, ContextBinding> = contextDataManager.getPrivateField("contexts")
-        val contextsWithoutId: Map<View, ContextBinding> = contextDataManager.getPrivateField("contextsWithoutId")
-        val viewBinding: Map<View, MutableSet<Binding<*>>> = contextDataManager.getPrivateField("viewBinding")
-        val contextsWithoutIdSizeBefore = contextsWithoutId.size
-        val contextsSizeBefore = contexts.size
-        val viewBindingSizeBefore = viewBinding.size
-        every { GlobalContext.clearObserverGlobalContext(any()) } just Runs
-
-        // When
-        contextDataManager.clearContexts()
-
-        // Then
-        assertNotEquals(contextsWithoutIdSizeBefore, contextsWithoutId.size)
-        assertNotEquals(contextsSizeBefore, contexts.size)
-        assertNotEquals(viewBindingSizeBefore, viewBinding.size)
-        assertTrue { contexts.isEmpty() }
-        assertTrue { contextsWithoutId.isEmpty() }
-        assertTrue { viewBinding.isEmpty() }
-        verify(exactly = once()) { GlobalContext.clearObserverGlobalContext(any()) }
-    }
-
-    @Test
-    fun evaluateContexts_should_get_value_from_evaluation() {
-        // Given
-        val value = true
-        val contextData = ContextData(CONTEXT_ID, value)
-        val bind = expressionOf<Boolean>("@{$CONTEXT_ID}")
-        val observer = mockk<Observer<Boolean?>>(relaxed = true)
-        contextDataManager.addContext(viewContext, contextData)
-        contextDataManager.addBinding(viewContext, bind, observer)
-
-        // When
-        contextDataManager.linkBindingToContextAndEvaluateThem(viewContext)
-
-        // Then
-        verify(exactly = once()) { observer(value) }
-    }
-
-    @Test
-    fun evaluateContexts_should_get_value_from_operation() {
-        // Given
-        val value = 2
-        val contextData = ContextData(CONTEXT_ID, value)
-        val bind = expressionOf<Int>("@{sum(1, 1)}")
-        val observer = mockk<Observer<Int?>>(relaxed = true)
-        contextDataManager.addContext(viewContext, contextData)
-        contextDataManager.addBinding(viewContext, bind, observer)
-
-        // When
-        contextDataManager.linkBindingToContextAndEvaluateThem(viewContext)
-
-        // Then
-        verify(exactly = once()) { observer(value) }
-    }
-
-    @Test
-    fun evaluateContexts_should_get_null_value_from_evaluation() {
-        // Given
-        val value = true
-        val contextData = ContextData(CONTEXT_ID, value)
-        val bind = expressionOf<Boolean>("@{$CONTEXT_ID.a}")
-        val observer = mockk<Observer<Boolean?>>(relaxed = true)
-        contextDataManager.addContext(viewContext, contextData)
-        contextDataManager.addBinding(viewContext, bind, observer)
-
-        // When
-        contextDataManager.linkBindingToContextAndEvaluateThem(viewContext)
-
-        // Then
-        verify(exactly = once()) { observer(null) }
-    }
-
-    @Test
-    fun evaluateContexts_should_get_different_value_type_from_context_evaluation() {
-        // Given
-        val contextData = ContextData(CONTEXT_ID, "value")
-        val bind = expressionOf<Boolean>("@{$CONTEXT_ID}")
-        contextDataManager.addContext(viewContext, contextData)
-        contextDataManager.addBinding(viewContext, bind) {
             // Then
-            assertNull(it)
+            val contexts = contextDataManager.getPrivateField<Map<Int, ContextBinding>>("contexts")
+            assertNotNull(contexts[Int.MAX_VALUE])
+            verify { GlobalContext.observeGlobalContextChange(any()) }
         }
-        contextDataManager.linkBindingToContextAndEvaluateThem(viewContext)
-    }
 
-    @Test
-    fun init_must_add_observer_to_GlobalContext_and_validate_the_updateGlobalContext_method() {
-        // Given
-        val globalContextObserver = slot<GlobalContextObserver>()
-        val contextData = ContextData("global", "")
-        val globalContextMock = mockk<ContextBinding>(relaxed = true) {
-            every { copy(any(), any(), any()) } returns this
-        }
-        val cache = mockk<LruCache<String, Any>>(relaxed = true)
-        every { globalContextMock.cache } returns cache
-        every { GlobalContext.observeGlobalContextChange(capture(globalContextObserver)) } just Runs
-
-        // When
-        val contextDataManager = spyk<ContextDataManager>(recordPrivateCalls = true)
-        val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
-        contextDataManager.setPrivateField("globalContext", globalContextMock)
-        globalContextObserver.captured.invoke(contextData)
-
-        // Then
-        verifyOrder {
-            globalContextMock.copy(context = contextData, cache = any(), bindings = any())
-            cache.evictAll()
-            contextDataManager.notifyBindingChanges(globalContextMock)
-        }
-        assertEquals(contexts[Int.MAX_VALUE], globalContextMock)
-    }
-
-    @Test
-    fun `GIVEN a view with id that has context WHEN getContextData THEN should return it`() {
-        // Given
-        val contextData = ContextData(CONTEXT_ID, true)
-        contextDataManager.addContext(viewContext, contextData)
-
-        // When
-        val result = contextDataManager.getContextData(viewContext)
-
-        // Then
-        assertEquals(contextData, result)
-    }
-
-    @Test
-    fun `GIVEN a view with id that has context WHEN restoreContext THEN should update view's context`() {
-        // Given
-        val contextData = ContextData(CONTEXT_ID, true)
-        contextDataManager.addContext(viewContext, contextData)
-
-        // When
-        contextDataManager.restoreContext(viewContext)
-
-        // Then
-        assertEquals(contextData, viewContext.getContextData())
-    }
-
-    @Test
-    fun `GIVEN a view without id that has context WHEN setIdToViewWithContext THEN should update view's context`() {
-        // Given
-        val contextData1 = ContextData(CONTEXT_ID, true)
-        val viewWithoutId = mockk<View>(relaxed = true) {
-            every { id } returns View.NO_ID
-            every { getContextBinding() } returns mockk(relaxed = true) {
-                every { context } returns contextData1
+        @DisplayName("Then should add observer to GlobalContext and validate the updateGlobalContext method")
+        @Test
+        fun globalContextMethod() {
+            // Given
+            val globalContextObserver = slot<GlobalContextObserver>()
+            val contextData = ContextData("global", "")
+            val globalContextMock = mockk<ContextBinding>(relaxed = true) {
+                every { copy(any(), any(), any()) } returns this
             }
-        }
-        contextDataManager.addContext(viewWithoutId, contextData1)
+            val cache = mockk<LruCache<String, Any>>(relaxed = true)
+            every { globalContextMock.cache } returns cache
+            every { GlobalContext.observeGlobalContextChange(capture(globalContextObserver)) } just Runs
 
-        val contextData2 = ContextData(CONTEXT_ID, false)
-        val viewWithId = viewWithoutId.apply {
-            every { id } returns 10
-            every { getContextBinding() } returns mockk(relaxed = true) {
-                every { context } returns contextData2
+            // When
+            val contextDataManager = spyk<ContextDataManager>(recordPrivateCalls = true)
+            val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
+            contextDataManager.setPrivateField("globalContext", globalContextMock)
+            globalContextObserver.captured.invoke(contextData)
+
+            // Then
+            verifyOrder {
+                globalContextMock.copy(context = contextData, cache = any(), bindings = any())
+                cache.evictAll()
+                contextDataManager.notifyBindingChanges(globalContextMock)
             }
+            assertEquals(contexts[Int.MAX_VALUE], globalContextMock)
         }
-        contextDataManager.addContext(viewWithId, contextData2)
-
-        val contextsWithoutId: Map<View, ContextBinding> = contextDataManager.getPrivateField("contextsWithoutId")
-        val contextsWithoutIdSizeBefore = contextsWithoutId.size
-
-        // When
-        contextDataManager.setIdToViewWithContext(viewWithId)
-
-        // Then
-        assertEquals(contextData2, viewWithId.getContextData())
-        assertNotEquals(contextsWithoutIdSizeBefore, contextsWithoutId.size)
     }
 
-    @Test
-    fun `GIVEN a view with id and context WHEN setIdToViewWithContext THEN should update manager's binding`() {
-        // Given
-        val contextData = ContextData(CONTEXT_ID, true)
-        val viewWithoutId = mockk<View>(relaxed = true) {
-            every { id } returns View.NO_ID
-            every { getContextBinding() } returns mockk(relaxed = true) {
-                every { context } returns contextData
-            }
+    @DisplayName("When addContext is called")
+    @Nested
+    inner class AddContext {
+
+        @DisplayName("Then should add new context")
+        @Test
+        fun addNewContext() {
+            // Given
+            val contextData = ContextData(CONTEXT_ID, true)
+
+            // When
+            contextDataManager.addContext(viewContext, contextData)
+
+            // Then
+            val contextBinding = contexts[viewContext.id]
+            assertNotNull(contextBinding)
+            assertEquals(contextBinding?.context, contextData)
+            assertEquals(0, contextBinding?.bindings?.size)
+            assertEquals(contextData, viewContext.getContextData())
         }
-        contextDataManager.addContext(viewWithoutId, contextData)
 
-        val viewWithId = viewWithoutId.apply { every { id } returns 10 }
+        @DisplayName("Then should not add global context")
+        @Test
+        fun notAddGlobalContext() {
+            // Given
+            val contextData = ContextData("global", true)
+            every { BeagleMessageLogs.globalKeywordIsReservedForGlobalContext() } just Runs
 
-        val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
-        val contextsWithoutId: Map<View, ContextBinding> = contextDataManager.getPrivateField("contextsWithoutId")
-        val contextsWithoutIdSizeBefore = contextsWithoutId.size
+            // When
+            contextDataManager.addContext(viewContext, contextData)
 
-        // When
-        contextDataManager.setIdToViewWithContext(viewWithId)
+            // Then
+            verify(exactly = once()) { BeagleMessageLogs.globalKeywordIsReservedForGlobalContext() }
+        }
 
-        // Then
-        assertEquals(contexts[viewWithId.id], viewWithId.getContextBinding())
-        assertNotEquals(contextsWithoutIdSizeBefore, contextsWithoutId.size)
+        @DisplayName("Then should not add context if already exists")
+        @Test
+        fun notAddContextTwice() {
+            // Given
+            val contextData1 = ContextData(CONTEXT_ID, true)
+            val contextData2 = ContextData(CONTEXT_ID, false)
+
+            // When
+            contextDataManager.addContext(viewContext, contextData1)
+            contextDataManager.addContext(viewContext, contextData2)
+
+            // Then
+            assertEquals(contextData1, contexts[viewContext.id]?.context)
+            assertEquals(contextData1, viewContext.getContextData())
+        }
+
+        @DisplayName("Then should override context only if shouldOverrideExistingContext")
+        @Test
+        fun shouldOverrideExistingContext() {
+            // Given
+            val contextData1 = ContextData(CONTEXT_ID, true)
+            val contextData2 = ContextData(CONTEXT_ID, false)
+            val shouldOverrideExistingContext = true
+            contextDataManager.addContext(viewContext, contextData1)
+
+            // When
+            contextDataManager.addContext(viewContext, contextData2, shouldOverrideExistingContext)
+
+            // Then
+            assertEquals(contextData2, contexts[viewContext.id]?.context)
+            assertEquals(contextData2, viewContext.getContextData())
+        }
+
+        @DisplayName("Then should clear bindings if already exists")
+        @Test
+        fun clearBindings() {
+            // Given
+            val contextData = ContextData(CONTEXT_ID, true)
+            contexts[viewContext.id] = ContextBinding(
+                context = contextData,
+                bindings = mutableSetOf(Binding<Boolean>(observer = mockk(), bind = mockk()))
+            )
+
+            // When
+            contextDataManager.addContext(viewContext, contextData)
+
+            // Then
+            assertTrue { contexts[viewContext.id]?.bindings?.isEmpty() ?: false }
+        }
     }
 
-    @Test
-    fun `GIVEN a view with oldId and context WHEN onViewIdChanged THEN should swipe context to newId`() {
-        // Given
-        val oldId = 0
-        val newId = 1
-        val contextData = ContextData(CONTEXT_ID, true)
-        val viewWithId = mockk<View>(relaxed = true) {
-            every { id } returns oldId
-            every { getContextBinding() } returns mockk(relaxed = true) {
-                every { context } returns contextData
-            }
+    @DisplayName("When addBinding is called")
+    @Nested
+    inner class AddBinding {
+
+        @DisplayName("Then should add binding to context to viewBinding")
+        @Test
+        fun viewBinding() {
+            // Given
+            val viewWithBind = mockk<View>()
+            val bind = Bind.Expression(listOf(), "@{$CONTEXT_ID[0]}", type = Boolean::class.java)
+            val contextData = ContextData(CONTEXT_ID, listOf(true))
+            val observer = mockk<Observer<Boolean?>>()
+            contextDataManager.addContext(viewContext, contextData)
+
+            // When
+            contextDataManager.addBinding(viewWithBind, bind, observer)
+
+            // Then
+            val binding = viewBinding[viewWithBind]?.first()
+            assertEquals(bind, binding?.bind)
+            assertEquals(observer, binding?.observer)
         }
-        contextDataManager.addContext(viewWithId, contextData)
 
-        val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
+        @DisplayName("Then should add binding to context on top of stack")
+        @Test
+        fun topOfStack() {
+            // Given
+            val viewWithBind = createViewForContext(viewContext)
+            val bind = expressionOf<Boolean>("@{$CONTEXT_ID}")
+            val observer = mockk<Observer<Boolean?>>(relaxed = true)
+            val contextData = ContextData(CONTEXT_ID, true)
+            contextDataManager.addContext(viewContext, contextData)
 
-        // When
-        contextDataManager.onViewIdChanged(oldId, newId, viewWithId)
+            // When
+            contextDataManager.addBinding(viewWithBind, bind, observer)
+            contextDataManager.linkBindingToContextAndEvaluateThem(viewWithBind)
 
-        // Then
-        assertEquals(contexts[newId], viewWithId.getContextBinding())
-        assertNull(contexts[oldId])
+            // Then
+            val contextBinding = contexts[viewContext.id]?.bindings?.first()
+            assertEquals(bind, contextBinding?.bind)
+            assertEquals(observer, contextBinding?.observer)
+            assertTrue { viewBinding.isEmpty() }
+        }
+
+        @DisplayName("Then should add binding to global context")
+        @Test
+        fun globalContext() {
+            // Given
+            val viewWithBind = createViewForContext()
+            val bind = expressionOf<Boolean>("@{global}")
+            val observer = mockk<Observer<Boolean?>>(relaxed = true)
+
+            // When
+            contextDataManager.addBinding(viewWithBind, bind, observer)
+            contextDataManager.linkBindingToContextAndEvaluateThem(viewWithBind)
+
+            // Then
+            val contextBinding = contexts[Int.MAX_VALUE]?.bindings?.first()
+            assertEquals(bind, contextBinding?.bind)
+            assertEquals(observer, contextBinding?.observer)
+        }
     }
 
-    @Test
-    fun `GIVEN a view with oldId and context with newId WHEN onViewIdChanged THEN should update new and remove old`() {
-        // Given
-        val oldId = 0
-        val newId = 1
-        val oldContextData = ContextData("old", true)
-        val oldViewWithId = mockk<View>(relaxed = true) {
-            every { id } returns oldId
-            every { getContextBinding() } returns mockk(relaxed = true) {
-                every { context } returns oldContextData
-            }
+    @DisplayName("When linkBindingToContextAndEvaluateThem is called")
+    @Nested
+    inner class EvaluateContexts {
+
+        @DisplayName("Then should call notifyBindingChanges if view is not in viewBinding")
+        @Test
+        fun notifyBindingChanges() {
+            // Given
+            val viewWithBind = createViewForContext()
+            val contextBinding = mockk<ContextBinding>(relaxed = true)
+            viewWithBind.setContextBinding(contextBinding)
+
+            // When
+            contextDataManager.linkBindingToContextAndEvaluateThem(viewWithBind)
+
+            // Then
+            verify(exactly = once()) { contextDataManager.notifyBindingChanges(contextBinding) }
         }
-        contextDataManager.addContext(oldViewWithId, oldContextData)
 
-        val newContextData = ContextData("new", true)
-        val newViewWithId = mockk<View>(relaxed = true) {
-            every { id } returns newId
-            every { getContextBinding() } returns mockk(relaxed = true) {
-                every { context } returns newContextData
-            }
+        @DisplayName("Then should get value from evaluation")
+        @Test
+        fun getValueEvaluation() {
+            // Given
+            val value = true
+            val contextData = ContextData(CONTEXT_ID, value)
+            val bind = expressionOf<Boolean>("@{$CONTEXT_ID}")
+            val observer = mockk<Observer<Boolean?>>(relaxed = true)
+            contextDataManager.addContext(viewContext, contextData)
+            contextDataManager.addBinding(viewContext, bind, observer)
+
+            // When
+            contextDataManager.linkBindingToContextAndEvaluateThem(viewContext)
+
+            // Then
+            verify(exactly = once()) { observer(value) }
         }
-        contextDataManager.addContext(newViewWithId, newContextData)
 
-        val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
+        @DisplayName("Then should get value from operation")
+        @Test
+        fun getValueOperation() {
+            // Given
+            val value = 2
+            val contextData = ContextData(CONTEXT_ID, value)
+            val bind = expressionOf<Int>("@{sum(1, 1)}")
+            val observer = mockk<Observer<Int?>>(relaxed = true)
+            contextDataManager.addContext(viewContext, contextData)
+            contextDataManager.addBinding(viewContext, bind, observer)
 
-        // When
-        contextDataManager.onViewIdChanged(oldId, newId, newViewWithId)
+            // When
+            contextDataManager.linkBindingToContextAndEvaluateThem(viewContext)
 
-        // Then
-        assertEquals(contexts[newId], newViewWithId.getContextBinding())
-        assertNull(contexts[oldId])
+            // Then
+            verify(exactly = once()) { observer(value) }
+        }
+
+        @DisplayName("Then should get null value from evaluation")
+        @Test
+        fun getNullValueEvaluation() {
+            // Given
+            val value = true
+            val contextData = ContextData(CONTEXT_ID, value)
+            val bind = expressionOf<Boolean>("@{$CONTEXT_ID.a}")
+            val observer = mockk<Observer<Boolean?>>(relaxed = true)
+            contextDataManager.addContext(viewContext, contextData)
+            contextDataManager.addBinding(viewContext, bind, observer)
+
+            // When
+            contextDataManager.linkBindingToContextAndEvaluateThem(viewContext)
+
+            // Then
+            verify(exactly = once()) { observer(null) }
+        }
+
+        @DisplayName("Then should get value from different type")
+        @Test
+        fun getNullValueEvaluationDifferentType() {
+            // Given
+            val contextData = ContextData(CONTEXT_ID, "value")
+            val bind = expressionOf<Boolean>("@{$CONTEXT_ID}")
+            contextDataManager.addContext(viewContext, contextData)
+            contextDataManager.addBinding(viewContext, bind) {
+                // Then
+                assertNull(it)
+            }
+            contextDataManager.linkBindingToContextAndEvaluateThem(viewContext)
+        }
+    }
+
+    @DisplayName("When updateContext is called")
+    @Nested
+    inner class UpdateContext {
+
+        @DisplayName("Then should update context data with context id")
+        @Test
+        fun updateContextData() {
+            // Given
+            val json = JSONObject().apply {
+                put("a", true)
+            }
+            val contextData = ContextData(CONTEXT_ID, json)
+            val updateContext = SetContextInternal(CONTEXT_ID, false, "a")
+            contextDataManager.addContext(viewContext, contextData)
+
+            // When
+            contextDataManager.updateContext(viewContext, updateContext)
+
+            // Then
+            assertFalse { json.getBoolean("a") }
+        }
+
+        @DisplayName("Then should set value on context root")
+        @Test
+        fun contextRoot() {
+            // Given
+            val contextData = ContextData(CONTEXT_ID, true)
+            val updateContext = SetContextInternal(CONTEXT_ID, false, null)
+            contextDataManager.addContext(viewContext, contextData)
+
+            // When
+            contextDataManager.updateContext(viewContext, updateContext)
+
+            // Then
+            val contextBinding = contexts[viewContext.id]?.context
+            assertEquals(updateContext.contextId, contextBinding?.id)
+            assertEquals(updateContext.value, contextBinding?.value)
+        }
+
+        @DisplayName("Then should call global context to id global")
+        @Test
+        fun globalContext() {
+            // Given
+            val updateContext = SetContextInternal("global", false, null)
+
+            // When
+            contextDataManager.updateContext(viewContext, updateContext)
+
+            // Then
+            verify(exactly = once()) { GlobalContext.set(updateContext.value, updateContext.path) }
+        }
+    }
+
+    @DisplayName("When getContextsFromBind is called")
+    @Nested
+    inner class GetContexts {
+
+        @DisplayName("Should filter all contexts from view hierarchy")
+        @Test
+        fun filterContexts() {
+            // Given
+            val contextId1 = RandomData.string()
+            val contextId2 = RandomData.string()
+            val bind = expressionOf<String>("@{$contextId1} @{$contextId2}")
+            val viewContext1 = createViewForContext()
+            viewContext1.setContextBinding(ContextBinding(
+                ContextData(
+                    id = contextId1,
+                    value = RandomData.string()
+                ))
+            )
+            val viewContext2 = createViewForContext(viewContext1)
+            viewContext2.setContextBinding(ContextBinding(
+                ContextData(
+                    id = contextId2,
+                    value = RandomData.string()
+                ))
+            )
+
+            // When
+            val contexts = contextDataManager.getContextsFromBind(viewContext2, bind)
+
+            // Then
+            assertEquals(2, contexts.size)
+            assertEquals(contextId2, contexts[0].id)
+            assertEquals(contextId1, contexts[1].id)
+        }
+
+        @DisplayName("Should return globalContext")
+        @Test
+        fun globalContext() {
+            // Given
+            val bind = expressionOf<String>("@{global}")
+            val viewContext = createViewForContext()
+
+            // When
+            val contexts = contextDataManager.getContextsFromBind(viewContext, bind)
+
+            // Then
+            assertEquals("global", contexts.first().id)
+        }
+    }
+
+    @DisplayName("When clearContexts is called")
+    @Nested
+    inner class ClearContexts {
+
+        @DisplayName("Should clear viewBindings, contexts and contextsWithoutId")
+        @Test
+        fun clearAllData() {
+            // Given
+            val bind = mockk<Bind.Expression<Boolean>>()
+            val observer = mockk<Observer<Boolean?>>()
+            val context = ContextData(id = RandomData.string(), value = RandomData.string())
+            val contextDataManager = ContextDataManager()
+            val viewWithoutId = mockk<View>(relaxed = true) {
+                every { id } returns View.NO_ID
+                every { getContextBinding() } returns mockk(relaxed = true)
+            }
+            contextDataManager.addContext(viewWithoutId, context)
+            contextDataManager.addContext(viewContext, context)
+            contextDataManager.addBinding(viewContext, bind, observer)
+            val contexts: Map<Int, ContextBinding> = contextDataManager.getPrivateField("contexts")
+            val contextsWithoutId: Map<View, ContextBinding> = contextDataManager.getPrivateField("contextsWithoutId")
+            val viewBinding: Map<View, MutableSet<Binding<*>>> = contextDataManager.getPrivateField("viewBinding")
+            val contextsWithoutIdSizeBefore = contextsWithoutId.size
+            val contextsSizeBefore = contexts.size
+            val viewBindingSizeBefore = viewBinding.size
+            every { GlobalContext.clearObserverGlobalContext(any()) } just Runs
+
+            // When
+            contextDataManager.clearContexts()
+
+            // Then
+            assertNotEquals(contextsWithoutIdSizeBefore, contextsWithoutId.size)
+            assertNotEquals(contextsSizeBefore, contexts.size)
+            assertNotEquals(viewBindingSizeBefore, viewBinding.size)
+            assertTrue { contexts.isEmpty() }
+            assertTrue { contextsWithoutId.isEmpty() }
+            assertTrue { viewBinding.isEmpty() }
+            verify(exactly = once()) { GlobalContext.clearObserverGlobalContext(any()) }
+        }
+    }
+
+    @DisplayName("When getContextData is called")
+    @Nested
+    inner class GetContext {
+
+        @DisplayName("Then should return context")
+        @Test
+        fun getContextData() {
+            // Given
+            val contextData = ContextData(CONTEXT_ID, true)
+            contextDataManager.addContext(viewContext, contextData)
+
+            // When
+            val result = contextDataManager.getContextData(viewContext)
+
+            // Then
+            assertEquals(contextData, result)
+        }
+    }
+
+    @DisplayName("When restoreContext is called")
+    @Nested
+    inner class RestoreContext {
+
+        @DisplayName("Then should update view's context")
+        @Test
+        fun restoreContextData() {
+            // Given
+            val contextData = ContextData(CONTEXT_ID, true)
+            contextDataManager.addContext(viewContext, contextData)
+
+            // When
+            contextDataManager.restoreContext(viewContext)
+
+            // Then
+            assertEquals(contextData, viewContext.getContextData())
+        }
+    }
+
+    @DisplayName("When setIdToViewWithContext is called")
+    @Nested
+    inner class SetIdToView {
+
+        @DisplayName("Then should update view's context")
+        @Test
+        fun setIdToViewWithContext() {
+            // Given
+            val contextData1 = ContextData(CONTEXT_ID, true)
+            val viewWithoutId = mockk<View>(relaxed = true) {
+                every { id } returns View.NO_ID
+                every { getContextBinding() } returns mockk(relaxed = true) {
+                    every { context } returns contextData1
+                }
+            }
+            contextDataManager.addContext(viewWithoutId, contextData1)
+
+            val contextData2 = ContextData(CONTEXT_ID, false)
+            val viewWithId = viewWithoutId.apply {
+                every { id } returns 10
+                every { getContextBinding() } returns mockk(relaxed = true) {
+                    every { context } returns contextData2
+                }
+            }
+            contextDataManager.addContext(viewWithId, contextData2)
+
+            val contextsWithoutId: Map<View, ContextBinding> = contextDataManager.getPrivateField("contextsWithoutId")
+            val contextsWithoutIdSizeBefore = contextsWithoutId.size
+
+            // When
+            contextDataManager.setIdToViewWithContext(viewWithId)
+
+            // Then
+            assertEquals(contextData2, viewWithId.getContextData())
+            assertNotEquals(contextsWithoutIdSizeBefore, contextsWithoutId.size)
+        }
+
+        @DisplayName("Then should update manager's binding")
+        @Test
+        fun setIdToViewWithContextManager() {
+            // Given
+            val contextData = ContextData(CONTEXT_ID, true)
+            val viewWithoutId = mockk<View>(relaxed = true) {
+                every { id } returns View.NO_ID
+                every { getContextBinding() } returns mockk(relaxed = true) {
+                    every { context } returns contextData
+                }
+            }
+            contextDataManager.addContext(viewWithoutId, contextData)
+
+            val viewWithId = viewWithoutId.apply { every { id } returns 10 }
+
+            val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
+            val contextsWithoutId: Map<View, ContextBinding> = contextDataManager.getPrivateField("contextsWithoutId")
+            val contextsWithoutIdSizeBefore = contextsWithoutId.size
+
+            // When
+            contextDataManager.setIdToViewWithContext(viewWithId)
+
+            // Then
+            assertEquals(contexts[viewWithId.id], viewWithId.getContextBinding())
+            assertNotEquals(contextsWithoutIdSizeBefore, contextsWithoutId.size)
+        }
+    }
+
+    @DisplayName("When onViewIdChanged is called")
+    @Nested
+    inner class OnViewIdChanged {
+
+        @DisplayName("Then should swipe context to newId to a view with oldId and context")
+        @Test
+        fun swipeContext() {
+            // Given
+            val oldId = 0
+            val newId = 1
+            val contextData = ContextData(CONTEXT_ID, true)
+            val viewWithId = mockk<View>(relaxed = true) {
+                every { id } returns oldId
+                every { getContextBinding() } returns mockk(relaxed = true) {
+                    every { context } returns contextData
+                }
+            }
+            contextDataManager.addContext(viewWithId, contextData)
+
+            val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
+
+            // When
+            contextDataManager.onViewIdChanged(oldId, newId, viewWithId)
+
+            // Then
+            assertEquals(contexts[newId], viewWithId.getContextBinding())
+            assertNull(contexts[oldId])
+        }
+
+        @DisplayName("Then should update new and remove old to a view with oldId and context with newId")
+        @Test
+        fun updateNewAndRemoveOld() {
+            // Given
+            val oldId = 0
+            val newId = 1
+            val oldContextData = ContextData("old", true)
+            val oldViewWithId = mockk<View>(relaxed = true) {
+                every { id } returns oldId
+                every { getContextBinding() } returns mockk(relaxed = true) {
+                    every { context } returns oldContextData
+                }
+            }
+            contextDataManager.addContext(oldViewWithId, oldContextData)
+
+            val newContextData = ContextData("new", true)
+            val newViewWithId = mockk<View>(relaxed = true) {
+                every { id } returns newId
+                every { getContextBinding() } returns mockk(relaxed = true) {
+                    every { context } returns newContextData
+                }
+            }
+            contextDataManager.addContext(newViewWithId, newContextData)
+
+            val contexts = contextDataManager.getPrivateField<MutableMap<Int, ContextBinding>>("contexts")
+
+            // When
+            contextDataManager.onViewIdChanged(oldId, newId, newViewWithId)
+
+            // Then
+            assertEquals(contexts[newId], newViewWithId.getContextBinding())
+            assertNull(contexts[oldId])
+        }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/GenerateIdManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/GenerateIdManagerTest.kt
@@ -34,8 +34,11 @@ import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@DisplayName("Given a GenerateIdManager")
 class GenerateIdManagerTest {
 
     private val rootView = mockk<RootView>(relaxed = true)
@@ -62,119 +65,142 @@ class GenerateIdManagerTest {
         unmockkStatic(View::class)
     }
 
-    @Test
-    fun `GIVEN a rootView with parentId WHEN createSingleManagerByRootViewId is called THEN should call createIfNotExisting`() {
-        // Given
-        val parentId = 10
-        every { rootView.getParentId() } returns parentId
+    @DisplayName("When createSingleManagerByRootViewId is called")
+    @Nested
+    inner class CreateManager {
 
-        // When
-        generateIdManager.createSingleManagerByRootViewId()
+        @DisplayName("Then should call createIfNotExisting to a rootView with parentId")
+        @Test
+        fun createSingleManagerByRootViewId() {
+            // Given
+            val parentId = 10
+            every { rootView.getParentId() } returns parentId
 
-        // Then
-        verify(exactly = 1) { generateIdViewModel.createIfNotExisting(parentId) }
+            // When
+            generateIdManager.createSingleManagerByRootViewId()
+
+            // Then
+            verify(exactly = 1) { generateIdViewModel.createIfNotExisting(parentId) }
+        }
     }
 
-    @Test
-    fun `GIVEN a rootView with parentId WHEN onViewDetachedFromWindow is called THEN should call setViewCreated and prepareToReuseIds`() {
-        // Given
-        val parentId = 10
-        every { rootView.getParentId() } returns parentId
+    @DisplayName("When onViewDetachedFromWindow is called")
+    @Nested
+    inner class SetViewCreated {
 
-        // When
-        generateIdManager.onViewDetachedFromWindow(view)
+        @DisplayName("Then should call setViewCreated and prepareToReuseIds to a rootView with parentId")
+        @Test
+        fun setViewCreatedAndPrepareToReuseIds() {
+            // Given
+            val parentId = 10
+            every { rootView.getParentId() } returns parentId
 
-        // Then
-        verify(exactly = 1) { generateIdViewModel.setViewCreated(parentId) }
-        verify(exactly = 1) { listViewIdViewModel.prepareToReuseIds(view) }
-        verify(exactly = 1) { onInitViewModel.markToRerun() }
+            // When
+            generateIdManager.onViewDetachedFromWindow(view)
+
+            // Then
+            verify(exactly = 1) { generateIdViewModel.setViewCreated(parentId) }
+            verify(exactly = 1) { listViewIdViewModel.prepareToReuseIds(view) }
+            verify(exactly = 1) { onInitViewModel.markToRerun() }
+        }
     }
 
-    @Test
-    fun `GIVEN a component it is not an IdentifierComponent WHEN manageId THEN should not generateViewId`() {
-        // Given
-        val component = mockk<ServerDrivenComponent>()
+    @DisplayName("When manageId is called")
+    @Nested
+    inner class ManageId {
 
-        // When
-        generateIdManager.manageId(component, view)
+        @DisplayName("Then should not generateViewId to a component it is not an IdentifierComponent")
+        @Test
+        fun notGenerateViewId() {
+            // Given
+            val component = mockk<ServerDrivenComponent>()
 
-        // Then
-        verify(exactly = 0) { View.generateViewId() }
-    }
+            // When
+            generateIdManager.manageId(component, view)
 
-    @Test
-    fun `GIVEN a IdentifierComponent with id WHEN manageId THEN should not generateViewId`() {
-        // Given
-        val component = Container(listOf()).setId("stub")
+            // Then
+            verify(exactly = 0) { View.generateViewId() }
+        }
 
-        // When
-        generateIdManager.manageId(component, view)
+        @DisplayName("Then should not generateViewId to a a IdentifierComponent with id")
+        @Test
+        fun notGenerateViewIdWithId() {
+            // Given
+            val component = Container(listOf()).setId("stub")
 
-        // Then
-        verify(exactly = 0) { View.generateViewId() }
-    }
+            // When
+            generateIdManager.manageId(component, view)
 
-    @Test
-    fun `GIVEN a IdentifierComponent without id and isAutoGenerateIdEnabled WHEN manageId THEN should getViewId`() {
-        // Given
-        val component = Container(listOf())
-        every { view.isAutoGenerateIdEnabled() } returns true
-        val recoveryId = 1
-        every { generateIdViewModel.getViewId(any()) } returns recoveryId
+            // Then
+            verify(exactly = 0) { View.generateViewId() }
+        }
 
-        // When
-        generateIdManager.manageId(component, view)
+        @DisplayName("Then should getViewId to a IdentifierComponent without id and isAutoGenerateIdEnabled")
+        @Test
+        fun getViewId() {
+            // Given
+            val component = Container(listOf())
+            every { view.isAutoGenerateIdEnabled() } returns true
+            val recoveryId = 1
+            every { generateIdViewModel.getViewId(any()) } returns recoveryId
 
-        // Then
-        verify(exactly = 1) { generateIdViewModel.getViewId(rootView.getParentId()) }
-        assertEquals(recoveryId.toString(), component.id)
-    }
+            // When
+            generateIdManager.manageId(component, view)
 
-    @Test
-    fun `GIVEN a IdentifierComponent without id and isAutoGenerateIdEnabled WHEN manageId THEN should try getViewId`() {
-        // Given
-        val component = Container(listOf())
-        every { view.isAutoGenerateIdEnabled() } returns true
-        every { generateIdViewModel.getViewId(any()) } throws Exception()
+            // Then
+            verify(exactly = 1) { generateIdViewModel.getViewId(rootView.getParentId()) }
+            assertEquals(recoveryId.toString(), component.id)
+        }
 
-        // When
-        generateIdManager.manageId(component, view)
+        @DisplayName("Then should try getViewId to a IdentifierComponent without id and isAutoGenerateIdEnabled")
+        @Test
+        fun tryGetViewId() {
+            // Given
+            val component = Container(listOf())
+            every { view.isAutoGenerateIdEnabled() } returns true
+            every { generateIdViewModel.getViewId(any()) } throws Exception()
 
-        // Then
-        verify(exactly = 1) { View.generateViewId() }
-        assertEquals(generatedId.toString(), component.id)
-    }
+            // When
+            generateIdManager.manageId(component, view)
 
-    @Test
-    fun `GIVEN a IdentifierComponent without id and auto generate id disabled WHEN manageId THEN should markEachNestedComponentAsNoIdIfNeeded`() {
-        // Given
-        val componentWithoutId = Text("stub")
-        val children = listOf<ServerDrivenComponent>(componentWithoutId)
-        val component = Container(children)
-        every { view.isAutoGenerateIdEnabled() } returns false
+            // Then
+            verify(exactly = 1) { View.generateViewId() }
+            assertEquals(generatedId.toString(), component.id)
+        }
 
-        // When
-        generateIdManager.manageId(component, view)
+        @DisplayName("Then should markEachNestedComponentAsNoIdIfNeeded to a IdentifierComponent without id and auto generate id disabled")
+        @Test
+        fun markEachNestedComponentAsNoIdIfNeeded() {
+            // Given
+            val componentWithoutId = Text("stub")
+            val children = listOf<ServerDrivenComponent>(componentWithoutId)
+            val component = Container(children)
+            every { view.isAutoGenerateIdEnabled() } returns false
 
-        // Then
-        assertEquals(COMPONENT_NO_ID, component.id)
-        assertEquals(COMPONENT_NO_ID, componentWithoutId.id)
-    }
+            // When
+            generateIdManager.manageId(component, view)
 
-    @Test
-    fun `GIVEN a IdentifierComponent without id and auto generate id disabled WHEN manageId THEN should keep previous ids`() {
-        // Given
-        val previousId = "id"
-        val componentWithId = Text("stub").setId(previousId)
-        val children = listOf<ServerDrivenComponent>(componentWithId)
-        val component = Container(children)
-        every { view.isAutoGenerateIdEnabled() } returns false
+            // Then
+            assertEquals(COMPONENT_NO_ID, component.id)
+            assertEquals(COMPONENT_NO_ID, componentWithoutId.id)
+        }
 
-        // When
-        generateIdManager.manageId(component, view)
+        @DisplayName("Then should should keep previous ids to a IdentifierComponent without id and auto generate id disabled")
+        @Test
+        fun keepPreviousIds() {
+            // Given
+            val previousId = "id"
+            val componentWithId = Text("stub").setId(previousId)
+            val children = listOf<ServerDrivenComponent>(componentWithId)
+            val component = Container(children)
+            every { view.isAutoGenerateIdEnabled() } returns false
 
-        // Then
-        assertEquals(COMPONENT_NO_ID, component.id)
-        assertEquals(previousId, componentWithId.id)
+            // When
+            generateIdManager.manageId(component, view)
+
+            // Then
+            assertEquals(COMPONENT_NO_ID, component.id)
+            assertEquals(previousId, componentWithId.id)
+        }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/GenerateIdManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/GenerateIdManagerTest.kt
@@ -22,6 +22,7 @@ import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.view.custom.BeagleFlexView
 import br.com.zup.beagle.android.view.viewmodel.GenerateIdViewModel
 import br.com.zup.beagle.android.view.viewmodel.ListViewIdViewModel
+import br.com.zup.beagle.android.view.viewmodel.OnInitViewModel
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.ext.setId
@@ -40,6 +41,7 @@ class GenerateIdManagerTest {
     private val rootView = mockk<RootView>(relaxed = true)
     private val generateIdViewModel = mockk<GenerateIdViewModel>(relaxed = true)
     private val listViewIdViewModel = mockk<ListViewIdViewModel>(relaxed = true)
+    private val onInitViewModel = mockk<OnInitViewModel>(relaxed = true)
     private val view = mockk<BeagleFlexView>()
     private val generatedId = 1
     private lateinit var generateIdManager: GenerateIdManager
@@ -50,8 +52,9 @@ class GenerateIdManagerTest {
         every { View.generateViewId() } returns generatedId
         every { rootView.generateViewModelInstance<GenerateIdViewModel>() } returns generateIdViewModel
         every { rootView.generateViewModelInstance<ListViewIdViewModel>() } returns listViewIdViewModel
+        every { rootView.generateViewModelInstance<OnInitViewModel>() } returns onInitViewModel
 
-        generateIdManager = GenerateIdManager(rootView, generateIdViewModel, listViewIdViewModel)
+        generateIdManager = GenerateIdManager(rootView, generateIdViewModel, listViewIdViewModel, onInitViewModel)
     }
 
     @AfterEach
@@ -84,6 +87,7 @@ class GenerateIdManagerTest {
         // Then
         verify(exactly = 1) { generateIdViewModel.setViewCreated(parentId) }
         verify(exactly = 1) { listViewIdViewModel.prepareToReuseIds(view) }
+        verify(exactly = 1) { onInitViewModel.markToRerun() }
     }
 
     @Test

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModelTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/OnInitViewModelTest.kt
@@ -16,6 +16,7 @@
 
 package br.com.zup.beagle.android.view.viewmodel
 
+import br.com.zup.beagle.android.testutil.getPrivateField
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.DisplayName
@@ -31,37 +32,144 @@ class OnInitViewModelTest {
     @Nested
     inner class SetOnInitStatus {
 
-        @DisplayName("Then should set to onInitStatusByComponent id the given value")
+        @DisplayName("Then should set to onInitStatusByViewId id the onInitCalled value")
         @Test
-        fun setOnInitActionStatus() {
+        fun setOnInitCalled() {
             // Given
-            val onInitiableComponentId = 10
+            val onInitiableViewId = 10
             val onInitCalled = true
+            val onInitFinished = false
+            val status = onInitViewModel.getPrivateField<MutableMap<Int, OnInitStatus>>("onInitStatusByViewId")
 
             // When
-            onInitViewModel.setOnInitActionStatus(onInitiableComponentId, onInitCalled)
-            val result = onInitViewModel.getOnInitActionStatus(onInitiableComponentId)
+            onInitViewModel.setOnInitCalled(onInitiableViewId, onInitCalled)
 
             // Then
-            assertEquals(onInitCalled, result)
+            assertEquals(onInitCalled, status[onInitiableViewId]?.onInitCalled)
+            assertEquals(onInitFinished, status[onInitiableViewId]?.onInitFinished)
+        }
+
+        @DisplayName("Then should set to onInitStatusByViewId id the onInitCalled value with previous value")
+        @Test
+        fun setOnInitCalledWithPreviousValue() {
+            // Given
+            val onInitiableViewId = 10
+            val onInitCalled = true
+            val onInitFinished = true
+            val status = onInitViewModel.getPrivateField<MutableMap<Int, OnInitStatus>>("onInitStatusByViewId")
+            status[onInitiableViewId] = OnInitStatus(onInitFinished = onInitFinished)
+
+            // When
+            onInitViewModel.setOnInitCalled(onInitiableViewId, onInitCalled)
+
+            // Then
+            assertEquals(onInitCalled, status[onInitiableViewId]?.onInitCalled)
+            assertEquals(onInitFinished, status[onInitiableViewId]?.onInitFinished)
+        }
+
+        @DisplayName("Then should set to onInitStatusByViewId id the onInitFinished value")
+        @Test
+        fun setOnInitFinished() {
+            // Given
+            val onInitiableViewId = 10
+            val onInitFinished = true
+            val onInitCalled = false
+            val status = onInitViewModel.getPrivateField<MutableMap<Int, OnInitStatus>>("onInitStatusByViewId")
+
+            // When
+            onInitViewModel.setOnInitFinished(onInitiableViewId, onInitFinished)
+
+            // Then
+            assertEquals(onInitFinished, status[onInitiableViewId]?.onInitFinished)
+            assertEquals(onInitCalled, status[onInitiableViewId]?.onInitCalled)
+        }
+
+        @DisplayName("Then should set to onInitStatusByViewId id the onInitFinished value with previous value")
+        @Test
+        fun setOnInitFinishedWithPreviousValue() {
+            // Given
+            val onInitiableViewId = 10
+            val onInitFinished = true
+            val onInitCalled = true
+            val status = onInitViewModel.getPrivateField<MutableMap<Int, OnInitStatus>>("onInitStatusByViewId")
+            status[onInitiableViewId] = OnInitStatus(onInitCalled = onInitCalled)
+
+            // When
+            onInitViewModel.setOnInitFinished(onInitiableViewId, onInitFinished)
+
+            // Then
+            assertEquals(onInitFinished, status[onInitiableViewId]?.onInitFinished)
+            assertEquals(onInitCalled, status[onInitiableViewId]?.onInitCalled)
         }
     }
 
     @DisplayName("When get OnInit action status not found")
     @Nested
-    inner class GetOnInitStatus {
+    inner class GetOnInitCalledStatus {
 
         @DisplayName("Then should return false")
         @Test
-        fun getOnInitActionStatus() {
+        fun isOnInitCalled() {
             // Given
-            val onInitiableComponentId = 10
+            val onInitiableViewId = 10
 
             // When
-            val result = onInitViewModel.getOnInitActionStatus(onInitiableComponentId)
+            val result = onInitViewModel.isOnInitCalled(onInitiableViewId)
 
             // Then
             assertFalse(result)
+        }
+
+        @DisplayName("Then should return false")
+        @Test
+        fun isOnInitFinished() {
+            // Given
+            val onInitiableViewId = 10
+
+            // When
+            val result = onInitViewModel.isOnInitFinished(onInitiableViewId)
+
+            // Then
+            assertFalse(result)
+        }
+    }
+
+    @DisplayName("When onInitFinished is false")
+    @Nested
+    inner class MarkToRerun {
+
+        @DisplayName("Then should set onInitCalled to false")
+        @Test
+        fun markToRerun() {
+            // Given
+            val onInitiableViewId = 10
+            val onInitFinished = false
+            val onInitCalled = false
+            val status = onInitViewModel.getPrivateField<MutableMap<Int, OnInitStatus>>("onInitStatusByViewId")
+            status[onInitiableViewId] = OnInitStatus(onInitCalled = true, onInitFinished = onInitFinished)
+
+            // When
+            onInitViewModel.markToRerun()
+
+            // Then
+            assertEquals(onInitCalled, status[onInitiableViewId]?.onInitCalled)
+        }
+
+        @DisplayName("Then should not set onInitCalled to false if finished")
+        @Test
+        fun markToRerunOnlyForNotFinished() {
+            // Given
+            val onInitiableViewId = 10
+            val onInitFinished = true
+            val onInitCalled = true
+            val status = onInitViewModel.getPrivateField<MutableMap<Int, OnInitStatus>>("onInitStatusByViewId")
+            status[onInitiableViewId] = OnInitStatus(onInitCalled = onInitCalled, onInitFinished = onInitFinished)
+
+            // When
+            onInitViewModel.markToRerun()
+
+            // Then
+            assertEquals(onInitCalled, status[onInitiableViewId]?.onInitCalled)
         }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/ScreenContextViewModelTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/ScreenContextViewModelTest.kt
@@ -116,10 +116,10 @@ class ScreenContextViewModelTest {
         val newId = 1
 
         // When
-        screenContextViewModel.onViewIdChanged(oldId, newId)
+        screenContextViewModel.onViewIdChanged(oldId, newId, view)
 
         // Then
-        verify(exactly = 1) { contextDataManager.onViewIdChanged(oldId, newId) }
+        verify(exactly = 1) { contextDataManager.onViewIdChanged(oldId, newId, view) }
     }
 
     @Test

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         classpath "com.karumi:shot:4.3.0"


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

### Description and Example

This PR fixes the behavior where onInit actions were re-executed when the device was rotated. OnInit's status update logic was also centralized to `OnInitiableComponentImpl`, in addition to simplifying the `ListAdapter`.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
