### PR TITLE
fix: android listview scroll threshold calculation

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
@@ -273,9 +273,12 @@ constructor(
     private fun calculateScrolledPercent(): Float {
         var scrolledPercentage: Float
         with(recyclerView.layoutManager as LinearLayoutManager) {
-            val totalItemCount = itemCount
-            val lastVisible = findLastVisibleItemPosition().toFloat()
-            scrolledPercentage = (lastVisible / totalItemCount) * 100
+            scrolledPercentage = if (itemCount <= 0) {
+                100.0F
+            } else {
+                val lastVisible = findLastVisibleItemPosition().toFloat()
+                (lastVisible / itemCount) * 100
+            }
         }
         return scrolledPercentage
     }


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>


### Related Issues

### Description and Example

When listview is empty and has a non null scrollEndThreshold, onScrollEnd is not being called.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
