### PR TITLE
fix: Android embedded listview without id

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
@@ -226,6 +226,14 @@ internal class ListViewHolder(
             val subViewId = bindIdToViewModel(view, isRecycled, position, recyclerId)
             setUpdatedIdToViewAndManagers(view, subViewId, listItem, isRecycled)
         }
+
+        // All RecyclerViews MUST have an id
+        directNestedRecyclers
+            .filter { it.id == View.NO_ID }
+            .forEach { innerRecyclerWithoutId ->
+                val subViewId = bindIdToViewModel(innerRecyclerWithoutId, isRecycled, position, recyclerId)
+                setUpdatedIdToViewAndManagers(innerRecyclerWithoutId, subViewId, listItem, isRecycled)
+            }
     }
 
     private fun bindIdToViewModel(view: View, isRecycled: Boolean, position: Int, recyclerId: Int): Int {
@@ -313,6 +321,14 @@ internal class ListViewHolder(
                 viewWithContext.id = savedId
             }
         }
+
+        directNestedRecyclers
+            .filter { it.id == View.NO_ID }
+            .forEach { innerRecyclerWithoutId ->
+                temporaryViewIds.pollFirst()?.let { savedId ->
+                    innerRecyclerWithoutId.id = savedId
+                }
+            }
     }
 
     private fun restoreAdapters(listItem: ListItem) {


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>


### Related Issues

### Description and Example
When an embedded ListView does not have ContextData neither a BFF id, system crashes because all ListViews in beagle android must have an id.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
