### PR TITLE
feat: iOS - Union Operation

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/ListViewScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/ListViewScreen.swift
@@ -281,9 +281,10 @@ struct ListViewScreen: DeeplinkScreen {
                     onSuccess: [
                         SetContext(contextId: "moviePage", path: "page", value: "@{onSuccess.data.page}"),
                         SetContext(contextId: "moviePage", path: "total_pages", value: "@{onSuccess.data.total_pages}"),
-                        Append(
-                            array: Binding(context: "moviePage", path: Path(nodes: [.key("results")])),
-                            items: "@{onSuccess.data.results}"
+                        SetContext(
+                            contextId: "moviePage",
+                            path: "results",
+                            value: "@{union(moviePage.results, onSuccess.data.results)}"
                         )
                     ]
                 )
@@ -368,9 +369,10 @@ struct ListViewScreen: DeeplinkScreen {
                             onSuccess: [
                                 SetContext(contextId: "moviePage", path: "page", value: "@{onSuccess.data.page}"),
                                 SetContext(contextId: "moviePage", path: "total_pages", value: "@{onSuccess.data.total_pages}"),
-                                Append(
-                                    array: Binding(context: "moviePage", path: Path(nodes: [.key("results")])),
-                                    items: "@{onSuccess.data.results}"
+                                SetContext(
+                                    contextId: "moviePage",
+                                    path: "results",
+                                    value: "@{union(moviePage.results, onSuccess.data.results)}"
                                 )
                             ]
                         )
@@ -380,27 +382,5 @@ struct ListViewScreen: DeeplinkScreen {
             },
             iteratorName: "category"
         )
-    }
-}
-
-/// This action should be replaced by array operations when available.
-private struct Append: Action {
-    
-    public let array: Binding
-    public let items: DynamicObject
-    
-    func execute(controller: BeagleController, origin: UIView) {
-        guard case .array(let sequenceToAppend) = items.evaluate(with: origin) else {
-            return
-        }
-        var result = [DynamicObject]()
-        let initialValue = DynamicObject.expression(.single(.value(.binding(array)))).evaluate(with: origin)
-        if case .array(let items) = initialValue {
-            result = items
-        }
-        result.append(contentsOf: sequenceToAppend)
-        
-        let setContext = SetContext(contextId: array.context, path: array.path.rawValue, value: .array(result))
-        controller.execute(actions: [setContext], origin: origin)
     }
 }

--- a/iOS/Sources/Beagle/Sources/ContextExpression/OperationsProvider.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/OperationsProvider.swift
@@ -119,6 +119,7 @@ extension OperationsProvider {
         register(operationId: "remove", handler: remove())
         register(operationId: "removeIndex", handler: removeIndex())
         register(operationId: "contains", handler: contains())
+        register(operationId: "union", handler: union())
         register(operationId: "isNull", handler: isNull())
         register(operationId: "isEmpty", handler: isEmpty())
         register(operationId: "length", handler: length())
@@ -438,6 +439,18 @@ extension OperationsProvider {
             guard parameters.count == 2, case let .array(array) = parameters[0] else { return nil }
             
             return .bool(array.contains(parameters[1]))
+        }
+    }
+    
+    func union() -> OperationHandler {
+        return { parameters in
+            var result = [DynamicObject]()
+            for parameter in parameters {
+                if case let .array(array) = parameter {
+                    result += array
+                }
+            }
+            return .array(result)
         }
     }
     

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Tests/OperationEvaluation/OperationArrayEvaluationTests.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Tests/OperationEvaluation/OperationArrayEvaluationTests.swift
@@ -114,4 +114,25 @@ final class OperationArrayEvaluationTests: OperationEvaluationTests {
             XCTAssertEqual(evaluatedResults, comparableResults)
         }
     }
+    
+    func testEvaluateUnion() {
+        // Given
+        let name = "union"
+        let contexts = [Context(id: "context", value: [1, 2, 3])]
+        let binding = contexts[0].id
+        
+        let simpleOperations = ["\(binding)", "\(binding), \(binding)", "\(binding), 2, \(binding)"].toOperations(name: name)
+        
+        let failingOperations = ["2, 4", "'true', 3.0", ""].toOperations(name: name)
+        
+        let operations = simpleOperations + failingOperations
+        
+        let comparableResults: [DynamicObject] = [[1, 2, 3], [1, 2, 3, 1, 2, 3], [1, 2, 3, 1, 2, 3], [], [], []]
+        
+        // When
+        evaluateOperations(operations, contexts: contexts) { evaluatedResults in
+            // Then
+            XCTAssertEqual(evaluatedResults, comparableResults)
+        }
+    }
 }

--- a/iOS/Sources/Beagle/Sources/Setup/Tests/__Snapshots__/BeagleSetupTests/testDefaultDependencies.1.txt
+++ b/iOS/Sources/Beagle/Sources/Setup/Tests/__Snapshots__/BeagleSetupTests/testDefaultDependencies.1.txt
@@ -155,7 +155,7 @@
   ▿ operationsProvider: OperationsDefault
     ▿ dependencies: InnerDependenciesResolver
       - container: (Function)
-    ▿ operations: 25 key/value pairs
+    ▿ operations: 26 key/value pairs
       ▿ (2 elements)
         - key: "and"
         - value: (Function)
@@ -227,6 +227,9 @@
         - value: (Function)
       ▿ (2 elements)
         - key: "sum"
+        - value: (Function)
+      ▿ (2 elements)
+        - key: "union"
         - value: (Function)
       ▿ (2 elements)
         - key: "uppercase"


### PR DESCRIPTION
### Related Issues

#503 

### Description and Example

The array _union_ operation was missing on iOS. 

```typescript
union(...arrays: any[][]) => any[]
```

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
