### PR TITLE
fix: Add useParentScroll property to ListView

### DIFF
--- a/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/ListView.kt
+++ b/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/ListView.kt
@@ -43,7 +43,8 @@ data class ListView(
     val onScrollEnd: List<Action>? = null,
     val scrollEndThreshold: Int? = null,
     val iteratorName: String = "item",
-    val key: String? = null
+    val key: String? = null,
+    val useParentScroll: Boolean? = null
 ) : Widget(), ContextComponent {
 
     /**
@@ -86,7 +87,8 @@ data class ListView(
         onScrollEnd: List<Action>? = null,
         scrollEndThreshold: Int? = null,
         iteratorName: String = "item",
-        key: String? = null
+        key: String? = null,
+        useParentScroll: Boolean? = null
     ) : this(
         null,
         direction,
@@ -97,7 +99,8 @@ data class ListView(
         onScrollEnd,
         scrollEndThreshold,
         iteratorName,
-        key
+        key,
+        useParentScroll
     )
 
     companion object


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>

### Description and Example

Adds useParentScroll property to backend listview contract. This property is used only on web

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
