### PR TITLE
fix: android listview oninit actions not been called for template items

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/OnInitiableComponent.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/OnInitiableComponent.kt
@@ -23,6 +23,7 @@ import br.com.zup.beagle.android.action.AsyncAction
 import br.com.zup.beagle.android.action.AsyncActionStatus
 import br.com.zup.beagle.android.utils.generateViewModelInstance
 import br.com.zup.beagle.android.utils.handleEvent
+import br.com.zup.beagle.android.utils.setIsInitiableComponent
 import br.com.zup.beagle.android.view.viewmodel.OnInitViewModel
 import br.com.zup.beagle.android.widget.RootView
 
@@ -79,6 +80,7 @@ class OnInitiableComponentImpl(override val onInit: List<Action>?) : OnInitiable
         onInitViewModel = rootView.generateViewModelInstance()
         this.origin = origin
         onInit?.let {
+            origin.setIsInitiableComponent(true)
             addListenerToExecuteOnInit(rootView)
         }
     }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
@@ -36,7 +36,7 @@ import br.com.zup.beagle.core.MultiChildComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.core.SingleChildComponent
 import org.json.JSONObject
-import java.util.*
+import java.util.LinkedList
 
 internal class ListViewHolder(
     itemView: View,

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
@@ -23,12 +23,12 @@ import android.widget.TextView
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView
 import br.com.zup.beagle.android.action.AsyncActionStatus
-import br.com.zup.beagle.android.components.OnInitiableComponent
 import br.com.zup.beagle.android.context.ContextComponent
 import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.utils.COMPONENT_NO_ID
 import br.com.zup.beagle.android.utils.getContextData
+import br.com.zup.beagle.android.utils.isInitiableComponent
 import br.com.zup.beagle.android.utils.safeGet
 import br.com.zup.beagle.android.utils.toAndroidId
 import br.com.zup.beagle.core.IdentifierComponent
@@ -36,7 +36,7 @@ import br.com.zup.beagle.core.MultiChildComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.core.SingleChildComponent
 import org.json.JSONObject
-import java.util.LinkedList
+import java.util.*
 
 internal class ListViewHolder(
     itemView: View,
@@ -49,24 +49,19 @@ internal class ListViewHolder(
 
     private val viewsWithId = mutableMapOf<String, View>()
     private val viewsWithContext = mutableListOf<View>()
+    private val viewsWithOnInit = mutableListOf<View>()
     private val directNestedRecyclers = mutableListOf<RecyclerView>()
     val directNestedImageViews = mutableListOf<ImageView>()
     val directNestedTextViews = mutableListOf<TextView>()
     private val contextComponents = mutableListOf<ContextData>()
-    private val initiableComponents = mutableListOf<OnInitiableComponent>()
     var observer: Observer<AsyncActionStatus>? = null
 
     init {
-        initializeViewsWithIdAndOnInit(template)
-        initializeViewsWithContextAndRecyclers(itemView)
+        extractViewInfoFromHolderTemplate(template)
+        extractViewInfoFromHolderItemView(itemView)
     }
 
-    private fun initializeViewsWithIdAndOnInit(component: ServerDrivenComponent) {
-        (component as? OnInitiableComponent)?.let {
-            component.onInit?.let {
-                initiableComponents.add(component)
-            }
-        }
+    private fun extractViewInfoFromHolderTemplate(component: ServerDrivenComponent) {
         (component as? IdentifierComponent)?.let {
             component.id?.let { id ->
                 if (id != COMPONENT_NO_ID) {
@@ -75,15 +70,18 @@ internal class ListViewHolder(
             }
         }
         if (component is SingleChildComponent) {
-            initializeViewsWithIdAndOnInit(component.child)
+            extractViewInfoFromHolderTemplate(component.child)
         } else if (component is MultiChildComponent) {
             component.children.forEach { child ->
-                initializeViewsWithIdAndOnInit(child)
+                extractViewInfoFromHolderTemplate(child)
             }
         }
     }
 
-    private fun initializeViewsWithContextAndRecyclers(view: View) {
+    private fun extractViewInfoFromHolderItemView(view: View) {
+        if (view.isInitiableComponent()) {
+            viewsWithOnInit.add(view)
+        }
         if (view.getContextData() != null) {
             viewsWithContext.add(view)
         }
@@ -102,7 +100,7 @@ internal class ListViewHolder(
         val count = view.childCount
         for (i in 0 until count) {
             val child = view.getChildAt(i)
-            initializeViewsWithContextAndRecyclers(child)
+            extractViewInfoFromHolderItemView(child)
         }
     }
 
@@ -234,6 +232,13 @@ internal class ListViewHolder(
                 val subViewId = bindIdToViewModel(innerRecyclerWithoutId, isRecycled, position, recyclerId)
                 setUpdatedIdToViewAndManagers(innerRecyclerWithoutId, subViewId, listItem, isRecycled)
             }
+
+        val viewsWithOnInitAndWithoutIdAndContext =
+            viewsWithOnInit.filterNot { viewsWithId.contains(it) || viewsWithContext.contains(it) }
+        viewsWithOnInitAndWithoutIdAndContext.forEach { view ->
+            val subViewId = bindIdToViewModel(view, isRecycled, position, recyclerId)
+            setUpdatedIdToViewAndManagers(view, subViewId, listItem, isRecycled)
+        }
     }
 
     private fun bindIdToViewModel(view: View, isRecycled: Boolean, position: Int, recyclerId: Int): Int {
@@ -329,6 +334,14 @@ internal class ListViewHolder(
                     innerRecyclerWithoutId.id = savedId
                 }
             }
+
+        val viewsWithOnInitAndWithoutIdAndContext =
+            viewsWithOnInit.filterNot { viewsWithId.contains(it) || viewsWithContext.contains(it) }
+        viewsWithOnInitAndWithoutIdAndContext.forEach { viewWithOnInit ->
+            temporaryViewIds.pollFirst()?.let { savedId ->
+                viewWithOnInit.id = savedId
+            }
+        }
     }
 
     private fun restoreAdapters(listItem: ListItem) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewExtensions.kt
@@ -96,3 +96,11 @@ internal fun View.setIsAutoGenerateIdEnabled(autoGenerateId: Boolean) {
 internal fun View.isAutoGenerateIdEnabled(): Boolean {
     return getTag(R.id.beagle_auto_generate_id_enabled) as? Boolean ?: true
 }
+
+internal fun View.setIsInitiableComponent(isInitiableComponent: Boolean) {
+    setTag(R.id.initiable_component, isInitiableComponent)
+}
+
+internal fun View.isInitiableComponent(): Boolean {
+    return getTag(R.id.initiable_component) as? Boolean ?: false
+}

--- a/android/beagle/src/main/res/values/ids.xml
+++ b/android/beagle/src/main/res/values/ids.xml
@@ -21,4 +21,5 @@
     <item name="beagle_context_view" type="id" />
     <item name="beagle_default_id" type="id" />
     <item name="beagle_auto_generate_id_enabled" type="id" />
+    <item name="initiable_component" type="id" />
 </resources>

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/OnInitiableComponentTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/OnInitiableComponentTest.kt
@@ -109,7 +109,7 @@ class OnInitiableComponentTest {
             initiableWidget.handleOnInit(rootView, origin)
 
             // Then
-            verify(exactly = 1) { origin.setIsInitiableComponent(false) }
+            verify(exactly = 1) { origin.setIsInitiableComponent(true) }
         }
 
         @DisplayName("Then if onInit actions list is empty, it shouldn't tag view as initiable_component")

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/OnInitiableComponentTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/OnInitiableComponentTest.kt
@@ -26,6 +26,7 @@ import br.com.zup.beagle.android.action.SendRequest
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.testutil.InstantExecutorExtension
 import br.com.zup.beagle.android.utils.handleEvent
+import br.com.zup.beagle.android.utils.setIsInitiableComponent
 import br.com.zup.beagle.android.view.viewmodel.OnInitViewModel
 import br.com.zup.beagle.android.widget.RootView
 import io.mockk.Runs
@@ -68,13 +69,13 @@ class OnInitiableComponentTest {
         unmockkConstructor(ViewModelProvider::class)
     }
 
-    @DisplayName("When handleOnInit")
+    @DisplayName("When handleOnInit is called")
     @Nested
     inner class HandleOnInit {
 
-        @DisplayName("Then shouldn't call addOnAttachStateChangeListener without onInit")
+        @DisplayName("Then shouldn't call addOnAttachStateChangeListener with empty onInit actions list")
         @Test
-        fun handleEmptyOnInit() {
+        fun handleOnInitCallWithEmptyOnInitActionsList() {
             // Given
             val initiableWidget = Container(children = listOf())
 
@@ -85,9 +86,9 @@ class OnInitiableComponentTest {
             verify(exactly = 0) { origin.addOnAttachStateChangeListener(any()) }
         }
 
-        @DisplayName("Then should call addOnAttachStateChangeListener")
+        @DisplayName("Then should call addOnAttachStateChangeListener with at least one onInit action")
         @Test
-        fun handleOnInit() {
+        fun handleOnInitCallWithAtLeastOneOnInitAction() {
             // Given
             val initiableWidget = Container(children = listOf(), onInit = listOf(Navigate.PopView()))
 
@@ -96,6 +97,32 @@ class OnInitiableComponentTest {
 
             // Then
             verify(exactly = 1) { origin.addOnAttachStateChangeListener(listenerSlot.captured) }
+        }
+
+        @DisplayName("Then if onInit has at least one action, it should tag view as initiable_component")
+        @Test
+        fun checkIfViewIsTaggedAsInitiableComponent() {
+            // Given
+            val initiableWidget = Container(children = listOf(), onInit = listOf(Navigate.PopView()))
+
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+
+            // Then
+            verify(exactly = 1) { origin.setIsInitiableComponent(false) }
+        }
+
+        @DisplayName("Then if onInit actions list is empty, it shouldn't tag view as initiable_component")
+        @Test
+        fun checkIfViewIsNotTaggedAsInitiableComponent() {
+            // Given
+            val initiableWidget = Container(children = listOf())
+
+            // When
+            initiableWidget.handleOnInit(rootView, origin)
+
+            // Then
+            verify(exactly = 0) { origin.setIsInitiableComponent(any()) }
         }
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/list/ListViewHolderTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/list/ListViewHolderTest.kt
@@ -29,6 +29,7 @@ import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.testutil.InstantExecutorExtension
 import br.com.zup.beagle.android.testutil.getPrivateField
 import br.com.zup.beagle.android.utils.getContextBinding
+import br.com.zup.beagle.android.utils.isInitiableComponent
 import br.com.zup.beagle.android.utils.toAndroidId
 import br.com.zup.beagle.android.view.viewmodel.ListViewIdViewModel
 import br.com.zup.beagle.android.view.viewmodel.ScreenContextViewModel
@@ -82,18 +83,19 @@ class ListViewHolderTest : BaseTest() {
     @Nested
     inner class Init {
 
-        @DisplayName("Then should add template with onInit to initiableComponents")
+        @DisplayName("Then should add view with onInit to viewsWithOnInit")
         @Test
-        fun initiableComponents() {
+        fun viewsWithOnInit() {
             // Given
-            val template = Container(children = listOf(), onInit = listOf(Navigate.PopView()))
+            val expectedViewsWithIdList = listOf(itemView)
+            every { itemView.isInitiableComponent() } returns true
 
             // When
             listViewHolder = ListViewHolder(itemView, template, serializer, listViewModels, jsonTemplate, iteratorName)
-            val initiableComponents = listViewHolder.getPrivateField<MutableList<OnInitiableComponent>>("initiableComponents")
+            val viewsWithOnInit = listViewHolder.getPrivateField<MutableList<View>>("viewsWithOnInit")
 
             // Then
-            assertEquals(template, initiableComponents[0])
+            assertEquals(expectedViewsWithIdList, viewsWithOnInit)
         }
 
         @DisplayName("Then should add view with id to viewsWithId")

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ViewExtensionsKtTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ViewExtensionsKtTest.kt
@@ -18,8 +18,10 @@ package br.com.zup.beagle.android.utils
 
 import android.view.View
 import br.com.zup.beagle.android.BaseTest
+import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextBinding
 import br.com.zup.beagle.android.context.ContextData
+import br.com.zup.beagle.android.testutil.InstantExecutorExtension
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -28,40 +30,53 @@ import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.extension.ExtendWith
 
-class ViewExtensionsKtTest : BaseTest() {
+@DisplayName("Given a View")
+class OnInitiableComponentTest : BaseTest() {
 
     private val view: View = mockk()
 
     private val contextData = ContextData("contextId", "stub")
 
-    @Test
-    fun `GIVEN a contextBinding WHEN setContextData THEN should use bindings`() {
-        // Given
-        val contextBinding = mockk<ContextBinding>(relaxed = true)
-        val bindingSlot = slot<ContextBinding>()
-        every { view.getContextBinding() } returns contextBinding
-        every { view.setContextBinding(capture(bindingSlot)) } just Runs
+    @DisplayName("When setContextData is called")
+    @Nested
+    inner class SetContextData {
 
-        // When
-        view.setContextData(contextData)
+        @DisplayName("Then should set bindings")
+        @Test
+        fun checkIfContextBindingWasSet() {
+            // Given
+            val contextBinding = mockk<ContextBinding>(relaxed = true)
+            val bindingSlot = slot<ContextBinding>()
+            every { view.getContextBinding() } returns contextBinding
+            every { view.setContextBinding(capture(bindingSlot)) } just Runs
 
-        // Then
-        assertEquals(bindingSlot.captured.context, contextData)
-        assertEquals(bindingSlot.captured.bindings, contextBinding.bindings)
-    }
+            // When
+            view.setContextData(contextData)
 
-    @Test
-    fun `GIVEN an empty contextBinding WHEN setContextData THEN should not set bindings`() {
-        // Given
-        val bindingSlot = slot<ContextBinding>()
-        every { view.getContextBinding() } returns null
-        every { view.setContextBinding(capture(bindingSlot)) } just Runs
+            // Then
+            assertEquals(bindingSlot.captured.context, contextData)
+            assertEquals(bindingSlot.captured.bindings, contextBinding.bindings)
+        }
 
-        // When
-        view.setContextData(contextData)
+        @DisplayName("Then should not set bindings")
+        @Test
+        fun checkIfContextBindingWasNotSet() {
+            // Given
+            val expectedBindings = mutableSetOf<Bind<*>>()
+            val bindingSlot = slot<ContextBinding>()
+            every { view.getContextBinding() } returns null
+            every { view.setContextBinding(capture(bindingSlot)) } just Runs
 
-        // Then
-        assertEquals(bindingSlot.captured.context, contextData)
+            // When
+            view.setContextData(contextData)
+
+            // Then
+            assertEquals(bindingSlot.captured.context, contextData)
+            assertEquals(bindingSlot.captured.bindings, expectedBindings)
+        }
     }
 }


### PR DESCRIPTION
### Related Issues

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

### Description and Example

Given a listView with a template that has a component with onInit actions and no id is setted on BFF to this component, then the onInit actions will be executed only for the first item on listView. 

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
