### PR TITLE
fix: Android listView id management

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
@@ -234,7 +234,7 @@ internal class ListViewHolder(
             }
 
         val viewsWithOnInitAndWithoutIdAndContext =
-            viewsWithOnInit.filterNot { viewsWithId.contains(it) || viewsWithContext.contains(it) }
+            viewsWithOnInit.filterNot { viewsWithId.containsValue(it) || viewsWithContext.contains(it) }
         viewsWithOnInitAndWithoutIdAndContext.forEach { view ->
             val subViewId = bindIdToViewModel(view, isRecycled, position, recyclerId)
             setUpdatedIdToViewAndManagers(view, subViewId, listItem, isRecycled)
@@ -336,7 +336,7 @@ internal class ListViewHolder(
             }
 
         val viewsWithOnInitAndWithoutIdAndContext =
-            viewsWithOnInit.filterNot { viewsWithId.contains(it) || viewsWithContext.contains(it) }
+            viewsWithOnInit.filterNot { viewsWithId.containsValue(it) || viewsWithContext.contains(it) }
         viewsWithOnInitAndWithoutIdAndContext.forEach { viewWithOnInit ->
             temporaryViewIds.pollFirst()?.let { savedId ->
                 viewWithOnInit.id = savedId

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/GenerateIdManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/GenerateIdManager.kt
@@ -51,12 +51,12 @@ internal class GenerateIdManager(
 
     fun manageId(component: ServerDrivenComponent, view: BeagleFlexView) {
         (component as? IdentifierComponent)?.let { identifierComponent ->
-            if (identifierComponent.id.isNullOrEmpty()) {
-                if (view.isAutoGenerateIdEnabled()) {
+            if (view.isAutoGenerateIdEnabled()) {
+                if (identifierComponent.id.isNullOrEmpty()) {
                     setComponentId(component)
-                } else {
-                    markEachNestedComponentAsNoIdIfNeeded(component)
                 }
+            } else {
+                markEachNestedComponentAsNoIdIfNeeded(component)
             }
         }
     }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/GenerateIdManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/GenerateIdManagerTest.kt
@@ -127,6 +127,7 @@ class GenerateIdManagerTest {
         fun notGenerateViewIdWithId() {
             // Given
             val component = Container(listOf()).setId("stub")
+            every { view.isAutoGenerateIdEnabled() } returns true
 
             // When
             generateIdManager.manageId(component, view)


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>

### Description and Example

Android listView was not recovering its internal views ids correctly when device screen was rotated.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
