### PR TITLE
fix: add controllerId to action resetApplication

### DIFF
--- a/iOS/Schema/Sources/Action/Types/Navigate/Navigate.swift
+++ b/iOS/Schema/Sources/Action/Types/Navigate/Navigate.swift
@@ -24,7 +24,7 @@ public enum Navigate: RawAction {
     case openNativeRoute(OpenNativeRoute)
 
     /// Resets the application's root navigation stack with a new navigation stack that has `Route` as the first view
-    case resetApplication(Route)
+    case resetApplication(Route, controllerId: String? = nil)
     
     /// Resets the views stack to create a new flow with the passed route.
     case resetStack(Route)

--- a/iOS/Schema/Sources/Action/Types/Navigate/Tests/NavigateTests.swift
+++ b/iOS/Schema/Sources/Action/Types/Navigate/Tests/NavigateTests.swift
@@ -61,12 +61,14 @@ final class NavigateTests: XCTestCase {
 
         _assertInlineSnapshot(matching: action, as: .dump, with: """
         ▿ Navigate
-          ▿ resetApplication: Route
-            ▿ remote: NewPath
-              - fallback: Optional<Screen>.none
-              - shouldPrefetch: false
-              ▿ url: Expression<String>
-                - value: "schema://path"
+          ▿ resetApplication: (2 elements)
+            ▿ .0: Route
+              ▿ remote: NewPath
+                - fallback: Optional<Screen>.none
+                - shouldPrefetch: false
+                ▿ url: Expression<String>
+                  - value: "schema://path"
+            - controllerId: Optional<String>.none
         """)
     }
     

--- a/iOS/Sources/Beagle/Sources/Action/Types/Navigate.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Navigate.swift
@@ -27,7 +27,7 @@ extension Navigate: Action {
 extension Navigate {
     var newPath: Route.NewPath? {
         switch self {
-        case let .resetApplication(route),
+        case let .resetApplication(route, _),
              let .resetStack(route),
              let .pushStack(route, _),
              let .pushView(route):

--- a/iOS/Sources/Beagle/Sources/Caching/Prefetch/Tests/__Snapshots__/BeaglePrefetchHelperTests/testNavigationIsPrefetchable.1.txt
+++ b/iOS/Sources/Beagle/Sources/Caching/Prefetch/Tests/__Snapshots__/BeaglePrefetchHelperTests/testNavigationIsPrefetchable.1.txt
@@ -4,11 +4,11 @@
 
   openNativeRoute(BeagleSchema.Navigate.OpenNativeRoute(route: "path", data: Optional(["data": "value"]), shouldResetApplication: false))  -->  NULL 
 
-  resetApplication(BeagleSchema.Route.declarative(BeagleSchema.Screen(id: nil, style: nil, safeArea: nil, navigationBar: nil, screenAnalyticsEvent: nil, child: BeagleSchema.Container(children: [], widgetProperties: BeagleSchema.WidgetProperties(id: nil, style: nil, accessibility: nil), onInit: nil, context: nil), context: nil)))  -->  NULL 
+  resetApplication(BeagleSchema.Route.declarative(BeagleSchema.Screen(id: nil, style: nil, safeArea: nil, navigationBar: nil, screenAnalyticsEvent: nil, child: BeagleSchema.Container(children: [], widgetProperties: BeagleSchema.WidgetProperties(id: nil, style: nil, accessibility: nil), onInit: nil, context: nil), context: nil)), controllerId: nil)  -->  NULL 
 
-  resetApplication(BeagleSchema.Route.remote(BeagleSchema.Route.NewPath(url: BeagleSchema.Expression<Swift.String>.value("path"), shouldPrefetch: true, fallback: nil)))  -->  NewPath(url: BeagleSchema.Expression<Swift.String>.value("path"), shouldPrefetch: true, fallback: nil) 
+  resetApplication(BeagleSchema.Route.remote(BeagleSchema.Route.NewPath(url: BeagleSchema.Expression<Swift.String>.value("path"), shouldPrefetch: true, fallback: nil)), controllerId: nil)  -->  NewPath(url: BeagleSchema.Expression<Swift.String>.value("path"), shouldPrefetch: true, fallback: nil) 
 
-  resetApplication(BeagleSchema.Route.remote(BeagleSchema.Route.NewPath(url: BeagleSchema.Expression<Swift.String>.value("path"), shouldPrefetch: false, fallback: nil)))  -->  NewPath(url: BeagleSchema.Expression<Swift.String>.value("path"), shouldPrefetch: false, fallback: nil) 
+  resetApplication(BeagleSchema.Route.remote(BeagleSchema.Route.NewPath(url: BeagleSchema.Expression<Swift.String>.value("path"), shouldPrefetch: false, fallback: nil)), controllerId: nil)  -->  NewPath(url: BeagleSchema.Expression<Swift.String>.value("path"), shouldPrefetch: false, fallback: nil) 
 
   resetStack(BeagleSchema.Route.declarative(BeagleSchema.Screen(id: nil, style: nil, safeArea: nil, navigationBar: nil, screenAnalyticsEvent: nil, child: BeagleSchema.Container(children: [], widgetProperties: BeagleSchema.WidgetProperties(id: nil, style: nil, accessibility: nil), onInit: nil, context: nil), context: nil)))  -->  NULL 
 

--- a/iOS/Sources/Beagle/Sources/Navigation/BeagleNavigator.swift
+++ b/iOS/Sources/Beagle/Sources/Navigation/BeagleNavigator.swift
@@ -66,8 +66,15 @@ class BeagleNavigator: BeagleNavigation {
             openExternalURL(path: url, controller: controller)
         case let .openNativeRoute(nativeRoute):
             openNativeRoute(controller: controller, animated: animated, nativeRoute: nativeRoute)
-        case let .resetApplication(route):
-            navigate(route: route, controller: controller, animated: animated, origin: origin, transition: resetApplication(origin:destination:animated:))
+        case let .resetApplication(route, controllerId):
+            navigate(
+                route: route,
+                controller: controller,
+                animated: animated,
+                origin: origin
+            ) { [weak self] origin, destination, animated in
+                self?.resetApplication(origin: origin, destination: destination, controllerId: controllerId, animated: animated)
+            }
         case let .resetStack(route):
             navigate(route: route, controller: controller, animated: animated, origin: origin, transition: resetStack(origin:destination:animated:))
         case let .pushView(route):
@@ -155,8 +162,10 @@ class BeagleNavigator: BeagleNavigation {
         }
     }
     
-    private func resetApplication(origin: BeagleController, destination: UIViewController, animated: Bool) {
-        origin.dependencies.windowManager.window?.replace(rootViewController: destination, animated: animated, completion: nil)
+    private func resetApplication(origin: BeagleController, destination: UIViewController, controllerId: String?, animated: Bool) {
+        let navigation = navigationController(forId: controllerId)
+        navigation.viewControllers = [destination]
+        origin.dependencies.windowManager.window?.replace(rootViewController: navigation, animated: animated, completion: nil)
     }
     
     private func resetStack(origin: BeagleController, destination: UIViewController, animated: Bool) {


### PR DESCRIPTION
### Related Issues

Closes #1225 

### Description and Example

Add the property controllerId to action resetApplication. It is used to customize the navigation controller.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
