### PR TITLE
fix: android listview context reference

### DIFF
--- a/android/automated-tests/src/androidTest/assets/features/ListView.feature
+++ b/android/automated-tests/src/androidTest/assets/features/ListView.feature
@@ -370,7 +370,7 @@ Feature: ListView Component Validation
             | 32       | Name: Hermione Granger      | Book: Harry Potter and the Philosopher's Stone | Collection: Harry Potter           |
             | 33       | Name: Rúbeo Hagrid          | Book: Harry Potter and the Philosopher's Stone | Collection: Harry Potter           |
 
-   Scenario Outline: ListView 20 - Books ListView: evaluates context correctly
+   Scenario Outline: ListView 20 - Books ListView: evaluates context correctly after screen rotation
        When I scroll listView with id categoriesList to position <categoriesListPosition>
        And I scroll listView with id categoriesBooksList:<categoryId> to position 6
        And I change the device orientation to landscape
@@ -399,3 +399,11 @@ Feature: ListView Component Validation
            | 2                     | 3          | 0                 | The Last Tribe   | REMOVE     |
            | 2                     | 3          | 1                 | The Last Tribe   | BUY        |
            | 2                     | 3          | 2                 | The Last Tribe   | BUY        |
+
+    Scenario: ListView 21 - Books ListView: evaluates context correctly
+        When I scroll listView with id categoriesBooksList:1 to position 6
+        And I scroll listView with id categoriesBooksList:1 to position 0
+        And I click on view with id cartButton:1:The Final Empire at position 0 of listView with id categoriesBooksList:1
+        And I scroll listView with id categoriesBooksList:1 to position 6
+        And I scroll listView with id categoriesBooksList:1 to position 0
+        Then listView with id categoriesBooksList:1 at position 0 should show text: REMOVE

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -116,7 +116,7 @@ internal class ContextDataManager(
 
     fun restoreContext(view: View) {
         contexts[view.id]?.let {
-            view.setContextData(it.context)
+            view.setContextBinding(it)
         }
     }
 


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>


### Description and Example

When a view with context was being restored after getting recycled, the context binding reference was being incorrectly changed due to call to View.setContextData().

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
