### PR TITLE
fix: android listview context reference

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/ContextDataManager.kt
@@ -116,7 +116,7 @@ internal class ContextDataManager(
 
     fun restoreContext(view: View) {
         contexts[view.id]?.let {
-            view.setContextData(it.context)
+            view.setContextBinding(it)
         }
     }
 


### PR DESCRIPTION
### Related Issues

### Description and Example

When a view with context was being restored after getting recycled, the context binding reference was being incorrectly changed due to call to View.setContextData().

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
