### PR TITLE
fix: add missing field controllerId when decoding action resetApplication

### DIFF
--- a/iOS/Sources/Beagle/Sources/Action/Types/Navigate.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Navigate.swift
@@ -132,7 +132,10 @@ extension Navigate: Decodable {
         case "beagle:opennativeroute":
             self = .openNativeRoute(try .init(from: decoder))
         case "beagle:resetapplication":
-            self = .resetApplication(try container.decode(Route.self, forKey: .route))
+            self = .resetApplication(
+                try container.decode(Route.self, forKey: .route),
+                controllerId: try container.decodeIfPresent(String.self, forKey: .controllerId)
+            )
         case "beagle:resetstack":
             self = .resetStack(try container.decode(Route.self, forKey: .route))
         case "beagle:pushstack":

--- a/iOS/Sources/Beagle/Sources/Action/Types/Tests/NavigateTests.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Tests/NavigateTests.swift
@@ -53,6 +53,7 @@ class NavigateTests: XCTestCase {
         let action: Navigate = try actionFromString("""
         {
             "_beagleAction_": "beagle:resetapplication",
+            "controllerId": "my-controller-id",
             "route": {
                 "url": "schema://path"
             }
@@ -68,7 +69,8 @@ class NavigateTests: XCTestCase {
                 - shouldPrefetch: false
                 ▿ url: Expression<String>
                   - value: "schema://path"
-            - controllerId: Optional<String>.none
+            ▿ controllerId: Optional<String>
+              - some: "my-controller-id"
         """)
     }
     


### PR DESCRIPTION
### Related Issues

Closes #1239

### Description and Example

See description at #1239 and test `testDecodingResetApplication`

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
