### PR TITLE
refactor: Convert corner radius that come from backend in dp to pixel…

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/ViewExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/ViewExtensions.kt
@@ -84,7 +84,7 @@ internal fun View.applyStroke(styleWidget: StyleComponent) {
 internal fun View.applyCornerRadius(styleWidget: StyleComponent) {
     styleWidget.style?.cornerRadius?.let { cornerRadius ->
         if (cornerRadius.radius > FLOAT_ZERO) {
-            (this.background as? GradientDrawable)?.cornerRadius = cornerRadius.radius.toFloat()
+            (this.background as? GradientDrawable)?.cornerRadius = cornerRadius.radius.dp().toFloat()
         }
     }
 }


### PR DESCRIPTION

### Related Issues

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->
#1230 

### Description and Example

<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most imporant thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

Convert cornerRadius that come from bff. In Android platform this value correspond to dp instead pixels, so we have to convert internally to pixels using dp( ) method.
This method is a extension function from float or double and convert from dp to pixels.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
