### PR TITLE
feat: Adds support for generation of dokka documentation to hugo md files

### DIFF
--- a/android/beagle/build.gradle
+++ b/android/beagle/build.gradle
@@ -113,7 +113,6 @@ dependencies {
 
 apply from: rootProject.file('../maven-publish.gradle')
 
-apply plugin: 'org.jetbrains.dokka'
 /**
  *  https://github.com/cotechde/dokka-hugo-plugin
  *  To run this task by ./gradlew dokkaHugo

--- a/android/beagle/build.gradle
+++ b/android/beagle/build.gradle
@@ -112,3 +112,14 @@ dependencies {
 }
 
 apply from: rootProject.file('../maven-publish.gradle')
+
+apply plugin: 'org.jetbrains.dokka'
+/**
+ *  https://github.com/cotechde/dokka-hugo-plugin
+ *  To run this task by ./gradlew dokkaHugo
+ */
+task dokkaHugo(type: org.jetbrains.dokka.gradle.DokkaTask) {
+    dependencies {
+        dokkaHugoPlugin 'com.github.cotechde:dokka-hugo-plugin:master-SNAPSHOT'
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         classpath "com.karumi:shot:4.3.0"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.20"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.0"
         classpath "com.hiya:jacoco-android:0.2"
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.13.0"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.6.2.0"
@@ -46,6 +46,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
This PR adds support for generating the javadoc md files supported on hugo.

![image](https://user-images.githubusercontent.com/45759570/103311363-ece3c800-49f8-11eb-8390-9f4264ed3063.png)
![image](https://user-images.githubusercontent.com/45759570/103311397-05ec7900-49f9-11eb-826c-dd77ca9c1992.png)
