### PR TITLE
feat: add flutter default text component

### DIFF
--- a/flutter/beagle/lib/utils/color_utils.dart
+++ b/flutter/beagle/lib/utils/color_utils.dart
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+
+Color hexToColor(String hexString, {String alphaChannel = 'FF'}) {
+  return Color(int.parse(hexString.replaceFirst('#', '0x$alphaChannel')));
+}

--- a/flutter/beagle_components/lib/beagle_text.dart
+++ b/flutter/beagle_components/lib/beagle_text.dart
@@ -17,9 +17,6 @@
 import 'package:flutter/material.dart';
 import 'package:beagle/utils/color_utils.dart';
 
-const kBeagleTextDefaultTextColor = '#000000';
-const kBeagleTextDefaultTextAlignment = TextAlign.left;
-
 class BeagleText extends StatelessWidget {
   const BeagleText({
     Key key,
@@ -27,6 +24,9 @@ class BeagleText extends StatelessWidget {
     this.textColor,
     this.alignment,
   }) : super(key: key);
+
+  static const defaultTextColor = '#000000';
+  static const defaultTextAlign = TextAlign.left;
 
   final String text;
   final String textColor;
@@ -51,12 +51,12 @@ class BeagleText extends StatelessWidget {
     } else if (alignment == TextAlignment.LEFT) {
       return TextAlign.left;
     } else {
-      return kBeagleTextDefaultTextAlignment;
+      return defaultTextAlign;
     }
   }
 
   Color getTextColor(String color) {
-    return hexToColor(color ?? kBeagleTextDefaultTextColor);
+    return hexToColor(color ?? defaultTextColor);
   }
 }
 

--- a/flutter/beagle_components/lib/beagle_text.dart
+++ b/flutter/beagle_components/lib/beagle_text.dart
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:beagle/utils/color_utils.dart';
+
+const kBeagleTextDefaultTextColor = '#000000';
+const kBeagleTextDefaultTextAlignment = TextAlign.left;
+
+class BeagleText extends StatelessWidget {
+  const BeagleText({
+    Key key,
+    this.text,
+    this.textColor,
+    this.alignment,
+  }) : super(key: key);
+
+  final String text;
+  final String textColor;
+  final TextAlignment alignment;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: TextStyle(
+        color: getTextColor(textColor),
+      ),
+      textAlign: getTextAlign(alignment),
+    );
+  }
+
+  TextAlign getTextAlign(TextAlignment alignment) {
+    if (alignment == TextAlignment.CENTER) {
+      return TextAlign.center;
+    } else if (alignment == TextAlignment.RIGHT) {
+      return TextAlign.right;
+    } else if (alignment == TextAlignment.LEFT) {
+      return TextAlign.left;
+    } else {
+      return kBeagleTextDefaultTextAlignment;
+    }
+  }
+
+  Color getTextColor(String color) {
+    return hexToColor(color ?? kBeagleTextDefaultTextColor);
+  }
+}
+
+enum TextAlignment {
+  /// Text content is LEFT aligned inside the text view.
+  ///
+  LEFT,
+
+  /// Text content is CENTER aligned inside the text view.
+  ///
+  CENTER,
+
+  /// Text content is RIGHT aligned inside the text view.
+  ///
+  RIGHT
+}

--- a/flutter/beagle_components/lib/default_components.dart
+++ b/flutter/beagle_components/lib/default_components.dart
@@ -16,7 +16,9 @@
  */
 
 import 'package:beagle/model/beagle_ui_element.dart';
+import 'package:beagle/utils/enum.dart';
 import 'package:beagle_components/beagle_lazy_component.dart';
+import 'package:beagle_components/beagle_text.dart';
 import 'package:beagle_components/beagle_text_input.dart';
 import 'package:beagle/interface/beagle_service.dart';
 import 'package:flutter/material.dart';
@@ -25,8 +27,7 @@ final Map<String, ComponentBuilder> defaultComponents = {
   'custom:loading': (element, _, __) =>
       Text('Loading...', key: element.getKey()),
   'custom:error': (element, _, __) => Text('Error!', key: element.getKey()),
-  'beagle:text': (element, _, __) =>
-      Text(element.getAttributeValue('text'), key: element.getKey()),
+  'beagle:text': beagleTextBuilder(),
   'beagle:container': (element, children, _) =>
       Container(key: element.getKey(), child: Column(children: children)),
   'beagle:textInput': (element, _, __) => BeagleTextInput(
@@ -56,3 +57,15 @@ final Map<String, ComponentBuilder> defaultComponents = {
         child: children.isEmpty ? null : children[0]);
   }
 };
+
+ComponentBuilder beagleTextBuilder() {
+  return (element, _, __) => BeagleText(
+        key: element.getKey(),
+        text: element.getAttributeValue('text'),
+        textColor: element.getAttributeValue('textColor'),
+        alignment: EnumUtils.fromString(
+          TextAlignment.values,
+          element.getAttributeValue('alignment') ?? '',
+        ),
+      );
+}

--- a/flutter/beagle_components/test/beagle_text_test.dart
+++ b/flutter/beagle_components/test/beagle_text_test.dart
@@ -78,7 +78,7 @@ void main() {
           (WidgetTester tester) async {
         await tester.pumpWidget(createWidget(textColor: null));
 
-        final expectedTextColor = hexToColor(kBeagleTextDefaultTextColor);
+        final expectedTextColor = hexToColor(BeagleText.defaultTextColor);
 
         expect(tester.widget<Text>(find.text(text)).style.color,
             expectedTextColor);
@@ -90,7 +90,7 @@ void main() {
           (WidgetTester tester) async {
         await tester.pumpWidget(createWidget(alignment: null));
 
-        const expectedTextAlign = kBeagleTextDefaultTextAlignment;
+        const expectedTextAlign = BeagleText.defaultTextAlign;
 
         expect(
             tester.widget<Text>(find.text(text)).textAlign, expectedTextAlign);

--- a/flutter/beagle_components/test/beagle_text_test.dart
+++ b/flutter/beagle_components/test/beagle_text_test.dart
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:beagle_components/beagle_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:beagle/utils/color_utils.dart';
+
+const text = 'Beagle Text';
+const textColor = '#00FF00';
+const alignment = TextAlignment.RIGHT;
+const textKey = Key('TextKey');
+
+Widget createWidget({
+  Key key = textKey,
+  String text = text,
+  String textColor = textColor,
+  TextAlignment alignment = alignment,
+}) {
+  return MaterialApp(
+    home: BeagleText(
+      key: key,
+      text: text,
+      textColor: textColor,
+      alignment: alignment,
+    ),
+  );
+}
+
+void main() {
+  group('Given a BeagleText', () {
+    group('When the widget is rendered', () {
+      testWidgets('Then it should have the correct text',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        final textFinder = find.text(text);
+
+        expect(textFinder, findsOneWidget);
+      });
+
+      testWidgets('Then it should have the correct text color',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        final expectedTextColor = hexToColor(textColor);
+
+        expect(tester.widget<Text>(find.text(text)).style.color,
+            expectedTextColor);
+      });
+
+      testWidgets('Then it should have the correct text alignment',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        const expectedTextAlign = TextAlign.right;
+
+        expect(
+            tester.widget<Text>(find.text(text)).textAlign, expectedTextAlign);
+      });
+    });
+
+    group('When a text color is not specified', () {
+      testWidgets('Then it should have the default text color',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(textColor: null));
+
+        final expectedTextColor = hexToColor(kBeagleTextDefaultTextColor);
+
+        expect(tester.widget<Text>(find.text(text)).style.color,
+            expectedTextColor);
+      });
+    });
+
+    group('When a text alignment is not specified', () {
+      testWidgets('Then it should have the default text alignment',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(alignment: null));
+
+        const expectedTextAlign = kBeagleTextDefaultTextAlignment;
+
+        expect(
+            tester.widget<Text>(find.text(text)).textAlign, expectedTextAlign);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>


### Related Issues

#1306

### Description and Example

Adds flutter default text component. It isn't possible to style the component yet.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
