### PR TITLE
feat: accessibility header 

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/TabBarScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/TabBarScreen.swift
@@ -58,7 +58,7 @@ struct TabBarScreen: DeeplinkScreen {
                 currentPage: "@{tab.currentTab}"
             ) {
                 Container(widgetProperties: .init(Flex().alignContent(.center))) {
-                    Text("Text1 Tab 1")
+                    Text("Text1 Tab 1", widgetProperties: .init(accessibility: Accessibility(accessible: true, isHeader: true)))
                     Image(.remote(.init(url: .networkImageBeagle, placeholder: "imageBeagle")))
                     Text("Text2 Tab 1")
                     Button(text: "change Context Tab 1", onPress: [

--- a/iOS/Sources/Beagle/Sources/Components/Widget/Tests/JSON/widgetWithAllAttributes.json
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/Tests/JSON/widgetWithAllAttributes.json
@@ -23,6 +23,7 @@
    },
    "accessibility":{
       "accessible":true,
-      "accessibilityLabel":"This is a text as title"
+      "accessibilityLabel":"This is a text as title",
+      "isHeader": true
    }
 }

--- a/iOS/Sources/Beagle/Sources/Components/Widget/Tests/__Snapshots__/WidgetTests/testParsingOfWidgetWithAllAttributes.1.txt
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/Tests/__Snapshots__/WidgetTests/testParsingOfWidgetWithAllAttributes.1.txt
@@ -15,7 +15,8 @@
         ▿ accessibilityLabel: Optional<String>
           - some: "This is a text as title"
         - accessible: true
-        - isHeader: Optional<Bool>.none
+        ▿ isHeader: Optional<Bool>
+          - some: true
     ▿ id: Optional<String>
       - some: "some id"
     ▿ style: Optional<Style>

--- a/iOS/Sources/Beagle/Sources/Components/Widget/Tests/__Snapshots__/WidgetTests/testParsingOfWidgetWithAllAttributes.1.txt
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/Tests/__Snapshots__/WidgetTests/testParsingOfWidgetWithAllAttributes.1.txt
@@ -15,6 +15,7 @@
         ▿ accessibilityLabel: Optional<String>
           - some: "This is a text as title"
         - accessible: true
+        - isHeader: Optional<Bool>.none
     ▿ id: Optional<String>
       - some: "some id"
     ▿ style: Optional<Style>

--- a/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/Accessibility.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/Accessibility.swift
@@ -29,7 +29,7 @@ public struct Accessibility: Decodable, Equatable {
     /// A Boolean value indicating whether the receiver is an accessibility element that an assistive application can access
     public var accessible: Bool
     
-    /// A mask that contains the OR combination of the accessibility traits that best characterize an accessibility element.
+    /// A Boolean value indicating whether header is available for an element
     public var isHeader: Bool?
         
     /// Initializer for Accessibility

--- a/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/Accessibility.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/Accessibility.swift
@@ -30,12 +30,8 @@ public struct Accessibility: Decodable, Equatable {
     public var accessible: Bool
     
     /// A mask that contains the OR combination of the accessibility traits that best characterize an accessibility element.
-//    public var accessibilityTraits: UIAccessibilityTraits?
-    
     public var isHeader: Bool?
-    
-    // TODO: all the trait options are available in swift4.2+ so we must check if we can update version
-    
+        
     /// Initializer for Accessibility
     /// - Parameters:
     ///   - accessibilityLabel: the identifier of the element. Default is nil
@@ -45,7 +41,7 @@ public struct Accessibility: Decodable, Equatable {
     public init(
         accessibilityLabel: String? = nil,
         accessible: Bool = true,
-        isHeader: Bool? = nil
+        isHeader: Bool? = false
     ) {
         self.accessibilityLabel = accessibilityLabel
         self.accessible = accessible

--- a/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/Accessibility.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/Accessibility.swift
@@ -30,7 +30,10 @@ public struct Accessibility: Decodable, Equatable {
     public var accessible: Bool
     
     /// A mask that contains the OR combination of the accessibility traits that best characterize an accessibility element.
-    //var accessibilityTraits: UIAccessibilityTraits = .zero
+//    public var accessibilityTraits: UIAccessibilityTraits?
+    
+    public var isHeader: Bool?
+    
     // TODO: all the trait options are available in swift4.2+ so we must check if we can update version
     
     /// Initializer for Accessibility
@@ -41,9 +44,11 @@ public struct Accessibility: Decodable, Equatable {
     ///   - isAccessibilityElement: A Boolean value indicating whether the receiver is an accessibility element that an assistive application can access. Default is true for UIKit elements.
     public init(
         accessibilityLabel: String? = nil,
-        accessible: Bool = true
+        accessible: Bool = true,
+        isHeader: Bool? = nil
     ) {
         self.accessibilityLabel = accessibilityLabel
         self.accessible = accessible
+        self.isHeader = isHeader
     }
 }

--- a/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/AccessibilityTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/AccessibilityTests.swift
@@ -25,7 +25,7 @@ class AccessibilityTest: XCTestCase {
     
     func testIfAttributesWereAppliedToNavigationItem() {
         //given
-        let accessibility = Accessibility(accessibilityLabel: label, accessible: true)
+        let accessibility = Accessibility(accessibilityLabel: label, accessible: true, isHeader: true)
         let navigationItem = UINavigationItem()
 
         //when
@@ -48,7 +48,7 @@ class AccessibilityTest: XCTestCase {
         //then
         XCTAssert(barButtonItem.accessibilityLabel == label)
         XCTAssert(barButtonItem.isAccessibilityElement)
-        XCTAssert(barButtonItem.accessibilityTraits == .button)
+        XCTAssert(barButtonItem.accessibilityTraits == .header)
     }
     
     func testIfAttributesWereAppliedToView() {

--- a/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/AccessibilityTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/WidgetProperties/Accessibility/AccessibilityTests.swift
@@ -34,11 +34,12 @@ class AccessibilityTest: XCTestCase {
         //then
         XCTAssert(navigationItem.accessibilityLabel == label)
         XCTAssert(navigationItem.isAccessibilityElement)
+        XCTAssert(navigationItem.accessibilityTraits == .header)
     }
 
     func testIfAttributesWereAppliedToBarButtonItem() {
         //given
-        let accessibility = Accessibility(accessibilityLabel: label, accessible: true)
+        let accessibility = Accessibility(accessibilityLabel: label, accessible: true, isHeader: true)
         let barButtonItem = UIBarButtonItem()
 
         //when
@@ -47,6 +48,7 @@ class AccessibilityTest: XCTestCase {
         //then
         XCTAssert(barButtonItem.accessibilityLabel == label)
         XCTAssert(barButtonItem.isAccessibilityElement)
+        XCTAssert(barButtonItem.accessibilityTraits == .button)
     }
     
     func testIfAttributesWereAppliedToView() {
@@ -59,6 +61,7 @@ class AccessibilityTest: XCTestCase {
         //then
         XCTAssert(testView.accessibilityLabel == label)
         XCTAssert(testView.isAccessibilityElement)
+        XCTAssert(testView.accessibilityTraits == .none)
     }
     
     func testIfViewIsNotAccessible() {

--- a/iOS/Sources/Beagle/Sources/Renderer/ViewConfigurator.swift
+++ b/iOS/Sources/Beagle/Sources/Renderer/ViewConfigurator.swift
@@ -95,29 +95,8 @@ class ViewConfigurator: ViewConfiguratorProtocol {
         }
         object?.isAccessibilityElement = accessibility.accessible
         
-        if let isHeader = accessibility.isHeader, isHeader, let object = object {
-            object.accessibilityTraits = getAccessibilityTrait(for: object)
+        if let isHeader = accessibility.isHeader {
+            object?.accessibilityTraits = isHeader ? .header : .none
         }
-    }
-    
-    private static func getAccessibilityTrait(for object: NSObject) -> UIAccessibilityTraits {
-        if object.isKind(of: UIBarButtonItem.self) || object.isKind(of: UIButton.self) || object.isKind(of: UINavigationItem.self) {
-            
-            return .button
-        }
-        if object.isKind(of: UINavigationItem.self) {
-            return .header
-        }
-        if object.isKind(of: UIImageView.self) || object.isKind(of: UIImageView.self) {
-            return .image
-        }
-        if object.isKind(of: UILabel.self) {
-            return .staticText
-        }
-        if object.isKind(of: UISearchBar.self) {
-            return .searchField
-        }
-
-        return .none
     }
 }

--- a/iOS/Sources/Beagle/Sources/Renderer/ViewConfigurator.swift
+++ b/iOS/Sources/Beagle/Sources/Renderer/ViewConfigurator.swift
@@ -94,5 +94,30 @@ class ViewConfigurator: ViewConfiguratorProtocol {
             object?.accessibilityLabel = label
         }
         object?.isAccessibilityElement = accessibility.accessible
+        
+        if let isHeader = accessibility.isHeader, isHeader, let object = object {
+            object.accessibilityTraits = getAccessibilityTrait(for: object)
+        }
+    }
+    
+    private static func getAccessibilityTrait(for object: NSObject) -> UIAccessibilityTraits {
+        if object.isKind(of: UIBarButtonItem.self) || object.isKind(of: UIButton.self) || object.isKind(of: UINavigationItem.self) {
+            
+            return .button
+        }
+        if object.isKind(of: UINavigationItem.self) {
+            return .header
+        }
+        if object.isKind(of: UIImageView.self) || object.isKind(of: UIImageView.self) {
+            return .image
+        }
+        if object.isKind(of: UILabel.self) {
+            return .staticText
+        }
+        if object.isKind(of: UISearchBar.self) {
+            return .searchField
+        }
+
+        return .none
     }
 }


### PR DESCRIPTION
### Related Issues

Epic: #1234 

### Description and Example

Support for accessibility header on components from beagle, it tells that a given component should be treated as a Title(header).

Example: Text("Title 1") with isHeader as true, would be said in VoiceOver as "Title 1, header" 

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.