### PR TITLE
feat: add flutter default page indicator and touchable components

### DIFF
--- a/flutter/beagle_components/lib/beagle_page_indicator.dart
+++ b/flutter/beagle_components/lib/beagle_page_indicator.dart
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:beagle/utils/color.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class BeaglePageIndicator extends StatelessWidget {
+  const BeaglePageIndicator({
+    Key key,
+    this.selectedColor,
+    this.unselectedColor,
+    this.numberOfPages,
+    this.currentPage,
+  }) : super(key: key);
+
+  final String selectedColor;
+  final String unselectedColor;
+  final int numberOfPages;
+  final int currentPage;
+
+  static const double dotSpacing = 25;
+  static const double dotSize = 8;
+
+  Widget buildDot(int index) {
+    return SizedBox(
+      width: dotSpacing,
+      child: Center(
+        child: Material(
+          color:
+              HexColor(index == currentPage ? selectedColor : unselectedColor),
+          type: MaterialType.circle,
+          child: const SizedBox(
+            width: dotSize,
+            height: dotSize,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List<Widget>.generate(numberOfPages, buildDot),
+    );
+  }
+}

--- a/flutter/beagle_components/lib/beagle_touchable.dart
+++ b/flutter/beagle_components/lib/beagle_touchable.dart
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+
+class BeagleTouchable extends StatelessWidget {
+  const BeagleTouchable({
+    Key key,
+    this.onPress,
+    this.child,
+  }) : super(key: key);
+
+  final Function onPress;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onPress,
+      child: child,
+    );
+  }
+}

--- a/flutter/beagle_components/lib/default_components.dart
+++ b/flutter/beagle_components/lib/default_components.dart
@@ -22,6 +22,7 @@ import 'package:beagle/utils/enum.dart';
 import 'package:beagle_components/beagle_button.dart';
 import 'package:beagle_components/beagle_image.dart';
 import 'package:beagle_components/beagle_lazy_component.dart';
+import 'package:beagle_components/beagle_page_indicator.dart';
 import 'package:beagle_components/beagle_page_view.dart';
 import 'package:beagle_components/beagle_tab_bar.dart';
 import 'package:beagle_components/beagle_text.dart';
@@ -39,6 +40,7 @@ final Map<String, ComponentBuilder> defaultComponents = {
   'beagle:tabbar': beagleTabBarBuilder(),
   'beagle:pageview': beaglePageViewBuilder(),
   'beagle:image': beagleImageBuilder(),
+  'beagle:pageIndicator': beaglePageIndicatorBuilder(),
 };
 
 ComponentBuilder beagleLoadingBuilder() {
@@ -142,5 +144,15 @@ ComponentBuilder beagleImageBuilder() {
           ImageContentMode.values,
           element.getAttributeValue('mode') ?? '',
         ),
+      );
+}
+
+ComponentBuilder beaglePageIndicatorBuilder() {
+  return (element, _, __) => BeaglePageIndicator(
+        key: element.getKey(),
+        selectedColor: element.getAttributeValue('selectedColor'),
+        unselectedColor: element.getAttributeValue('unselectedColor'),
+        numberOfPages: element.getAttributeValue('numberOfPages'),
+        currentPage: element.getAttributeValue('currentPage'),
       );
 }

--- a/flutter/beagle_components/lib/default_components.dart
+++ b/flutter/beagle_components/lib/default_components.dart
@@ -27,6 +27,7 @@ import 'package:beagle_components/beagle_page_view.dart';
 import 'package:beagle_components/beagle_tab_bar.dart';
 import 'package:beagle_components/beagle_text.dart';
 import 'package:beagle_components/beagle_text_input.dart';
+import 'package:beagle_components/beagle_touchable.dart';
 import 'package:flutter/material.dart';
 
 final Map<String, ComponentBuilder> defaultComponents = {
@@ -41,6 +42,7 @@ final Map<String, ComponentBuilder> defaultComponents = {
   'beagle:pageview': beaglePageViewBuilder(),
   'beagle:image': beagleImageBuilder(),
   'beagle:pageIndicator': beaglePageIndicatorBuilder(),
+  'beagle:touchable': beagleTouchableBuilder(),
 };
 
 ComponentBuilder beagleLoadingBuilder() {
@@ -154,5 +156,13 @@ ComponentBuilder beaglePageIndicatorBuilder() {
         unselectedColor: element.getAttributeValue('unselectedColor'),
         numberOfPages: element.getAttributeValue('numberOfPages'),
         currentPage: element.getAttributeValue('currentPage'),
+      );
+}
+
+ComponentBuilder beagleTouchableBuilder() {
+  return (element, children, __) => BeagleTouchable(
+        key: element.getKey(),
+        onPress: element.getAttributeValue('onPress'),
+        child: children[0],
       );
 }

--- a/flutter/beagle_components/test/beagle_page_indicator_test.dart
+++ b/flutter/beagle_components/test/beagle_page_indicator_test.dart
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:beagle/utils/color.dart';
+import 'package:beagle_components/beagle_page_indicator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const pageIndicatorKey = Key('BeaglePageIndicator');
+  const selectedColor = '#000000';
+  const unselectedColor = '#888888';
+
+  Widget createWidget({
+    Key key = pageIndicatorKey,
+    String selectedColor = selectedColor,
+    String unselectedColor = unselectedColor,
+    int numberOfPages,
+    int currentPage,
+  }) {
+    return MaterialApp(
+      home: BeaglePageIndicator(
+        key: key,
+        selectedColor: selectedColor,
+        unselectedColor: unselectedColor,
+        numberOfPages: numberOfPages,
+        currentPage: currentPage,
+      ),
+    );
+  }
+
+  group('Given a BeaglePageIndicator with two pages', () {
+    group('When it is rendered', () {
+      final pageIndicator = createWidget(numberOfPages: 2, currentPage: 0);
+      testWidgets('Then it should have two material widgets',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(pageIndicator);
+
+        final dotFinder = find.byType(Material);
+        expect(dotFinder, findsNWidgets(2));
+      });
+    });
+    group('When currentPage is 0', () {
+      final pageIndicator = createWidget(numberOfPages: 2, currentPage: 0);
+      testWidgets(
+          'Then it should paint first dot with selectedColor and second dot with unselectedColor ',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(pageIndicator);
+
+        final expectedFirstDotColor = HexColor(selectedColor);
+        final expectedSecondDotColor = HexColor(unselectedColor);
+
+        final widgets = tester.widgetList<Material>(find.byType(Material));
+
+        expect(expectedFirstDotColor, widgets.elementAt(0).color);
+        expect(expectedSecondDotColor, widgets.elementAt(1).color);
+      });
+    });
+    group('When currentPage is 1', () {
+      final pageIndicator = createWidget(numberOfPages: 2, currentPage: 1);
+      testWidgets(
+          'Then it should paint second dot with selectedColor and first dot with unselectedColor ',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(pageIndicator);
+
+        final expectedFirstDotColor = HexColor(unselectedColor);
+        final expectedSecondDotColor = HexColor(selectedColor);
+
+        final widgets = tester.widgetList<Material>(find.byType(Material));
+
+        expect(expectedFirstDotColor, widgets.elementAt(0).color);
+        expect(expectedSecondDotColor, widgets.elementAt(1).color);
+      });
+    });
+  });
+}

--- a/flutter/beagle_components/test/beagle_touchable_test.dart
+++ b/flutter/beagle_components/test/beagle_touchable_test.dart
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:beagle_components/beagle_touchable.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const touchableKey = Key('BeagleTouchable');
+
+Widget createWidget({
+  Key touchableKey = touchableKey,
+  Function onPress,
+  Widget child,
+}) {
+  return MaterialApp(
+    home: BeagleTouchable(
+      key: touchableKey,
+      onPress: onPress,
+      child: child,
+    ),
+  );
+}
+
+void main() {
+  group('Given a BeagleTouchable', () {
+    group('When I click on it', () {
+      testWidgets('Then it should call onPress callback',
+          (WidgetTester tester) async {
+        var tapCount = 0;
+        void onPress() {
+          tapCount++;
+        }
+
+        await tester.pumpWidget(createWidget(onPress: onPress));
+
+        await tester.tap(find.byType(BeagleTouchable));
+        await tester.tap(find.byType(BeagleTouchable));
+        await tester.tap(find.byType(BeagleTouchable));
+
+        const expectedTapCount = 3;
+        expect(tapCount, expectedTapCount);
+      });
+    });
+  });
+}

--- a/flutter/sample/lib/beagle_sample_screen.dart
+++ b/flutter/sample/lib/beagle_sample_screen.dart
@@ -17,18 +17,25 @@
 import 'package:beagle/beagle_remote_view.dart';
 import 'package:flutter/material.dart';
 
-class TabBarScreen extends StatefulWidget {
-  const TabBarScreen({Key key}) : super(key: key);
+class BeagleSampleScreen extends StatefulWidget {
+  const BeagleSampleScreen({
+    Key key,
+    this.title,
+    this.route,
+  }) : super(key: key);
+
+  final String title;
+  final String route;
 
   @override
-  _TabBarScreenState createState() => _TabBarScreenState();
+  _BeagleSampleScreenState createState() => _BeagleSampleScreenState();
 }
 
-class _TabBarScreenState extends State<TabBarScreen> {
+class _BeagleSampleScreenState extends State<BeagleSampleScreen> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Tab Bar',
+      title: widget.title,
       theme: Theme.of(context).copyWith(
         indicatorColor: Colors.white,
         appBarTheme: const AppBarTheme(
@@ -37,9 +44,9 @@ class _TabBarScreenState extends State<TabBarScreen> {
       ),
       home: Scaffold(
         appBar: AppBar(
-          title: const Text('TabBar Sample'),
+          title: Text(widget.title),
         ),
-        body: const BeagleRemoteView(route: '/beagle_tab_bar'),
+        body: BeagleRemoteView(route: widget.route),
       ),
     );
   }

--- a/flutter/sample/lib/main.dart
+++ b/flutter/sample/lib/main.dart
@@ -21,10 +21,11 @@ import 'package:beagle/interface/navigation_controller.dart';
 import 'package:beagle_components/beagle_components.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:sample/beagle_sample_screen.dart';
 import 'package:sample/design_system.dart';
-import 'package:sample/tab_bar_screen.dart';
 
-const BASE_URL = 'https://run.mocky.io/v3/2c1f3442-28ec-4df8-abd9-56fcc90e8a4d';
+const BASE_URL =
+    'https://gist.githubusercontent.com/paulomeurerzup/80e54caf96ba56ae96d07b4e671cae42/raw/84af7623f20411c90bbbfd2ca07ed2fa616d0341';
 
 void main() {
   runApp(const MaterialApp(home: BeagleSampleApp()));
@@ -38,7 +39,10 @@ class BeagleSampleApp extends StatefulWidget {
 }
 
 class _BeagleSampleApp extends State<BeagleSampleApp> {
-  static const _appBarMenuOptions = ['Tab Bar'];
+  static final _appBarMenuOptions = [
+    MenuOption(title: 'Tab Bar', route: '/beagle_tab_bar'),
+    MenuOption(title: 'Page View', route: '/beagle_pageview'),
+  ];
 
   bool isBeagleReady = false;
   Map<String, ComponentBuilder> myCustomComponents = {
@@ -97,9 +101,9 @@ class _BeagleSampleApp extends State<BeagleSampleApp> {
               onSelected: _handleAppBarMenuOption,
               itemBuilder: (BuildContext context) {
                 return _appBarMenuOptions.map((menuOption) {
-                  return PopupMenuItem<String>(
+                  return PopupMenuItem<MenuOption>(
                     value: menuOption,
-                    child: Text(menuOption),
+                    child: Text(menuOption.title),
                   );
                 }).toList();
               },
@@ -115,12 +119,20 @@ class _BeagleSampleApp extends State<BeagleSampleApp> {
     );
   }
 
-  void _handleAppBarMenuOption(String menuOption) {
-    if (menuOption == _appBarMenuOptions[0]) {
-      Navigator.push(
-          context,
-          MaterialPageRoute<TabBarScreen>(
-              builder: (buildContext) => const TabBarScreen()));
-    }
+  void _handleAppBarMenuOption(MenuOption menuOption) {
+    Navigator.push(
+        context,
+        MaterialPageRoute<BeagleSampleScreen>(
+            builder: (buildContext) => BeagleSampleScreen(
+                  title: menuOption.title,
+                  route: menuOption.route,
+                )));
   }
+}
+
+class MenuOption {
+  MenuOption({this.title, this.route});
+
+  final String title;
+  final String route;
 }

--- a/flutter/sample/lib/main.dart
+++ b/flutter/sample/lib/main.dart
@@ -25,7 +25,7 @@ import 'package:sample/beagle_sample_screen.dart';
 import 'package:sample/design_system.dart';
 
 const BASE_URL =
-    'https://gist.githubusercontent.com/paulomeurerzup/80e54caf96ba56ae96d07b4e671cae42/raw/84af7623f20411c90bbbfd2ca07ed2fa616d0341';
+    'https://gist.githubusercontent.com/paulomeurerzup/80e54caf96ba56ae96d07b4e671cae42/raw/b000186cfa79ad1ed450bda48da5f6ed9077942c';
 
 void main() {
   runApp(const MaterialApp(home: BeagleSampleApp()));
@@ -42,6 +42,7 @@ class _BeagleSampleApp extends State<BeagleSampleApp> {
   static final _appBarMenuOptions = [
     MenuOption(title: 'Tab Bar', route: '/beagle_tab_bar'),
     MenuOption(title: 'Page View', route: '/beagle_pageview'),
+    MenuOption(title: 'Touchable', route: '/beagle_touchable'),
   ];
 
   bool isBeagleReady = false;


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>


### Related Issues

#1306

### Description and Example

Adds flutter default page indicator and touchable components.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
