### PR TITLE
feat: Add flutter default WebView component

### DIFF
--- a/flutter/beagle_components/lib/beagle_webview.dart
+++ b/flutter/beagle_components/lib/beagle_webview.dart
@@ -18,12 +18,15 @@ import 'package:flutter/material.dart';
 import 'package:webview_flutter/platform_interface.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+/// A web view widget for showing html content.
 class BeagleWebView extends StatelessWidget {
+  /// Creates a new web view.
   const BeagleWebView({
     Key key,
     this.url,
   }) : super(key: key);
 
+  /// The initial URL to load.
   final String url;
 
   @override

--- a/flutter/beagle_components/lib/beagle_webview.dart
+++ b/flutter/beagle_components/lib/beagle_webview.dart
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/platform_interface.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class BeagleWebView extends StatelessWidget {
+  const BeagleWebView({
+    Key key,
+    this.url,
+  }) : super(key: key);
+
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    return WebView(
+      initialUrl: url,
+      javascriptMode: JavascriptMode.unrestricted,
+      onWebResourceError: _handleError,
+      onPageStarted: _handleLoading,
+      onPageFinished: _handleSuccess,
+    );
+  }
+
+  void _handleLoading(String url) {
+    // TODO: loading handling is pending until definition of Beagle's screen state handling mechanism.
+  }
+
+  void _handleSuccess(String url) {
+    // TODO: success handling is pending until definition of Beagle's screen state handling mechanism.
+  }
+
+  void _handleError(WebResourceError error) {
+    // TODO: error handling is pending until definition of Beagle's screen state handling mechanism.
+  }
+}

--- a/flutter/beagle_components/lib/default_components.dart
+++ b/flutter/beagle_components/lib/default_components.dart
@@ -28,6 +28,7 @@ import 'package:beagle_components/beagle_tab_bar.dart';
 import 'package:beagle_components/beagle_text.dart';
 import 'package:beagle_components/beagle_text_input.dart';
 import 'package:beagle_components/beagle_touchable.dart';
+import 'package:beagle_components/beagle_webview.dart';
 import 'package:flutter/material.dart';
 
 final Map<String, ComponentBuilder> defaultComponents = {
@@ -43,6 +44,7 @@ final Map<String, ComponentBuilder> defaultComponents = {
   'beagle:image': beagleImageBuilder(),
   'beagle:pageIndicator': beaglePageIndicatorBuilder(),
   'beagle:touchable': beagleTouchableBuilder(),
+  'beagle:webView': beagleWebViewBuilder(),
 };
 
 ComponentBuilder beagleLoadingBuilder() {
@@ -167,5 +169,12 @@ ComponentBuilder beagleTouchableBuilder() {
         key: element.getKey(),
         onPress: element.getAttributeValue('onPress'),
         child: children[0],
+      );
+}
+
+ComponentBuilder beagleWebViewBuilder() {
+  return (element, children, __) => BeagleWebView(
+        key: element.getKey(),
+        url: element.getAttributeValue('url'),
       );
 }

--- a/flutter/beagle_components/pubspec.yaml
+++ b/flutter/beagle_components/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   beagle:
     path: '../beagle'
+  webview_flutter: ^1.0.7
 
 dev_dependencies:
   flutter_test:

--- a/flutter/beagle_components/test/beagle_webview_test.dart
+++ b/flutter/beagle_components/test/beagle_webview_test.dart
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:beagle_components/beagle_webview.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+void main() {
+  const webViewKey = Key('BeagleWebView');
+  const defaultUrl = 'https://usebeagle.io/';
+
+  Widget createWidget({
+    Key webViewKey = webViewKey,
+    String url = defaultUrl,
+  }) {
+    return MaterialApp(
+      home: BeagleWebView(
+        key: webViewKey,
+        url: url,
+      ),
+    );
+  }
+
+  group('Given a BeagleWebView', () {
+    group('When the component is rendered', () {
+      testWidgets('Then it should have a WebView child widget',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        final webViewFinder = find.byType(WebView);
+        expect(webViewFinder, findsOneWidget);
+      });
+    });
+  });
+}

--- a/flutter/beagle_components/test/beagle_webview_test.dart
+++ b/flutter/beagle_components/test/beagle_webview_test.dart
@@ -45,5 +45,15 @@ void main() {
         expect(webViewFinder, findsOneWidget);
       });
     });
+
+    group('When I pass an URL', () {
+      testWidgets('Then it should load the correct initial URL',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(tester.widget<WebView>(find.byType(WebView)).initialUrl,
+            defaultUrl);
+      });
+    });
   });
 }

--- a/flutter/sample/lib/main.dart
+++ b/flutter/sample/lib/main.dart
@@ -25,7 +25,7 @@ import 'package:sample/app_design_system.dart';
 import 'package:sample/beagle_sample_screen.dart';
 
 const BASE_URL =
-    'https://gist.githubusercontent.com/paulomeurerzup/80e54caf96ba56ae96d07b4e671cae42/raw/b000186cfa79ad1ed450bda48da5f6ed9077942c';
+    'https://gist.githubusercontent.com/paulomeurerzup/80e54caf96ba56ae96d07b4e671cae42/raw/20e593662467d0962ac2aa4e9194a7256a1e0b48';
 
 void main() {
   runApp(const MaterialApp(home: BeagleSampleApp()));
@@ -43,6 +43,7 @@ class _BeagleSampleApp extends State<BeagleSampleApp> {
     MenuOption(title: 'Tab Bar', route: '/beagle_tab_bar'),
     MenuOption(title: 'Page View', route: '/beagle_pageview'),
     MenuOption(title: 'Touchable', route: '/beagle_touchable'),
+    MenuOption(title: 'Web View', route: '/beagle_webview'),
   ];
 
   bool isBeagleReady = false;


### PR DESCRIPTION
Signed-off-by: paulomeurerzup <paulo.meurer@zup.com.br>


### Related Issues

#1306

### Description and Example

Adds flutter default WebView component.

It uses flutter team webview package: https://pub.dev/packages/webview_flutter

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
