### PR TITLE
refactor: Change the AnalyticsRecord structure

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/newanalytics/ActionReportFactory.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/newanalytics/ActionReportFactory.kt
@@ -167,35 +167,14 @@ internal object ActionReportFactory {
         dataActionReport: DataActionReport,
     ) = AnalyticsRecord(
         type = "action",
-        values = generateValues(dataActionReport),
+        event = dataActionReport.analyticsValue,
+        attributes = if (dataActionReport.attributes.size == 0) null else dataActionReport.attributes,
+        additionalEntries = dataActionReport.additionalEntries,
+        beagleAction = dataActionReport.actionType,
+        component = generateComponentHashMap(dataActionReport),
         timestamp = dataActionReport.timestamp,
         screen = dataActionReport.screenId ?: "",
     )
-
-    private fun generateValues(
-        dataActionReport: DataActionReport,
-    ): HashMap<String, Any> {
-        val hashMap: HashMap<String, Any> = HashMap()
-        dataActionReport.analyticsValue?.let {
-            hashMap["event"] = it
-        }
-        getAttributesValue(dataActionReport)?.let {
-            hashMap.putAll(it)
-        }
-        dataActionReport.additionalEntries?.let {
-            hashMap.putAll(it)
-        }
-        hashMap["beagleAction"] = dataActionReport.actionType
-        hashMap["component"] = generateComponentHashMap(dataActionReport)
-        return hashMap
-    }
-
-    private fun getAttributesValue(dataActionReport: DataActionReport): HashMap<String, Any>? {
-        if (dataActionReport.attributes.size == 0) {
-            return null
-        }
-        return dataActionReport.attributes
-    }
 
     private fun generateComponentHashMap(dataActionReport: DataActionReport): HashMap<String, Any> {
         val hashMap: HashMap<String, Any> = HashMap()

--- a/android/beagle/src/main/java/br/com/zup/beagle/newanalytics/AnalyticsRecord.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/newanalytics/AnalyticsRecord.kt
@@ -27,7 +27,11 @@ package br.com.zup.beagle.newanalytics
 data class AnalyticsRecord(
     val type: String,
     val platform: String = "android",
-    val values: HashMap<String, Any>? = null,
+    val attributes: Map<String, Any>? = null,
+    val component: Map<String, Any>? = null,
+    val beagleAction: String? = null,
+    val event: String? = null,
+    val additionalEntries: Map<String, Any>? = null,
     val timestamp: Long,
-    val screen : String
+    val screen: String,
 )

--- a/android/beagle/src/test/java/br/com/zup/beagle/newanalytics/ActionReportFactoryTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/newanalytics/ActionReportFactoryTest.kt
@@ -133,7 +133,7 @@ internal class ActionReportFactoryTest : BaseTest() {
             val report = reportDataAction(dataActionReport)
 
             //Then
-            Assert.assertEquals(componentReport, report.values?.get("component"))
+            Assert.assertEquals(componentReport, report.component)
         }
 
         @Test
@@ -150,7 +150,7 @@ internal class ActionReportFactoryTest : BaseTest() {
             val report = reportDataAction(dataActionReport)
 
             //Then
-            Assert.assertEquals(componentReport, report.values?.get("component"))
+            Assert.assertEquals(componentReport, report.component)
         }
 
         @Test
@@ -165,7 +165,7 @@ internal class ActionReportFactoryTest : BaseTest() {
             val report = reportDataAction(dataActionReport)
 
             //Then
-            Assert.assertEquals(componentReport, report.values?.get("component"))
+            Assert.assertEquals(componentReport, report.component)
         }
 
         private fun generateComponentReport() = hashMapOf<String, Any>(
@@ -215,8 +215,8 @@ internal class ActionReportFactoryTest : BaseTest() {
 
             //Then
             commonAsserts(report, dataActionReport)
-            Assert.assertEquals(route, report.values?.get("route"))
-            assertTrue(report.values?.get("additionalEntries") as Boolean)
+            Assert.assertEquals(route, report.attributes?.get("route"))
+            assertTrue(report.additionalEntries?.get("additionalEntries") as Boolean)
         }
 
         @Test
@@ -235,8 +235,8 @@ internal class ActionReportFactoryTest : BaseTest() {
 
             //Then
             commonAsserts(report, dataActionReport)
-            Assert.assertEquals(url, report.values?.get(ROUTE_URL_CONSTANT))
-            Assert.assertEquals(false, report.values?.get(ROUTE_SHOULD_PREFETCH_CONSTANT))
+            Assert.assertEquals(url, report.attributes?.get(ROUTE_URL_CONSTANT))
+            Assert.assertEquals(false, report.attributes?.get(ROUTE_SHOULD_PREFETCH_CONSTANT))
         }
 
         @Test
@@ -255,13 +255,13 @@ internal class ActionReportFactoryTest : BaseTest() {
             print(report)
             //Then
             commonAsserts(report, dataActionReport)
-            Assert.assertEquals(null, report.values?.get("route.a"))
+            Assert.assertEquals(null, report.attributes?.get("route.a"))
         }
 
         private fun commonAsserts(report: AnalyticsRecord, dataReport: DataReport) {
             Assert.assertEquals(dataReport.timestamp, report.timestamp)
-            Assert.assertEquals("onPress", report.values?.get("event"))
-            Assert.assertEquals(actionType, report.values?.get("beagleAction"))
+            Assert.assertEquals("onPress", report.event)
+            Assert.assertEquals(actionType, report.beagleAction)
         }
 
     }

--- a/android/beagle/src/test/java/br/com/zup/beagle/newanalytics/ScreenReportFactoryTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/newanalytics/ScreenReportFactoryTest.kt
@@ -43,7 +43,7 @@ class ScreenReportFactoryTest : BaseTest() {
             assertEquals("android", result.platform)
             assertEquals("screen", result.type)
             assertEquals("screenId", result.screen)
-            assertEquals(null, result.values)
+            commonAssert(result)
             assertEquals(timestamp, result.timestamp)
         }
     }
@@ -65,7 +65,7 @@ class ScreenReportFactoryTest : BaseTest() {
             assertEquals("android", result.platform)
             assertEquals("screen", result.type)
             assertEquals("url", result.screen)
-            assertEquals(null, result.values)
+            commonAssert(result)
             assertEquals(timestamp, result.timestamp)
         }
 
@@ -84,8 +84,18 @@ class ScreenReportFactoryTest : BaseTest() {
             assertEquals("android", result.platform)
             assertEquals("screen", result.type)
             assertEquals("url", result.screen)
-            assertEquals(null, result.values)
+            commonAssert(result)
             assertEquals(timestamp, result.timestamp)
         }
+    }
+    
+    private fun commonAssert(result: AnalyticsRecord){
+        assertEquals(null, result.additionalEntries)
+        assertEquals(null, result.attributes)
+        assertEquals(null, result.component)
+        assertEquals(null, result.beagleAction)
+        assertEquals(null, result.event)
+
+
     }
 }


### PR DESCRIPTION
### Related Issues
#745 

### Description and Example
This pr is a change on AnalyticsRecord so that the json generated by the platforms are the same.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner
