### PR TITLE
fix: timestamp and beahvior when both global config and action config are enabled

### DIFF
--- a/iOS/Sources/Beagle/Sources/Analytics/Service/RecordFactory.swift
+++ b/iOS/Sources/Beagle/Sources/Analytics/Service/RecordFactory.swift
@@ -60,7 +60,7 @@ struct ActionRecordFactory {
 // MARK: - Private
 
 private func timestamp() -> Double {
-    return Date().timeIntervalSince1970 * 1000
+    return (Date().timeIntervalSince1970 * 1000).rounded()
 }
 
 private func screenInfo(_ screenType: ScreenType) -> String? {

--- a/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/ActionRecordFactoryTests.swift
+++ b/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/ActionRecordFactoryTests.swift
@@ -65,6 +65,7 @@ class ActionRecordFactoryTests: RecordFactoryHelpers {
         recordShouldBeEqualTo("""
         {
           "attributes" : {
+            "method" : "DELETE",
             "path" : "PATH"
           }
         }
@@ -119,10 +120,29 @@ class ActionRecordFactoryTests: RecordFactoryHelpers {
         // And
         actionWithConfig(.enabled(nil))
 
+        // Then should use global config
+        recordShouldBeEqualTo("""
+        {
+          "attributes" : {
+            "method" : "DELETE",
+            "path" : "PATH"
+          }
+        }
+        """)
+    }
+
+    func testActionWithEnabledAttributesAndGlobalConfigEnabled() {
+        // Given
+        globalConfigWithActionEnabled()
+        // And
+        actionWithJust1AttributeEnabled()
+
         // Then should use Action config
         recordShouldBeEqualTo("""
         {
-
+          "attributes" : {
+            "method" : "DELETE"
+          }
         }
         """)
     }
@@ -202,7 +222,7 @@ class RecordFactoryHelpers: XCTestCase {
 
     func globalConfigWithActionEnabled() {
         _globalConfig = .init(actions: [
-            "beagle:formremoteaction": ["methods", "path"]
+            "beagle:formremoteaction": ["method", "path"]
         ])
     }
 


### PR DESCRIPTION

### Related Issues

#745

### Description and Example

- rounds timestamp to be equal to other platforms
- fix when global config enabled and action enabled(nil)

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.
