### PR TITLE
fix: breaking change due to new `analytics` attribute on actions

### DIFF
--- a/iOS/Example/BeagleDemo/BeagleDemo/DesignSystem/GenerationTests/Protocols.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/DesignSystem/GenerationTests/Protocols.swift
@@ -37,7 +37,6 @@ struct TextComponentsDefault: TextComponents {
 }
 
 struct ActionDummyDefault: ActionDummy {
-    var analytics: ActionAnalyticsConfig? { return nil }
     
     func execute(controller: BeagleController, origin: UIView) {}
 }

--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/GlobalContextScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/GlobalContextScreen.swift
@@ -45,7 +45,6 @@ struct GlobalContexScreen: DeeplinkScreen {
 }
 
 struct ClearGlobalContextAction: Action {
-    var analytics: ActionAnalyticsConfig? { return nil }
     
     func execute(controller: BeagleController, origin: UIView) {
         dependencies.globalContext.clear()

--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/SendRequestScreen.swift
@@ -76,7 +76,6 @@ let sendRequestDeclarativeScreen: Screen = {
 }()
 
 struct CustomConsoleLogAction: Action {
-    var analytics: ActionAnalyticsConfig? { return nil }
     
     func execute(controller: BeagleController, origin: UIView) {
         print("SendRequestScreen.CustomConsoleAction")
@@ -84,7 +83,6 @@ struct CustomConsoleLogAction: Action {
 }
 
 struct OkAction: Action {
-    var analytics: ActionAnalyticsConfig? { return nil }
     
     func execute(controller: BeagleController, origin: UIView) {
         print("onPressOk from Alert clicked")
@@ -92,7 +90,6 @@ struct OkAction: Action {
 }
 
 struct CancelAction: Action {
-    var analytics: ActionAnalyticsConfig? { return nil }
     
     func execute(controller: BeagleController, origin: UIView) {
         print("onPressCancel from Confirm clicked")

--- a/iOS/Example/BeagleDemo/BeagleDemo/Screens/SimpleForm.swift
+++ b/iOS/Example/BeagleDemo/BeagleDemo/Screens/SimpleForm.swift
@@ -60,19 +60,13 @@ struct SimpleFormScreen: DeeplinkScreen {
 }
 
 struct FirstAction: Action {
-    var analytics: ActionAnalyticsConfig? {
-        return nil
-    }
-    
+
     func execute(controller: BeagleController, origin: UIView) {
         print("FirstAction Executed")
     }
 }
 
 struct SecondAction: Action {
-    var analytics: ActionAnalyticsConfig? {
-        return nil
-    }
     
     func execute(controller: BeagleController, origin: UIView) {
         print("SecondAction Executed")

--- a/iOS/Sources/Beagle/Beagle.xcodeproj/project.pbxproj
+++ b/iOS/Sources/Beagle/Beagle.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		3D526B5D25CA14140027AB03 /* PopView-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 3D526B5C25CA14140027AB03 /* PopView-1.json */; };
 		3D526B6825CA14C30027AB03 /* ActionAttributesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB1BF8C25B1E9B1008248C6 /* ActionAttributesTest.swift */; };
 		3D6D9A5B25C8C3B9004FF423 /* AssertNever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6D9A5A25C8C3B9004FF423 /* AssertNever.swift */; };
+		3D8209AB25E3F48300DCAA0E /* SetContext-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 3D8209AA25E3F48300DCAA0E /* SetContext-1.json */; };
 		3D8E5C7E2542341C002B92E2 /* HttpAditionalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D8E5C7D2542341C002B92E2 /* HttpAditionalData.swift */; };
 		3D9B27D325C9D4C900144CF5 /* DecodeActionAnalyticsConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB1BF8125B0FC53008248C6 /* DecodeActionAnalyticsConfigTests.swift */; };
 		3DAEFAEF25D1E91B002B0109 /* ScreenRecordFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAEFAEE25D1E91B002B0109 /* ScreenRecordFactoryTests.swift */; };
@@ -379,6 +380,7 @@
 		3D526B5C25CA14140027AB03 /* PopView-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "PopView-1.json"; sourceTree = "<group>"; };
 		3D526B7625CA179D0027AB03 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		3D6D9A5A25C8C3B9004FF423 /* AssertNever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertNever.swift; sourceTree = "<group>"; };
+		3D8209AA25E3F48300DCAA0E /* SetContext-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "SetContext-1.json"; sourceTree = "<group>"; };
 		3D8E5C7D2542341C002B92E2 /* HttpAditionalData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpAditionalData.swift; sourceTree = "<group>"; };
 		3DAEFAEE25D1E91B002B0109 /* ScreenRecordFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordFactoryTests.swift; sourceTree = "<group>"; };
 		3DB1BF7B25B0F544008248C6 /* ActionAnalyticsConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionAnalyticsConfig.swift; sourceTree = "<group>"; };
@@ -1493,6 +1495,7 @@
 				A0EB6C0E2591192C001A3E65 /* PushStack-1.json */,
 				A0EB6BFE2591192C001A3E65 /* PushStack-2.json */,
 				A0EB6C002591192C001A3E65 /* SendRequest-1.json */,
+				3D8209AA25E3F48300DCAA0E /* SetContext-1.json */,
 			);
 			name = JSON;
 			path = Sources/Analytics/Service/Tests/JSON;
@@ -2242,6 +2245,7 @@
 				9398CABE255475770003A010 /* pushview.json in Resources */,
 				C05E165A2437CC7C0088F9D2 /* buttonAnalyticsComponent.json in Resources */,
 				A0EB6C192591192C001A3E65 /* Alert-1.json in Resources */,
+				3D8209AB25E3F48300DCAA0E /* SetContext-1.json in Resources */,
 				9398CAD925549F900003A010 /* PageViewWith3Pages.json in Resources */,
 				9398CABD255475770003A010 /* opennativeroute.json in Resources */,
 				A0EB6C182591192C001A3E65 /* FormLocalAction-1.json in Resources */,

--- a/iOS/Sources/Beagle/Sources/Action/Action.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Action.swift
@@ -19,12 +19,15 @@ import UIKit
 /// Markup to define an action to be triggered in response to some event
 public protocol Action: Decodable {
 
+    func execute(controller: BeagleController, origin: UIView)
+}
+
+// TODO: 2.0 - merge with Action protocol
+public protocol AnalyticsAction: Action {
     /// can be used to override the global `AnalyticsConfig`.
     ///
     /// - when `nil`: analytics behavior for this action will be determined by global `AnalyticsConfig`.
     var analytics: ActionAnalyticsConfig? { get }
-    
-    func execute(controller: BeagleController, origin: UIView)
 }
 
 public protocol AsyncAction: Action {

--- a/iOS/Sources/Beagle/Sources/Action/Types/AddChildren.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/AddChildren.swift
@@ -15,7 +15,7 @@
  */
 
 /// Action that insert children components in a node hierarchy
-public struct AddChildren: Action, AutoInitiableAndDecodable {
+public struct AddChildren: Action, AnalyticsAction, AutoInitiableAndDecodable {
     
     public let componentId: String
     public let value: [ServerDrivenComponent]

--- a/iOS/Sources/Beagle/Sources/Action/Types/AddChildren.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/AddChildren.swift
@@ -15,7 +15,7 @@
  */
 
 /// Action that insert children components in a node hierarchy
-public struct AddChildren: Action, AnalyticsAction, AutoInitiableAndDecodable {
+public struct AddChildren: AnalyticsAction, AutoInitiableAndDecodable {
     
     public let componentId: String
     public let value: [ServerDrivenComponent]

--- a/iOS/Sources/Beagle/Sources/Action/Types/Alert.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Alert.swift
@@ -15,7 +15,7 @@
  */
 
 /// Action to represent a alert
-public struct Alert: Action, AutoInitiableAndDecodable {
+public struct Alert: Action, AnalyticsAction, AutoInitiableAndDecodable {
     
     public let title: Expression<String>?
     public let message: Expression<String>

--- a/iOS/Sources/Beagle/Sources/Action/Types/Alert.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Alert.swift
@@ -15,7 +15,7 @@
  */
 
 /// Action to represent a alert
-public struct Alert: Action, AnalyticsAction, AutoInitiableAndDecodable {
+public struct Alert: AnalyticsAction, AutoInitiableAndDecodable {
     
     public let title: Expression<String>?
     public let message: Expression<String>

--- a/iOS/Sources/Beagle/Sources/Action/Types/Condition.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Condition.swift
@@ -15,7 +15,7 @@
  */
 
 /// Action to represent a condition
-public struct Condition: Action, AnalyticsAction, AutoInitiableAndDecodable {
+public struct Condition: AnalyticsAction, AutoInitiableAndDecodable {
     
     public let condition: Expression<Bool>
     public let onTrue: [Action]?

--- a/iOS/Sources/Beagle/Sources/Action/Types/Condition.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Condition.swift
@@ -15,7 +15,7 @@
  */
 
 /// Action to represent a condition
-public struct Condition: Action, AutoInitiableAndDecodable {
+public struct Condition: Action, AnalyticsAction, AutoInitiableAndDecodable {
     
     public let condition: Expression<Bool>
     public let onTrue: [Action]?

--- a/iOS/Sources/Beagle/Sources/Action/Types/Confirm.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Confirm.swift
@@ -15,7 +15,7 @@
  */
 
 /// Action that represents confirm
-public struct Confirm: Action, AutoInitiableAndDecodable {
+public struct Confirm: Action, AnalyticsAction, AutoInitiableAndDecodable {
     
     public let title: Expression<String>?
     public let message: Expression<String>

--- a/iOS/Sources/Beagle/Sources/Action/Types/Confirm.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Confirm.swift
@@ -15,7 +15,7 @@
  */
 
 /// Action that represents confirm
-public struct Confirm: Action, AnalyticsAction, AutoInitiableAndDecodable {
+public struct Confirm: AnalyticsAction, AutoInitiableAndDecodable {
     
     public let title: Expression<String>?
     public let message: Expression<String>

--- a/iOS/Sources/Beagle/Sources/Action/Types/FormLocalAction.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/FormLocalAction.swift
@@ -15,7 +15,7 @@
  */
 
 /// An action to handle form submit locally
-public struct FormLocalAction: Action, AutoInitiable {
+public struct FormLocalAction: Action, AnalyticsAction, AutoInitiable {
     
     public let name: String
     public let data: [String: String]

--- a/iOS/Sources/Beagle/Sources/Action/Types/FormLocalAction.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/FormLocalAction.swift
@@ -15,7 +15,7 @@
  */
 
 /// An action to handle form submit locally
-public struct FormLocalAction: Action, AnalyticsAction, AutoInitiable {
+public struct FormLocalAction: AnalyticsAction, AutoInitiable {
     
     public let name: String
     public let data: [String: String]

--- a/iOS/Sources/Beagle/Sources/Action/Types/FormRemoteAction.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/FormRemoteAction.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-public struct FormRemoteAction: Action, AutoInitiable {
+public struct FormRemoteAction: Action, AnalyticsAction, AutoInitiable {
     
     public let path: String
     public let method: Method

--- a/iOS/Sources/Beagle/Sources/Action/Types/FormRemoteAction.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/FormRemoteAction.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-public struct FormRemoteAction: Action, AnalyticsAction, AutoInitiable {
+public struct FormRemoteAction: AnalyticsAction, AutoInitiable {
     
     public let path: String
     public let method: Method

--- a/iOS/Sources/Beagle/Sources/Action/Types/FormValidation.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/FormValidation.swift
@@ -32,7 +32,7 @@ public struct FieldError: Codable, AutoInitiable {
 }
 
 /// Action to represent a form validation error
-public struct FormValidation: Action, AutoInitiable {
+public struct FormValidation: Action, AnalyticsAction, AutoInitiable {
     
     public let errors: [FieldError]
     public let analytics: ActionAnalyticsConfig?

--- a/iOS/Sources/Beagle/Sources/Action/Types/FormValidation.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/FormValidation.swift
@@ -32,7 +32,7 @@ public struct FieldError: Codable, AutoInitiable {
 }
 
 /// Action to represent a form validation error
-public struct FormValidation: Action, AnalyticsAction, AutoInitiable {
+public struct FormValidation: AnalyticsAction, AutoInitiable {
     
     public let errors: [FieldError]
     public let analytics: ActionAnalyticsConfig?

--- a/iOS/Sources/Beagle/Sources/Action/Types/Navigate.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Navigate.swift
@@ -15,7 +15,7 @@
  */
 
 /// Handles screens navigations actions of the application.
-public enum Navigate: Action, AnalyticsAction {
+public enum Navigate: AnalyticsAction {
     
     /// Opens up an available browser on the device and navigates to a specified URL as String.
     case openExternalURL(String, analytics: ActionAnalyticsConfig? = nil)

--- a/iOS/Sources/Beagle/Sources/Action/Types/Navigate.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Navigate.swift
@@ -15,7 +15,7 @@
  */
 
 /// Handles screens navigations actions of the application.
-public enum Navigate: Action {
+public enum Navigate: Action, AnalyticsAction {
     
     /// Opens up an available browser on the device and navigates to a specified URL as String.
     case openExternalURL(String, analytics: ActionAnalyticsConfig? = nil)

--- a/iOS/Sources/Beagle/Sources/Action/Types/SendRequest.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/SendRequest.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-public struct SendRequest: Action, AutoInitiableAndDecodable {
+public struct SendRequest: Action, AutoInitiableAndDecodable, AnalyticsAction {
     
     public enum HTTPMethod: String, Codable {
         case get = "GET"

--- a/iOS/Sources/Beagle/Sources/Action/Types/SetContext.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/SetContext.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-public struct SetContext: Action, AnalyticsAction {
+public struct SetContext: AnalyticsAction {
     public let contextId: String
     public let path: Path?
     public let value: DynamicObject

--- a/iOS/Sources/Beagle/Sources/Action/Types/SetContext.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/SetContext.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-public struct SetContext: Action {
+public struct SetContext: Action, AnalyticsAction {
     public let contextId: String
     public let path: Path?
     public let value: DynamicObject

--- a/iOS/Sources/Beagle/Sources/Action/Types/SubmitForm.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/SubmitForm.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-public struct SubmitForm: Action, AutoInitiable {
+public struct SubmitForm: Action, AnalyticsAction, AutoInitiable {
     public let analytics: ActionAnalyticsConfig?
 
 // sourcery:inline:auto:SubmitForm.Init

--- a/iOS/Sources/Beagle/Sources/Action/Types/SubmitForm.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/SubmitForm.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-public struct SubmitForm: Action, AnalyticsAction, AutoInitiable {
+public struct SubmitForm: AnalyticsAction, AutoInitiable {
     public let analytics: ActionAnalyticsConfig?
 
 // sourcery:inline:auto:SubmitForm.Init

--- a/iOS/Sources/Beagle/Sources/Action/Types/Tests/FormLocalActionTests.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Tests/FormLocalActionTests.swift
@@ -75,7 +75,7 @@ class LocalFormHandlerSpy: LocalFormHandler {
     }
 }
 
-class ActionSpy: Action {
+class ActionSpy: Action, AnalyticsAction {
     var analytics: ActionAnalyticsConfig? { return nil }
     private(set) var executionCount = 0
     private(set) var lastController: BeagleController?

--- a/iOS/Sources/Beagle/Sources/Action/Types/Tests/FormLocalActionTests.swift
+++ b/iOS/Sources/Beagle/Sources/Action/Types/Tests/FormLocalActionTests.swift
@@ -75,7 +75,7 @@ class LocalFormHandlerSpy: LocalFormHandler {
     }
 }
 
-class ActionSpy: Action, AnalyticsAction {
+class ActionSpy: AnalyticsAction {
     var analytics: ActionAnalyticsConfig? { return nil }
     private(set) var executionCount = 0
     private(set) var lastController: BeagleController?

--- a/iOS/Sources/Beagle/Sources/Analytics/Service/ActionAttributes.swift
+++ b/iOS/Sources/Beagle/Sources/Analytics/Service/ActionAttributes.swift
@@ -44,15 +44,6 @@ extension Action {
     }
 }
 
-private func pathForAttribute(_ attribute: String) -> Path? {
-    guard let path = Path(rawValue: attribute) else { return nil }
-
-    for node in path.nodes {
-        if case .index = node { return nil }
-    }
-    return path
-}
-
 extension DynamicDictionary {
 
     func getSomeAttributes(_ attributes: [String], contextProvider: UIView?) -> DynamicDictionary {
@@ -73,6 +64,15 @@ extension DynamicDictionary {
 
         return values
     }
+}
+
+private func pathForAttribute(_ attribute: String) -> Path? {
+    guard let path = Path(rawValue: attribute) else { return nil }
+
+    for node in path.nodes {
+        if case .index = node { return nil }
+    }
+    return path
 }
 
 // MARK: - JSON Transformation

--- a/iOS/Sources/Beagle/Sources/Analytics/Service/RecordFactory.swift
+++ b/iOS/Sources/Beagle/Sources/Analytics/Service/RecordFactory.swift
@@ -87,7 +87,7 @@ private extension ActionRecordFactory {
     }
 
     func enabledValuesForAction(named name: String) -> EnabledValues? {
-        switch info.action.analytics {
+        switch (info.action as? AnalyticsAction)?.analytics {
         case .disabled:
             return nil
 

--- a/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/ActionAttributesTest.swift
+++ b/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/ActionAttributesTest.swift
@@ -32,7 +32,8 @@ class ActionAttributesTest: XCTestCase {
             try doRecord(Navigate.self, fromJson: "PopView-1"),
             try doRecord(Navigate.self, fromJson: "PushStack-1"),
             try doRecord(Navigate.self, fromJson: "PushStack-2"),
-            try doRecord(SendRequest.self, fromJson: "SendRequest-1")
+            try doRecord(SendRequest.self, fromJson: "SendRequest-1"),
+            try doRecord(SetContext.self, fromJson: "SetContext-1")
         ]
 
         records.forEach {
@@ -60,7 +61,7 @@ class ActionAttributesTest: XCTestCase {
         let view = try analyticsViewHierarchyWith(context: context).view
 
         var attributes = [String]()
-        if case .enabled(let config?) = action.analytics {
+        if case .enabled(let config?) = (action as? AnalyticsAction)?.analytics {
             attributes = config.attributes ?? []
         }
 

--- a/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/AnalyticsServiceTests.swift
+++ b/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/AnalyticsServiceTests.swift
@@ -134,7 +134,7 @@ class AnalyticsServiceTests: XCTestCase {
         }
     }
 
-    private func triggerAction(_ action: Action? = nil) {
+    private func triggerAction(_ action: AnalyticsAction? = nil) {
         sut.createRecord(action: .init(
             action: action ?? FormRemoteAction(path: "PATH", method: .delete),
             event: nil,

--- a/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/JSON/SetContext-1.json
+++ b/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/JSON/SetContext-1.json
@@ -1,0 +1,13 @@
+{
+     "_beagleAction_": "beagle:setContext",
+     "analytics": {
+         "attributes": [
+             "contextId",
+             "value",
+             "path"
+         ]
+     },
+     "contextId": "context",
+     "path": "bla.path.bla",
+     "value": "new value from setContext [@{context.query}]"
+ }

--- a/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/__Snapshots__/ActionAttributesTest/attributes.SetContext-1.json
+++ b/iOS/Sources/Beagle/Sources/Analytics/Service/Tests/__Snapshots__/ActionAttributesTest/attributes.SetContext-1.json
@@ -1,0 +1,5 @@
+{
+  "contextId" : "context",
+  "path" : "bla.path.bla",
+  "value" : "new value from setContext [beagle]"
+}

--- a/iOS/Sources/Beagle/Sources/Components/ServerDrivenComponent/Form/FormManager/FormManager.swift
+++ b/iOS/Sources/Beagle/Sources/Components/ServerDrivenComponent/Form/FormManager/FormManager.swift
@@ -149,7 +149,7 @@ class FormManager {
 
 }
 
-private struct SubmitRemoteFormAction: Action {
+private struct SubmitRemoteFormAction: Action, AnalyticsAction {
     
     let remote: FormRemoteAction
     let inputs: [String: String]

--- a/iOS/Sources/Beagle/Sources/Components/ServerDrivenComponent/Form/FormManager/FormManager.swift
+++ b/iOS/Sources/Beagle/Sources/Components/ServerDrivenComponent/Form/FormManager/FormManager.swift
@@ -149,7 +149,7 @@ class FormManager {
 
 }
 
-private struct SubmitRemoteFormAction: Action, AnalyticsAction {
+private struct SubmitRemoteFormAction: AnalyticsAction {
     
     let remote: FormRemoteAction
     let inputs: [String: String]

--- a/iOS/Sources/Beagle/Sources/Components/ServerDrivenComponent/ListView/ListViewController.swift
+++ b/iOS/Sources/Beagle/Sources/Components/ServerDrivenComponent/ListView/ListViewController.swift
@@ -156,10 +156,6 @@ private struct AsyncActionTracker: Action {
     let uuid: UUID
     weak var delegate: ListViewDelegate?
     
-    var analytics: ActionAnalyticsConfig? {
-        return nil
-    }
-    
     init(uuid: UUID, delegate: ListViewDelegate?) {
         self.uuid = uuid
         self.delegate = delegate

--- a/iOS/Sources/Beagle/Sources/Components/ServerDrivenComponent/ListView/Tests/ListViewTests.swift
+++ b/iOS/Sources/Beagle/Sources/Components/ServerDrivenComponent/ListView/Tests/ListViewTests.swift
@@ -264,7 +264,6 @@ final class ListViewTests: XCTestCase {
 
 private struct ActionStub: Action {
     
-    var analytics: ActionAnalyticsConfig? { return nil }
     let execute: ((BeagleController, UIView) -> Void)?
     
     init(execute: @escaping (BeagleController, UIView) -> Void) {

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Path.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Path.swift
@@ -32,10 +32,10 @@ extension Path: RepresentableByParsableString {
 
     public var rawValue: String {
         var path = ""
-        for node in self.nodes {
+        for (i, node) in self.nodes.enumerated() {
             switch node {
             case let .key(string):
-                if node != nodes.first {
+                if i != 0 {
                     path += "."
                 }
                 path += string

--- a/iOS/Sources/Beagle/Sources/Decoding/Tests/ComponentDecoderTests.swift
+++ b/iOS/Sources/Beagle/Sources/Decoding/Tests/ComponentDecoderTests.swift
@@ -145,7 +145,7 @@ public final class ComponentDecoderTests: XCTestCase {
     }
 
     private class TestAction: Action {
-        var analytics: ActionAnalyticsConfig? { return nil }
+        
         let value: Int
         
         func execute(controller: BeagleController, origin: UIView) {

--- a/iOS/Sources/Beagle/Sources/Setup/Tests/BeagleSetupTests.swift
+++ b/iOS/Sources/Beagle/Sources/Setup/Tests/BeagleSetupTests.swift
@@ -130,7 +130,6 @@ struct ComponentDummy: ServerDrivenComponent, CustomStringConvertible {
 }
 
 struct ActionDummy: Action, Equatable {
-    var analytics: ActionAnalyticsConfig? { return nil }
     
     func execute(controller: BeagleController, origin: UIView) {}
 }


### PR DESCRIPTION
### Related Issues

#745 

### Description and Example

By adding the `analytics` attribute to all `Action`, we would create a breaking change inside users custom actions. To avoid that breaking change, we now provide a new protocol called `AnalyticsAction` that defines that attribute. 
That way, users will need to explicitly say they want an `AnalyticsAction` in order to use it.

Examples:

```swift
public protocol Action: Decodable {

    func execute(controller: BeagleController, origin: UIView)
}

public protocol AnalyticsAction: Action {
    
    var analytics: ActionAnalyticsConfig? { get }
}

public struct UserCustomAction: Action {
    // ...
    // No compilation errors
}

public struct UserCustomActionWithAnalytics: AnalyticsAction {
    // ...
    public var analytics: ActionAnalyticsConfig? = nil
}
```

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
