### PR TITLE
fix: iOS - ContextExpression parser

### DIFF
--- a/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Expression.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Expression.swift
@@ -134,10 +134,8 @@ extension String {
 extension Expression: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         let escaped = value.escapeExpressions()
-        if let expression = SingleExpression(rawValue: value) {
-            self = .expression(.single(expression))
-        } else if let multiple = MultipleExpression(rawValue: value) {
-            self = .expression(.multiple(multiple))
+        if let expression = ContextExpression(rawValue: value) {
+            self = .expression(expression)
         } else if let value = escaped as? T {
             self = .value(value)
         } else {

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Parser.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Parser.swift
@@ -28,6 +28,13 @@ extension Parser {
 
 // MARK: Basic Parsers
 
+let end = Parser<Void> { str in
+    if !str.isEmpty {
+        return nil
+    }
+    return ()
+}
+
 let int = Parser<Int> { str in
     let intString = prefix(with: #"^(-\d+|\d+)\b(?!\.\d)"#).run(&str)
     return Int(intString ?? "")
@@ -197,8 +204,8 @@ let multipleExpression: Parser<MultipleExpression> = zeroOrMore(
 }
 
 let singleOrMultipleExpression: Parser<ContextExpression> = oneOf(
-    singleExpression.map { ContextExpression.single($0) },
-    multipleExpression.map { ContextExpression.multiple($0) }
+    zip(singleExpression, end).map { str, _ in ContextExpression.single(str) },
+    zip(multipleExpression, end).map { str, _ in ContextExpression.multiple(str) }
 )
 
 // MARK: High Order Functions

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Tests/ExpressionTests.swift
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Tests/ExpressionTests.swift
@@ -127,6 +127,17 @@ final class ExpressionTests: XCTestCase {
         }
     }
     
+    func testContextExpression() {
+        // Given
+        let data = ["@{expression}", "@{expression} + string", "string"]
+        
+        // When
+        let result = data.map { ContextExpression(rawValue: $0) }
+            
+        // Then
+        assertSnapshot(matching: result, as: .dump)
+    }
+    
     func testDictionarySnapShot() throws {
         guard let url = Bundle(for: ComponentDecoderTests.self).url(
             forResource: "testDictionarySnapShot",

--- a/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Tests/__Snapshots__/ExpressionTests/testContextExpression.1.txt
+++ b/iOS/Sources/Beagle/Sources/ContextExpression/Expression/Tests/__Snapshots__/ExpressionTests/testContextExpression.1.txt
@@ -1,0 +1,23 @@
+▿ 3 elements
+  ▿ Optional<ContextExpression>
+    ▿ some: ContextExpression
+      ▿ single: SingleExpression
+        ▿ value: Value
+          ▿ binding: Binding
+            - context: "expression"
+            ▿ path: Path
+              - nodes: 0 elements
+  ▿ Optional<ContextExpression>
+    ▿ some: ContextExpression
+      ▿ multiple: MultipleExpression
+        ▿ nodes: 2 elements
+          ▿ Node
+            ▿ expression: SingleExpression
+              ▿ value: Value
+                ▿ binding: Binding
+                  - context: "expression"
+                  ▿ path: Path
+                    - nodes: 0 elements
+          ▿ Node
+            - string: " + string"
+  - Optional<ContextExpression>.none


### PR DESCRIPTION
### Description and Example

Fixed a problem related to the parser _singleOrMultipleExpression_. For multiple expression beginning with bind the parser was returning _nil_. Ex: "{expression} + string" 

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
