### PR TITLE
feat: add behaviour in lazy component to show error when failed request

### DIFF
--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/LazyComponentTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/LazyComponentTest.kt
@@ -16,27 +16,45 @@
 
 package br.com.zup.beagle.android.components
 
+import android.view.LayoutInflater
 import android.view.View
+import android.widget.Button
 import androidx.core.view.get
+import br.com.zup.beagle.R
 import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.testutil.RandomData
+import br.com.zup.beagle.android.utils.BeagleRetry
+import br.com.zup.beagle.android.view.ServerDrivenState
 import br.com.zup.beagle.android.view.ViewFactory
 import br.com.zup.beagle.android.view.custom.BeagleView
+import br.com.zup.beagle.android.view.custom.OnServerStateChanged
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.android.synthetic.main.beagle_include_error_server_driven.view.buttonRetry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 
 private val URL = RandomData.httpUrl()
 
+@DisplayName("Given a Lazy Component")
 class LazyComponentTest : BaseComponentTest() {
 
     private val initialStateView: View = mockk()
     private val initialState: ServerDrivenComponent = mockk()
     private val beagleView: BeagleView = mockk(relaxed = true)
+    private val slot = slot<OnServerStateChanged>()
+    private val errorView = mockk<View>(relaxed = true)
+    private val errorRetryButton = mockk<Button>(relaxed = true, relaxUnitFun = true)
 
     private lateinit var lazyComponent: LazyComponent
 
@@ -47,21 +65,100 @@ class LazyComponentTest : BaseComponentTest() {
         every { anyConstructed<ViewFactory>().makeBeagleView(any()) } returns beagleView
         every { beagleView[0] } returns initialStateView
 
+        every {
+            beagleView.serverStateChangedListener = capture(slot)
+        } just Runs
+
+        mockkStatic(LayoutInflater::class)
+        every {
+            LayoutInflater.from(beagleView.context)
+                .inflate(R.layout.beagle_include_error_server_driven,
+                    null)
+        } returns errorView
+
+        every { errorView.buttonRetry } returns errorRetryButton
+
         lazyComponent = LazyComponent(URL, initialState)
     }
 
-    @Test
-    fun build_should_call_make_a_BeagleView() {
-        val actual = lazyComponent.buildView(rootView)
+    @DisplayName("When call build view")
+    @Nested
+    inner class BuildViewTest {
 
-        assertTrue(actual is BeagleView)
+        @Test
+        @DisplayName("Then should return a beagle view")
+        fun testCorrectView() {
+            // When
+            val actual = lazyComponent.buildView(rootView)
+
+            // Then
+            assertTrue(actual is BeagleView)
+        }
+
+
+        @Test
+        @DisplayName("Then should update a view")
+        fun testUpdateView() {
+            // When
+            lazyComponent.buildView(rootView)
+
+            // Then
+            verify(exactly = once()) {
+                beagleView.addServerDrivenComponent(initialState)
+                beagleView.updateView(URL, initialStateView)
+
+            }
+        }
     }
 
-    @Test
-    fun build_should_add_initialState_and_trigger_updateView() {
-        lazyComponent.buildView(rootView)
+    @DisplayName("When state of view it is error")
+    @Nested
+    inner class ErrorViewTest {
 
-        verify(exactly = once()) { beagleView.addServerDrivenComponent(initialState) }
-        verify(exactly = once()) { beagleView.updateView(URL, initialStateView) }
+        @Test
+        @DisplayName("Then should return a correct error view")
+        fun testCorrectView() {
+            // When
+            lazyComponent.buildView(rootView)
+            slot.captured.invoke(ServerDrivenState.Error(mockk(), mockk()))
+
+            // Then
+            verify(exactly = once()) {
+                beagleView.addView(any())
+            }
+        }
+
     }
+
+    @DisplayName("When try again in error view")
+    @Nested
+    inner class ErrorTryAgainViewTest {
+
+        @Test
+        @DisplayName("Then should call try again")
+        fun testCorrectTryAgain() {
+            // Given
+            val viewOnClickListenerSlot = slot<View.OnClickListener>()
+            val retry = mockk<BeagleRetry>(relaxUnitFun = true, relaxed = true)
+            val errorState = ServerDrivenState.Error(mockk(), retry)
+
+            every {
+                errorRetryButton.setOnClickListener(capture(viewOnClickListenerSlot))
+            } just Runs
+
+            // When
+            lazyComponent.buildView(rootView)
+            slot.captured.invoke(errorState)
+            viewOnClickListenerSlot.captured.onClick(view)
+
+            // Then
+            verifyOrder {
+                beagleView.removeAllViews()
+                beagleView.addServerDrivenComponent(initialState)
+                retry.invoke()
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
### Related Issues

#1342

### Description and Example

Add simple error screen when failed request in lazy component
![Screenshot_1614118005](https://user-images.githubusercontent.com/63263091/108914565-4d167500-760a-11eb-92fa-1f69c2de0f8d.png)


### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
