### PR TITLE
feat: custom operations

### DIFF
--- a/flutter/beagle/lib/action/beagle_open_native_route.dart
+++ b/flutter/beagle/lib/action/beagle_open_native_route.dart
@@ -1,6 +1,7 @@
-import 'package:beagle/beagle.dart';
+import 'package:beagle/logger/beagle_logger.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:beagle/service_locator.dart';
 
 class BeagleOpenNativeRoute {
   factory BeagleOpenNativeRoute() {
@@ -19,7 +20,8 @@ class BeagleOpenNativeRoute {
     try {
       Navigator.pushNamed(buildContext, url);
     } catch (err) {
-      BeagleSdk.logger.error('Error: $err while trying to navigate to $url');
+      beagleServiceLocator<BeagleLogger>()
+          .error('Error: $err while trying to navigate to $url');
     }
   }
 }

--- a/flutter/beagle/lib/beagle_sdk.dart
+++ b/flutter/beagle/lib/beagle_sdk.dart
@@ -57,6 +57,7 @@ class BeagleSdk {
 
     /// [BeagleLogger] interface that provides logger to beagle use in application.
     BeagleLogger logger,
+    Map<String, Operation> customOperations,
   }) {
     setupServiceLocator(
       beagleConfig: beagleConfig ?? DefaultEmptyConfig(),
@@ -71,6 +72,7 @@ class BeagleSdk {
       imageDownloader: imageDownloader,
       strategy: strategy ?? BeagleNetworkStrategy.beagleWithFallbackToCache,
       logger: logger ?? DefaultEmptyLogger(),
+      customOperations: customOperations,
     );
   }
 }

--- a/flutter/beagle/lib/bridge_impl/beagle_js_engine.dart
+++ b/flutter/beagle/lib/bridge_impl/beagle_js_engine.dart
@@ -188,7 +188,6 @@ class BeagleJSEngine {
     if (_operationListener == null) {
       return;
     }
-
     _operationListener(
         operationMessage['operation'], operationMessage['params']);
   }

--- a/flutter/beagle/lib/bridge_impl/beagle_service_js.dart
+++ b/flutter/beagle/lib/bridge_impl/beagle_service_js.dart
@@ -35,6 +35,7 @@ class BeagleServiceJS implements BeagleService {
     this.actions,
     this.strategy,
     this.navigationControllers,
+    this.customOperations,
   });
 
   @override
@@ -51,6 +52,8 @@ class BeagleServiceJS implements BeagleService {
   BeagleNetworkStrategy strategy;
   @override
   Map<String, NavigationController> navigationControllers;
+  @override
+  Map<String, Operation> customOperations;
 
   final BeagleJSEngine _beagleJSEngine;
 
@@ -69,16 +72,17 @@ class BeagleServiceJS implements BeagleService {
   @override
   Future<void> start() async {
     await _beagleJSEngine.start();
-
     _registerBeagleService();
     _registerHttpListener();
     _registerActionListener();
+    _registerOperationListener();
   }
 
   void _registerBeagleService() {
     final params = {
       'baseUrl': baseUrl,
       'actionKeys': actions.keys.toList(),
+      'customOperations': customOperations.keys.toList(),
       'useBeagleHeaders': useBeagleHeaders,
       'strategy': NetworkStrategyUtils.getJsStrategyName(strategy),
     };
@@ -104,6 +108,16 @@ class BeagleServiceJS implements BeagleService {
         return;
       }
       handler(action: action, view: view, element: element);
+    });
+  }
+
+  void _registerOperationListener() {
+    _beagleJSEngine.onOperation((operationName, params) {
+      final handler = customOperations[operationName];
+      if (handler == null) {
+        return;
+      }
+      handler(params);
     });
   }
 }

--- a/flutter/beagle/lib/interface/beagle_service.dart
+++ b/flutter/beagle/lib/interface/beagle_service.dart
@@ -31,6 +31,8 @@ typedef ComponentBuilder = Widget Function(
 typedef ActionHandler = void Function(
     {BeagleAction action, BeagleView view, BeagleUIElement element});
 
+typedef Operation = void Function(List<dynamic> args);
+
 abstract class BeagleService {
   /// URL to the backend providing the views (JSON) for Beagle.
   String baseUrl;
@@ -62,6 +64,16 @@ abstract class BeagleService {
   /// Options for the visual feedback when navigating from a view to another. To set the default
   /// options, use `default: true` in the navigation controller.
   Map<String, NavigationController> navigationControllers;
+
+  /*
+   * The map of custom operations that can be used to extend the capability of the Beagle expressions and are called like functions, 
+   * e.g. `@{sum(1, 2)}`.
+   * The keys of this object represent the operation name and the values must be the functions themselves. 
+   * An operation name must contain only letters, numbers and the character _, 
+   * it also must contain at least one letter or _.
+   * Note: If you create custom operations using the same name of a default from Beagle, the default will be overwritten by the custom one
+   */
+  Map<String, Operation> customOperations;
 
   // todo:
   /*Analytics analytics;

--- a/flutter/beagle/lib/service_locator.dart
+++ b/flutter/beagle/lib/service_locator.dart
@@ -34,19 +34,19 @@ import 'package:get_it/get_it.dart';
 
 final GetIt beagleServiceLocator = GetIt.instance;
 
-void setupServiceLocator({
-  BeagleConfig beagleConfig,
-  HttpClient httpClient,
-  Map<String, ComponentBuilder> components,
-  Storage storage,
-  bool useBeagleHeaders,
-  Map<String, ActionHandler> actions,
-  BeagleNetworkStrategy strategy,
-  Map<String, NavigationController> navigationControllers,
-  BeagleDesignSystem designSystem,
-  BeagleImageDownloader imageDownloader,
-  BeagleLogger logger,
-}) {
+void setupServiceLocator(
+    {BeagleConfig beagleConfig,
+    HttpClient httpClient,
+    Map<String, ComponentBuilder> components,
+    Storage storage,
+    bool useBeagleHeaders,
+    Map<String, ActionHandler> actions,
+    BeagleNetworkStrategy strategy,
+    Map<String, NavigationController> navigationControllers,
+    BeagleDesignSystem designSystem,
+    BeagleImageDownloader imageDownloader,
+    BeagleLogger logger,
+    Map<String, Operation> customOperations}) {
   beagleServiceLocator
     ..registerSingleton<JavascriptRuntimeWrapper>(
         createJavascriptRuntimeWrapperInstance())
@@ -64,6 +64,7 @@ void setupServiceLocator({
       actions: actions,
       strategy: strategy,
       navigationControllers: navigationControllers,
+      customOperations: customOperations,
     ))
     ..registerFactoryParam<BeagleViewJS, BeagleNetworkOptions, String>(
         (networkOptions, initialControllerId) => BeagleViewJS(

--- a/flutter/beagle/lib/service_locator.dart
+++ b/flutter/beagle/lib/service_locator.dart
@@ -46,7 +46,8 @@ void setupServiceLocator(
     BeagleDesignSystem designSystem,
     BeagleImageDownloader imageDownloader,
     BeagleLogger logger,
-    Map<String, Operation> customOperations}) {
+    Map<String, Operation> customOperations,
+    }) {
   beagleServiceLocator
     ..registerSingleton<JavascriptRuntimeWrapper>(
         createJavascriptRuntimeWrapperInstance())

--- a/flutter/beagle/test/bridge_impl/beagle_js_engine_test.dart
+++ b/flutter/beagle/test/bridge_impl/beagle_js_engine_test.dart
@@ -112,6 +112,15 @@ void main() {
         verify(jsRuntimeMock.onMessage(expectedChannelName, any));
       });
 
+      test('Then should register for javascript operation messages', () async {
+        final beagleJSEngine = BeagleJSEngine(jsRuntimeMock, storageMock);
+
+        await beagleJSEngine.start();
+
+        const expectedChannelName = 'operation';
+        verify(jsRuntimeMock.onMessage(expectedChannelName, any));
+      });
+
       test('Then should register for javascript beagleView.update messages',
           () async {
         final beagleJSEngine = BeagleJSEngine(jsRuntimeMock, storageMock);
@@ -275,6 +284,32 @@ void main() {
             .single({'action': actionMessage});
 
         expect(actionListenerCalled, true);
+      });
+    });
+
+    group('When an operation message is received', () {
+      test('Then should call registered operation listener', () async {
+        final beagleJSEngine = BeagleJSEngine(jsRuntimeMock, storageMock);
+        await beagleJSEngine.start();
+
+        final operationMessage = {
+          'operation': 'mockOperation',
+          'params': ['paramA', 'paramB'],
+        };
+
+        var operationListener = false;
+
+        beagleJSEngine.onOperation((operation, params) {
+          operationListener = true;
+          expect(operation, 'mockOperation');
+          expect(params, ['paramA', 'paramB']);
+        });
+
+        verify(jsRuntimeMock.onMessage('operation', captureAny))
+            .captured
+            .single(operationMessage);
+
+        expect(operationListener, true);
       });
     });
 

--- a/flutter/beagle/test/bridge_impl/beagle_service_js_test.dart
+++ b/flutter/beagle/test/bridge_impl/beagle_service_js_test.dart
@@ -31,6 +31,7 @@ void main() {
   const baseUrl = 'https://usebeagle.io';
   const useBeagleHeaders = true;
   final actions = {'beagle:alert': ({action, view, element}) {}};
+  final customOperations = {'operation': ([paramA, paramB]) {}};
   const strategy = BeagleNetworkStrategy.networkOnly;
   final navigationControllers = {
     'general': NavigationController(
@@ -47,6 +48,7 @@ void main() {
       baseUrl: baseUrl,
       useBeagleHeaders: useBeagleHeaders,
       actions: actions,
+      customOperations: customOperations,
       strategy: strategy,
       navigationControllers: navigationControllers,
     );
@@ -64,6 +66,7 @@ void main() {
         final expectedParams = {
           'baseUrl': baseUrl,
           'actionKeys': actions.keys.toList(),
+          'customOperations': customOperations.keys.toList(),
           'useBeagleHeaders': useBeagleHeaders,
           'strategy': NetworkStrategyUtils.getJsStrategyName(strategy),
           'navigationControllers': {

--- a/flutter/javascript-bridge/src/global.d.ts
+++ b/flutter/javascript-bridge/src/global.d.ts
@@ -7,6 +7,7 @@ type FlutterJSChannel = (
   | 'storage.set'
   | 'storage.remove'
   | 'storage.clear'
+  | 'operation'
 )
 
 declare function sendMessage(channel: FlutterJSChannel, message: String)

--- a/flutter/javascript-bridge/src/index.ts
+++ b/flutter/javascript-bridge/src/index.ts
@@ -4,6 +4,7 @@ import createBeagleService, {
   NavigationController,
   NetworkOptions,
   Strategy,
+  Operation
 } from '@zup-it/beagle-web'
 import { createCustomActionMap } from './action'
 import { createBeagleView, getView } from './view'
@@ -11,10 +12,12 @@ import { storage } from './storage'
 import { callFunction } from './function'
 import { httpClient, respondHttpRequest } from './http-client'
 import { resolvePromise, rejectPromise } from './promise'
+import { createCustomOperationMap } from './operation'
 
 interface StartParams {
   baseUrl: string,
   actionKeys: string[],
+  customOperations: string[]
   navigationControllers: Record<string, NavigationController>,
   useBeagleHeaders: boolean,
   strategy: Strategy,
@@ -25,13 +28,14 @@ window.beagle = (() => {
   let service: BeagleService
 
   const api = {
-    start: ({ actionKeys, ...other }: StartParams) => {
+    start: ({ actionKeys, customOperations, ...other }: StartParams) => {
       service = createBeagleService({
         components: {},
         disableCssTransformation: true,
         fetchData: httpClient.fetch,
         customStorage: storage,
         customActions: createCustomActionMap(actionKeys),
+        customOperations: createCustomOperationMap(customOperations),
         ...other,
       })
 

--- a/flutter/javascript-bridge/src/operation.ts
+++ b/flutter/javascript-bridge/src/operation.ts
@@ -1,0 +1,16 @@
+import { Operation } from '@zup-it/beagle-web'
+
+function handlerWrapper(operationName: string) {
+  
+  const flutterOperationHandler: Operation = (...args: any[]) => {
+    sendMessage('operation', JSON.stringify({ operation: operationName, params: args }))
+  }
+
+  return flutterOperationHandler
+}
+
+export function createCustomOperationMap(operations: string[]): Record<string, Operation> {
+  return operations.reduce((result, operationName) => {
+    return { ...result, [operationName]: handlerWrapper(operationName) }
+  }, {})
+}


### PR DESCRIPTION
### Related Issues
Closes #1405 
<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

### Description and Example
Created support for custom operations, to solve this issue I simply added the comunication between the JS bridge and the flutter library following the project's patterns.

A single point of warning for this PR is that inside the Beagle Web Core library an operation is defined as following:
![image](https://user-images.githubusercontent.com/50678762/109977040-2a0b5580-7cdb-11eb-8f8a-348a467a3434.png)
The rest operator ('...') allows us to pass as many arguments as we want when using this interface.

It seems though that dart language does not support any operator that would mimic this behavior, what I did instead is create an interface that receives a list of dynamic types. This solutions does not add any additional problems, it only requires that the function parameters be surrounded by brackets ``myCustomFunc([parameter])``
<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most imporant thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

### Checklist

Please, check if these important points are met using `[x]`:

- [ ] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
