### PR TITLE
fix: iOS - ErrorView retry block

### DIFF
--- a/iOS/Sources/Beagle/CodeGeneration/Generated/AutoDecodable.generated.swift
+++ b/iOS/Sources/Beagle/CodeGeneration/Generated/AutoDecodable.generated.swift
@@ -422,6 +422,7 @@ extension TextInput {
         case value
         case placeholder
         case disabled
+        case enabled
         case readOnly
         case type
         case hidden
@@ -431,7 +432,6 @@ extension TextInput {
         case onFocus
         case error
         case showError
-        case enabled
     }
 
     public init(from decoder: Decoder) throws {

--- a/iOS/Sources/Beagle/Sources/Renderer/BeagleErrorView.swift
+++ b/iOS/Sources/Beagle/Sources/Renderer/BeagleErrorView.swift
@@ -113,16 +113,17 @@ class BeagleErrorView: UIVisualEffectView {
     }
     
     @objc private func retryAction() {
-        dismiss()
-        retry.forEach { $0?() }
-        retry.removeAll()
+        dismiss {
+            self.retry.forEach { $0?() }
+            self.retry.removeAll()
+        }
     }
     
     @objc private func cancelAction() {
         dismiss()
     }
     
-    private func dismiss() {
+    private func dismiss(completion: (() -> Void)? = nil) {
         UIView.animate(
             withDuration: 0.2,
             animations: {
@@ -130,6 +131,7 @@ class BeagleErrorView: UIVisualEffectView {
             },
             completion: { _ in
                 self.removeFromSuperview()
+                completion?()
             }
         )
     }


### PR DESCRIPTION
### Related Issues

Fixes #1427 

### Description and Example

Fixes the bug by creating a completion block that guarantees the retry block call when the controller has already left the memory. We still need to add an automated ui test that validates this on both platforms.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
