### PR TITLE
fix: adjust crash when passing color in page indicator

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageIndicator.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/page/PageIndicator.kt
@@ -16,10 +16,10 @@
 
 package br.com.zup.beagle.android.components.page
 
-import android.graphics.Color
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.valueOf
 import br.com.zup.beagle.android.utils.observeBindChanges
+import br.com.zup.beagle.android.utils.toAndroidColor
 import br.com.zup.beagle.android.view.ViewFactory
 import br.com.zup.beagle.android.view.custom.BeaglePageIndicatorView
 import br.com.zup.beagle.android.widget.RootView
@@ -57,8 +57,13 @@ class PageIndicator(
 
     override fun buildView(rootView: RootView) = viewFactory.makePageIndicator(rootView.getContext()).apply {
         pageIndicator = this
-        setSelectedColor(Color.parseColor(selectedColor))
-        setUnselectedColor(Color.parseColor(unselectedColor))
+        selectedColor.toAndroidColor()?.let {
+            setSelectedColor(it)
+        }
+        unselectedColor.toAndroidColor()?.let {
+            setUnselectedColor(it)
+        }
+
         numberOfPages?.let {
             setCount(it)
         }


### PR DESCRIPTION
### Related Issues

Closes #1451 

### Description and Example

When passing some color the beagle crashing.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
