### PR TITLE
feat: add function observer and evaluate in bind

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ActionExtensions.kt
@@ -121,7 +121,7 @@ fun <T> Action.evaluateExpression(
     origin: View,
     bind: Bind<T>,
 ): T? {
-    return bind.evaluateForAction(rootView, origin, this)
+    return bind.evaluate(rootView, origin, this)
 }
 
 internal fun Action.evaluateExpression(rootView: RootView, view: View, data: Any): Any? {
@@ -147,5 +147,5 @@ internal fun Action.evaluateExpression(rootView: RootView, view: View, data: Any
 }
 
 private fun String.generateBindAndEvaluateForAction(rootView: RootView, view: View, caller: Action): Any? {
-    return expressionOf<Any>(this).evaluateForAction(rootView, view, caller)
+    return expressionOf<Any>(this).evaluate(rootView, view, caller)
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/BindExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/BindExtensions.kt
@@ -25,20 +25,34 @@ import br.com.zup.beagle.android.widget.RootView
 
 typealias Observer<T> = (value: T) -> Unit
 
-// This method should be used if its inside a ServerDrivenComponent
-internal fun <T> Bind<T>.observe(
+/**
+ * Observe a specific Bind to changes. If the Bind is type of Value, then the actual value will be returned.
+ * But if the value is an Expression, then the evaluation will be make.
+ * @property rootView from buildView
+ * @property view that will receive the binding
+ * @property observes is function that will be called when a expression is evaluated
+ */
+fun <T> Bind<T>.observe(
     rootView: RootView,
     view: View,
-    observes: Observer<T?>? = null
-): T? {
-    return evaluateBind(rootView, view, this, null, observes)
+    observes: Observer<T?>? = null,
+) {
+    val value = evaluateBind(rootView, view, this, null, observes)
+    if (this is Bind.Value) {
+        observes?.invoke(value)
+    }
 }
 
-// This method should be used if its inside a Action
-internal fun <T> Bind<T>.evaluateForAction(
+/**
+ * Evaluate the expression to a value
+ * @property rootView from buildView
+ * @property origin received on execute method
+ * @property caller action called function
+ */
+fun <T> Bind<T>.evaluate(
     rootView: RootView,
     origin: View,
-    caller: Action
+    caller: Action,
 ): T? {
     return evaluateBind(rootView, origin, this, caller, null)
 }
@@ -48,7 +62,7 @@ private fun <T> evaluateBind(
     view: View,
     bind: Bind<T>,
     caller: Action?,
-    observes: Observer<T?>?
+    observes: Observer<T?>?,
 ): T? {
     return try {
         when (bind) {
@@ -66,7 +80,7 @@ private fun <T> evaluateExpression(
     view: View,
     bind: Bind.Expression<T>,
     observes: Observer<T?>? = null,
-    caller: Action? = null
+    caller: Action? = null,
 ): T? {
     val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
     return if (caller != null) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/WidgetExtensions.kt
@@ -152,10 +152,7 @@ internal fun <T> internalObserveBindChanges(
     bind: Bind<T>,
     observes: Observer<T?>,
 ) {
-    val value = bind.observe(rootView, view, observes)
-    if (bind is Bind.Value) {
-        observes(value)
-    }
+    bind.observe(rootView, view, observes)
 }
 
 /**


### PR DESCRIPTION
### Related Issues

#1414 

### Description and Example

Currently, it is not intuitive for the developer as he should evaluate an expression or observe, I made the methods available in the class itself to be easier because the auto-complete will help him.

The names were changed to keep the same name that is on iOS so we will have the same name, making it easier for the developer.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
