### PR TITLE
feat: improved Android Appium tests speed with deep links

### DIFF
--- a/tests/appium/app-android/app/src/main/AndroidManifest.xml
+++ b/tests/appium/app-android/app/src/main/AndroidManifest.xml
@@ -49,6 +49,16 @@
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>
+        <activity android:name="br.com.zup.beagle.appiumapp.activity.BffDeepLinkActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with "appiumapp://bffurl” -->
+                <data android:scheme="appiumapp"
+                    android:host="bffurl" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
@@ -47,10 +47,23 @@ abstract class AbstractStep {
         return driver!!
     }
 
-    protected fun loadBffScreenFromMainScreen() {
+    protected fun loadBffScreenFromMainScreen(){
         val mainScreen = MainScreen(getDriver())
         mainScreen.setBffUrl(SuiteSetup.getBffBaseUrl() + bffRelativeUrlPath)
         mainScreen.clickOnGoButton()
+    }
+
+    protected fun loadBffScreenFromDeepLink(){
+        getDriver().get("appiumapp://bffurl/" + SuiteSetup.getBffBaseUrl() + bffRelativeUrlPath)
+    }
+
+    protected fun loadBffScreen(){
+        if (SuiteSetup.isAndroid()) {
+            loadBffScreenFromDeepLink()
+        }
+        else{
+            loadBffScreenFromMainScreen()
+        }
     }
 
     /**

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ActionNotRegisteredScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ActionNotRegisteredScreenSteps.kt
@@ -25,7 +25,7 @@ class ActionNotRegisteredScreenSteps : AbstractStep() {
 
     @Before("@unregisteredaction")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the ActionNotRegistered Screen url$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AddChildrenScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AddChildrenScreenSteps.kt
@@ -32,7 +32,7 @@ class AddChildrenScreenSteps : AbstractStep() {
 
     @Before("@addChildren")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^that I'm on the addChildren Screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AlertScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AlertScreenSteps.kt
@@ -28,7 +28,7 @@ class AlertScreenSteps : AbstractStep() {
 
     @Before("@alert")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the alert screen url$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AnalyticsScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AnalyticsScreenSteps.kt
@@ -48,7 +48,7 @@ class AnalyticsScreenSteps : AbstractStep() {
     @Given("AppiumApp did navigate to remote screen with url {string}")
     fun checkBaseScreen(url: String) {
         bffRelativeUrlPath = url
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
         waitForElementWithTextToBeClickable("Analytics 2.0", false, false)
     }
 

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ButtonScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ButtonScreenSteps.kt
@@ -35,7 +35,7 @@ class ButtonScreenSteps : AbstractStep() {
 
     @Before("@button")
     fun setup() {
-        loadBffScreenFromMainScreen()
+      loadBffScreen()
     }
 
     @Given("^that I'm on the button screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConditionalScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConditionalScreenSteps.kt
@@ -26,7 +26,7 @@ class ConditionalScreenSteps : AbstractStep() {
 
     @Before("@conditional")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the conditional screen url$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConfirmScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConfirmScreenSteps.kt
@@ -26,7 +26,7 @@ class ConfirmScreenSteps : AbstractStep() {
 
     @Before("@confirm")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the confirm screen url$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ContainerScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ContainerScreenSteps.kt
@@ -26,7 +26,7 @@ class ContainerScreenSteps : AbstractStep() {
 
     @Before("@container")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the container screen url$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/HookManager.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/HookManager.kt
@@ -64,6 +64,8 @@ class HookManager {
             }
         }
 
-        SuiteSetup.restartApp()
+        // Android tests by default won't restart app anymore because they now use deep links to load bff screens
+        if (SuiteSetup.isIos())
+          SuiteSetup.restartApp()
     }
 }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ImageScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ImageScreenSteps.kt
@@ -29,7 +29,7 @@ class ImageScreenSteps : AbstractStep() {
 
     @Before("@image")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^that I'm on the image screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/LazyComponentScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/LazyComponentScreenSteps.kt
@@ -25,7 +25,7 @@ class LazyComponentScreenSteps : AbstractStep() {
 
     @Before("@lazyComponent")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the LazyComponent Screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/NavigateScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/NavigateScreenSteps.kt
@@ -29,7 +29,7 @@ class NavigateScreenSteps : AbstractStep() {
 
     @Before("@navigation")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the navigation screen url$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/PageViewScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/PageViewScreenSteps.kt
@@ -31,7 +31,7 @@ class PageViewScreenSteps : AbstractStep() {
 
     @Before("@pageview")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^that I'm on the pageview screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ScrollViewScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ScrollViewScreenSteps.kt
@@ -51,7 +51,7 @@ class ScrollViewScreenSteps : AbstractStep() {
 
     @Before("@scrollview")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^that I'm on the scrollview screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/SendRequestScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/SendRequestScreenSteps.kt
@@ -26,7 +26,7 @@ class SendRequestScreenSteps : AbstractStep() {
 
     @Before("@sendrequest")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the send request screen url$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/SetContextScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/SetContextScreenSteps.kt
@@ -26,7 +26,7 @@ class SetContextScreenSteps: AbstractStep() {
 
     @Before("@setcontext")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the SetContext screen url$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/SimpleFormScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/SimpleFormScreenSteps.kt
@@ -27,7 +27,7 @@ class SimpleFormScreenSteps : AbstractStep() {
 
     @Before("@simpleform")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^that I'm on the simple form screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TabBarScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TabBarScreenSteps.kt
@@ -29,7 +29,7 @@ class TabBarScreenSteps : AbstractStep() {
 
     @Before("@tabBar")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^that I'm on the tabBar screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TextInputScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TextInputScreenSteps.kt
@@ -28,7 +28,7 @@ class TextInputScreenSteps : AbstractStep() {
 
     @Before("@textinput")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the textInput on screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TextStyleScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TextStyleScreenSteps.kt
@@ -26,7 +26,7 @@ class TextStyleScreenSteps: AbstractStep() {
 
     @Before("@textStyle")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^the Beagle application did launch with the texts on the screen$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TouchScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TouchScreenSteps.kt
@@ -33,7 +33,7 @@ class TouchScreenSteps : AbstractStep() {
 
     @Before("@touchable")
     fun setup() {
-        loadBffScreenFromMainScreen()
+        loadBffScreen()
     }
 
     @Given("^that I'm on the touchable screen$")


### PR DESCRIPTION
### Related Issues

#1438 

### Description and Example

Android Appium tests no longer will use a screen to type a text to load a bff screen. Now the bff screens will load by deep link calls. This change reduced the test **run time by over 60%!**


### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
