### PR TITLE
fix: RecyclerView id access from ListView 

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
@@ -249,7 +249,7 @@ constructor(
         observeBindChanges(rootView, recyclerView, dataSource!!) { value ->
             canScrollEnd = true
             val adapter = recyclerView.adapter as ListAdapter
-            adapter.setList(value)
+            adapter.setList(value, this.id)
             if (value?.isEmpty() == true) {
                 executeScrollEndActions()
             }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListAdapter.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListAdapter.kt
@@ -26,6 +26,7 @@ import br.com.zup.beagle.android.context.AsyncActionData
 import br.com.zup.beagle.android.context.normalizeContextValue
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.utils.setIsAutoGenerateIdEnabled
+import br.com.zup.beagle.android.utils.toAndroidId
 import br.com.zup.beagle.android.view.ViewFactory
 import br.com.zup.beagle.core.ServerDrivenComponent
 
@@ -155,11 +156,11 @@ internal class ListAdapter(
         holder.onViewAttachedToWindow()
     }
 
-    fun setList(list: List<Any>?) {
+    fun setList(list: List<Any>?, componentId: String? = null) {
         list?.let {
             if (list != listItems) {
                 clearAdapterContent()
-                notifyListViewIdViewModel(listItems.isEmpty())
+                notifyListViewIdViewModel(listItems.isEmpty(), componentId)
                 listItems = list
                 adapterItems = list.map { ListItem(data = it.normalizeContextValue()) }
                 notifyDataSetChanged()
@@ -172,10 +173,10 @@ internal class ListAdapter(
         createdViewHolders.clear()
     }
 
-    private fun notifyListViewIdViewModel(adapterPreviouslyEmpty: Boolean) {
+    private fun notifyListViewIdViewModel(adapterPreviouslyEmpty: Boolean, componentId: String?) {
         listViewModels
             .listViewIdViewModel
-            .createSingleManagerByListViewId(getRecyclerId(), adapterPreviouslyEmpty)
+            .createSingleManagerByListViewId(getRecyclerId(componentId), adapterPreviouslyEmpty)
     }
 
     private fun clearList() {
@@ -192,10 +193,11 @@ internal class ListAdapter(
         }
     }
 
-    private fun getRecyclerId(): Int {
-        return recyclerId.takeIf {
+    private fun getRecyclerId(componentId: String?): Int {
+        val id = recyclerId.takeIf {
             it != View.NO_ID
-        } ?: createTempId()
+        } ?: componentId?.toAndroidId()
+        return id ?: createTempId()
     }
 
     private fun createTempId(): Int {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListViewHolder.kt
@@ -211,7 +211,7 @@ internal class ListViewHolder(
         position: Int,
         recyclerId: Int
     ) {
-        val itemViewId = bindIdToViewModel(itemView, isRecycled, position, recyclerId)
+        val itemViewId = bindIdToViewModel(position, recyclerId)
         setUpdatedIdToViewAndManagers(itemView, itemViewId, listItem, isRecycled)
 
         viewsWithId.forEach { (id, view) ->
@@ -223,14 +223,14 @@ internal class ListViewHolder(
 
         val viewsWithContextAndWithoutId = viewsWithContext.filterNot { viewsWithId.containsValue(it) }
         viewsWithContextAndWithoutId.forEach { view ->
-            val subViewId = bindIdToViewModel(view, isRecycled, position, recyclerId)
+            val subViewId = bindIdToViewModel(position, recyclerId)
             setUpdatedIdToViewAndManagers(view, subViewId, listItem, isRecycled)
         }
 
         val viewsWithOnInitAndWithoutIdAndContext =
             viewsWithOnInit.filterNot { viewsWithId.containsValue(it) || viewsWithContext.contains(it) }
         viewsWithOnInitAndWithoutIdAndContext.forEach { view ->
-            val subViewId = bindIdToViewModel(view, isRecycled, position, recyclerId)
+            val subViewId = bindIdToViewModel(position, recyclerId)
             setUpdatedIdToViewAndManagers(view, subViewId, listItem, isRecycled)
         }
 
@@ -241,12 +241,12 @@ internal class ListViewHolder(
                     viewsWithOnInit.contains(it)
             }
             .forEach { innerRecyclerWithoutId ->
-                val subViewId = bindIdToViewModel(innerRecyclerWithoutId, isRecycled, position, recyclerId)
+                val subViewId = bindIdToViewModel(position, recyclerId)
                 setUpdatedIdToViewAndManagers(innerRecyclerWithoutId, subViewId, listItem, isRecycled)
             }
     }
 
-    private fun bindIdToViewModel(view: View, isRecycled: Boolean, position: Int, recyclerId: Int): Int {
+    private fun bindIdToViewModel(position: Int, recyclerId: Int): Int {
         return listViewModels.listViewIdViewModel.getViewId(recyclerId, position)
     }
 

--- a/backend/automated-tests/src/main/kotlin/br/com/zup/beagle/automatedtests/builders/ListViewScreenBuilder.kt
+++ b/backend/automated-tests/src/main/kotlin/br/com/zup/beagle/automatedtests/builders/ListViewScreenBuilder.kt
@@ -16,6 +16,7 @@
 
 package br.com.zup.beagle.automatedtests.builders
 
+import br.com.zup.beagle.automatedtests.model.Genre
 import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.ext.applyFlex
 import br.com.zup.beagle.ext.applyStyle
@@ -49,10 +50,6 @@ data class PageResponse(
     var currentPage: Bind<Int>,
     var totalPages: Bind<Int>,
     var result: Bind<List<Any>>
-)
-
-data class GenreResponse(
-    var genres: Any? = null
 )
 
 data class CategoryResponse(
@@ -209,20 +206,6 @@ object ListViewScreenBuilder {
         )
 
     private fun secondListView() = Container(
-        context = ContextData(id = "genreResponse", value = GenreResponse()),
-        onInit = listOf(
-            SendRequest(
-                url = "/book-database/categories",
-                onSuccess = listOf(
-                    SetContext(
-                        contextId = "genreResponse",
-                        value = GenreResponse(
-                            genres = "@{onSuccess.data}"
-                        )
-                    )
-                )
-            )
-        ),
         children = listOf(
             Text("Categories List View (nested)")
                 .applyStyle(
@@ -240,7 +223,7 @@ object ListViewScreenBuilder {
         return ListView(
             key = "id",
             direction = ListDirection.VERTICAL,
-            dataSource = expressionOf("@{genreResponse.genres}"),
+            dataSource = valueOf(Genre.createMock()),
             template = Container(
                 context = ContextData(id = "categoryResponse", value = CategoryResponse()),
                 children = listOf(


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>


### Related Issues

Fixes #1473 

### Description and Example

When the `dataSource` of a `ListView` was informed together with the component, there was a crash on Android due to the synchronization of component ids with the view. To cover this scenario, an integrated test was changed, since all tests set the `dataSource` through the evaluation of a context and none were set directly.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
