### PR TITLE
fix: renderScreen replacement method

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -274,13 +274,73 @@ private fun loadView(
 }
 
 /**
+ * Render a Json in String format from a ServerDrivenComponent into this ViewGroup
+ * @param activity that is parent of this view.
+ * Make sure to use this method if you are inside a Activity because of the lifecycle.
+ * @param screenJson Json in String format that represents your component.
+ * @param screenId that represents an screen identifier to create the analytics when the screen is created.
+ * @param shouldResetContext when true, this clear at the time of calling this function all de context data
+ * linked to the lifecycle owner.
+ */
+fun ViewGroup.loadView(
+    activity: AppCompatActivity,
+    screenJson: String,
+    screenId: String = "",
+    shouldResetContext: Boolean = false,
+) {
+    loadView(ActivityRootView(activity, this.id, screenId), screenJson, shouldResetContext)
+}
+
+/**
+ * Render a Json in String format from a ServerDrivenComponent into this ViewGroup
+ * @param fragment that is parent of this view.
+ * Make sure to use this method if you are inside a Fragment because of the lifecycle.
+ * @param screenJson Json in String format that represents your component.
+ * @param screenId that represents an screen identifier to create the analytics when the screen is created.
+ * @param shouldResetContext when true, this clear at the time of calling this function all de context data
+ * linked to the lifecycle owner.
+ */
+fun ViewGroup.loadView(
+    fragment: Fragment,
+    screenJson: String,
+    screenId: String = "",
+    shouldResetContext: Boolean = false,
+) {
+    loadView(FragmentRootView(fragment, this.id, screenId), screenJson, shouldResetContext)
+}
+
+internal fun ViewGroup.loadView(
+    rootView: RootView,
+    screenJson: String,
+    shouldResetContext: Boolean,
+    generateIdManager: GenerateIdManager = GenerateIdManager(rootView),
+) {
+    if (shouldResetContext) {
+        val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
+        viewModel.clearContexts()
+    }
+    generateIdManager.createSingleManagerByRootViewId()
+    val component = beagleSerializerFactory.deserializeComponent(screenJson)
+    val view = viewExtensionsViewFactory.makeBeagleView(rootView).apply {
+        addServerDrivenComponent(component)
+        listenerOnViewDetachedFromWindow = {
+            generateIdManager.onViewDetachedFromWindow(this)
+        }
+    }
+    removeAllViews()
+    addView(view)
+}
+
+/**
  * Render a ServerDrivenComponent into this ViewGroup
  * @property activity that is parent of this view.
  * Make sure to use this method if you are inside a Activity because of the lifecycle
  * @property screenJson that represents your component
  * @property screenId that represents an screen identifier to create the analytics when the screen is created
- * the screen is created
  */
+@Deprecated("This method was deprecated in version 1.7.0 and will be removed in a future version. " +
+    "Use the loadView method with screenJson param to avoid problems with navigation and have control over context.",
+    replaceWith = ReplaceWith("loadView(activity = activity, screenJson = screenJson)"))
 fun ViewGroup.renderScreen(
     activity: AppCompatActivity,
     screenJson: String,
@@ -291,13 +351,14 @@ fun ViewGroup.renderScreen(
 
 /**
  * Render a ServerDrivenComponent into this ViewGroup
- * @property fragment <p>that is parent of this view.
- * Make sure to use this method if you are inside a Fragment bec
- * ause of the lifecycle</p>
+ * @property fragment that is parent of this view.
+ * Make sure to use this method if you are inside a Fragment because of the lifecycle
  * @property screenJson that represents your component
  * @property screenId that represents an screen identifier to create the analytics when the screen is created
- * the screen is created
  */
+@Deprecated("This method was deprecated in version 1.7.0 and will be removed in a future version. " +
+    "Use the loadView method with screenJson param to avoid problems with navigation and have control over context.",
+    replaceWith = ReplaceWith("loadView(fragment = fragment, screenJson = screenJson)"))
 fun ViewGroup.renderScreen(
     fragment: Fragment,
     screenJson: String,
@@ -310,13 +371,5 @@ internal fun ViewGroup.renderScreen(
     rootView: RootView,
     screenJson: String,
 ) {
-    val viewModel = rootView.generateViewModelInstance<ScreenContextViewModel>()
-    viewModel.clearContexts()
-    val component = beagleSerializerFactory.deserializeComponent(screenJson)
-    (rootView.getContext() as AppCompatActivity)
-        .supportFragmentManager
-        .beginTransaction()
-        .replace(this.id, BeagleFragment.newInstance(component, rootView.getScreenId()))
-        .addToBackStack(null)
-        .commit()
+    loadView(rootView, screenJson, shouldResetContext = true)
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -24,7 +24,6 @@ import androidx.fragment.app.Fragment
 import br.com.zup.beagle.android.components.utils.viewExtensionsViewFactory
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.networking.RequestData
-import br.com.zup.beagle.android.view.BeagleFragment
 import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.android.view.ServerDrivenState
 import br.com.zup.beagle.android.view.custom.OnServerStateChanged

--- a/android/preview/src/test/java/br/com/zup/beagle/android/preview/PreviewActivityTest.kt
+++ b/android/preview/src/test/java/br/com/zup/beagle/android/preview/PreviewActivityTest.kt
@@ -146,7 +146,6 @@ class PreviewActivityTest {
         incrementButton?.performClick()
 
         // THEN
-        assertNotNull(activity!!.supportFragmentManager.fragments.first().view)
         assertNotNull(textComponent)
         assertEquals("Counter: 3", textComponent?.text)
         assertNotNull(incrementButton)


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>


### Related Issues

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

Fixes #1491.

### Description and Example

<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most imporant thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

When using the `renderScreen` method to convert a json string in view into multiple fragments within the same activity, there was a conflict with the navigation. Now, the method instead of passing the responsibility to `supportFragmentManager`, it simply replaces the views in the viewGroup with the rendered view.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
