### PR TITLE
feat: added bindable fields to navigate methods

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/action/Navigate.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/action/Navigate.kt
@@ -41,9 +41,23 @@ sealed class Navigate : AnalyticsAction {
      * @param url defined route to be shown.
      */
     @BeagleJson(name = "openExternalURL")
-    data class OpenExternalURL(val url: String, override var analytics: ActionAnalyticsConfig? = null) : Navigate() {
+    data class OpenExternalURL(
+        val url: Bind<String>,
+        override var analytics: ActionAnalyticsConfig? = null,
+    ) : Navigate() {
+
+        constructor(
+            url: String,
+            analytics: ActionAnalyticsConfig? = null,
+        ) : this(
+            url = expressionOrValueOf(url),
+            analytics = analytics
+        )
+
         override fun execute(rootView: RootView, origin: View) {
-            BeagleNavigator.openExternalURL(rootView.getContext(), url)
+            evaluateExpression(rootView, origin, url)?.let { url ->
+                BeagleNavigator.openExternalURL(rootView.getContext(), url)
+            }
         }
     }
 
@@ -56,13 +70,28 @@ sealed class Navigate : AnalyticsAction {
      */
     @BeagleJson(name = "openNativeRoute")
     class OpenNativeRoute(
-        val route: String,
+        val route: Bind<String>,
         val shouldResetApplication: Boolean = false,
         val data: Map<String, String>? = null,
         override var analytics: ActionAnalyticsConfig? = null,
     ) : Navigate() {
+
+        constructor(
+            route: String,
+            shouldResetApplication: Boolean = false,
+            data: Map<String, String>? = null,
+            analytics: ActionAnalyticsConfig? = null,
+        ) : this(
+            route = expressionOrValueOf(route),
+            shouldResetApplication = shouldResetApplication,
+            data = data,
+            analytics = analytics
+        )
+
         override fun execute(rootView: RootView, origin: View) {
-            BeagleNavigator.openNativeRoute(rootView, route, data, shouldResetApplication)
+            evaluateExpression(rootView, origin, route)?.let { route ->
+                BeagleNavigator.openNativeRoute(rootView, route, data, shouldResetApplication)
+            }
         }
     }
 
@@ -92,9 +121,23 @@ sealed class Navigate : AnalyticsAction {
      * @param route route of a screen that it's on the pile.
      */
     @BeagleJson(name = "popToView")
-    data class PopToView(val route: String, override var analytics: ActionAnalyticsConfig? = null) : Navigate() {
+    data class PopToView(
+        val route: Bind<String>,
+        override var analytics: ActionAnalyticsConfig? = null,
+    ) : Navigate() {
+
+        constructor(
+            route: String,
+            analytics: ActionAnalyticsConfig? = null,
+        ) : this(
+            route = expressionOrValueOf(route),
+            analytics = analytics
+        )
+
         override fun execute(rootView: RootView, origin: View) {
-            BeagleNavigator.popToView(rootView.getContext(), route)
+            evaluateExpression(rootView, origin, route)?.let { route ->
+                BeagleNavigator.popToView(rootView.getContext(), route)
+            }
         }
     }
 
@@ -232,7 +275,6 @@ sealed class Route {
         val screen: Screen,
     ) : Route()
 }
-
 
 /**
  * HttpAdditionalData is used to do requests.

--- a/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/action/Navigate.kt
+++ b/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/action/Navigate.kt
@@ -71,7 +71,19 @@ sealed class Navigate : AnalyticsAction {
      * Opens one of the browsers available on the device with the passed url.
      * @param url defined route to be shown.
      */
-    data class OpenExternalURL(val url: String, override var analytics: ActionAnalyticsConfig? = null) : Navigate()
+    data class OpenExternalURL(
+        val url: Bind<String>,
+        override var analytics: ActionAnalyticsConfig? = null,
+    ) : Navigate() {
+
+        constructor(
+            url: String,
+            analytics: ActionAnalyticsConfig? = null,
+        ) : this(
+            url = valueOf(url),
+            analytics = analytics
+        )
+    }
 
     /**
      * This action opens the route to execute the action declared in the deeplink that was defined for the application.
@@ -80,10 +92,25 @@ sealed class Navigate : AnalyticsAction {
      * restarting the application view stack.
      * @param data pass information between screens.
      */
-    class OpenNativeRoute(val route: String,
-                          val shouldResetApplication: Boolean = false,
-                          val data: Map<String, String>? = null,
-                          override var analytics: ActionAnalyticsConfig? = null) : Navigate()
+    class OpenNativeRoute(
+        val route: Bind<String>,
+        val shouldResetApplication: Boolean = false,
+        val data: Map<String, String>? = null,
+        override var analytics: ActionAnalyticsConfig? = null,
+    ) : Navigate() {
+
+        constructor(
+            route: String,
+            shouldResetApplication: Boolean = false,
+            data: Map<String, String>? = null,
+            analytics: ActionAnalyticsConfig? = null,
+        ) : this(
+            route = valueOf(route),
+            shouldResetApplication = shouldResetApplication,
+            data = data,
+            analytics = analytics
+        )
+    }
 
     /**
      * Present a new screen with the link declared in the route attribute.
@@ -123,7 +150,19 @@ sealed class Navigate : AnalyticsAction {
      *
      * @param route route of a screen that it's on the pile.
      */
-    data class PopToView(val route: String, override var analytics: ActionAnalyticsConfig? = null) : Navigate()
+    data class PopToView(
+        val route: Bind<String>,
+        override var analytics: ActionAnalyticsConfig? = null,
+    ) : Navigate() {
+
+        constructor(
+            route: String,
+            analytics: ActionAnalyticsConfig? = null,
+        ) : this(
+            route = valueOf(route),
+            analytics = analytics
+        )
+    }
 
     /**
      * This attribute, when selected, opens a screen with the route informed


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>


### Related Issues

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

Closes #1504

### Description and Example

<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most important thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

This PR adds support to pass expression to `OpenExternalURL`, `OpenNativeRoute` and `PopToView` navigate types.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
