### PR TITLE
fix: toolbar set title in beagle android

### DIFF
--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ToolbarManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ToolbarManagerTest.kt
@@ -253,8 +253,8 @@ internal class ToolbarManagerTest : BaseTest() {
     inner class ConfigureToolbar {
 
         @Test
-        @DisplayName("Then should check the title settings")
-        fun verifyCallTheGenerateTitle() {
+        @DisplayName("Then should check the center title settings")
+        fun verifyCallTheGenerateCenterTitle() {
             // GIVEN
             every { toolbar.findViewById<TextView>(any()) } returns textView
             every { navigationBar.title } returns title
@@ -281,6 +281,65 @@ internal class ToolbarManagerTest : BaseTest() {
                 toolbar.addView(textViewMock)
                 toolbarTextManagerMock.centerTitle(toolbar, textViewMock)
             }
+        }
+
+        @Test
+        @DisplayName("Then you should check if the title and the style have been applied")
+        fun checkIfTheTitleAndStyleHasBeenApplied() {
+            // GIVEN
+            toolbar = mockk()
+            val beagleActivityMock = mockk<BeagleActivity>(relaxed = true)
+            every { (rootView.getContext() as BeagleActivity) } returns beagleActivityMock
+            val slotStyle = slot<Int>()
+            every { beagleActivityMock.obtainStyledAttributes(capture(slotStyle),R.styleable.BeagleToolbarStyle) } returns mockk(relaxed = true)
+            every { toolbar.title } returns title
+            every { beagleActivityMock.getToolbar() } returns toolbar
+            every { navigationBar.styleId } returns style
+            every { beagleSdk.designSystem } returns designSystemMock
+            every { designSystemMock.toolbarStyle(style) } returns styleInt
+            every { toolbar.visibility = View.VISIBLE } just runs
+            every { toolbar.menu } returns menu
+            every { toolbar.navigationIcon = null } just runs
+            every { toolbar.findViewById<TextView>(any()) } returns textView
+            every { toolbar.removeView(textView) } just runs
+            every { toolbar.title  = title } just runs
+            every { toolbar.setTitleTextAppearance(beagleActivityMock, styleInt)  } just runs
+            every { navigationBar.title } returns title
+            every {
+                typedArray.getResourceId(R.styleable.BeagleToolbarStyle_titleTextAppearance, 0)
+            } returns textAppearanceMock
+
+            // WHEN
+            toolbarManager.configureToolbar(rootView, navigationBar, beagleFlexView, screenComponent)
+
+            // THEN
+            assertEquals(title, toolbar.title.toString())
+            assertEquals(styleInt, slotStyle.captured)
+        }
+
+        @Test
+        @DisplayName("Then you should check if the title has been applied")
+        fun checkIfTheTitleHasBeenApplied() {
+            // GIVEN
+            toolbar = mockk()
+            val beagleActivityMock = mockk<BeagleActivity>(relaxed = true)
+            every { (rootView.getContext() as BeagleActivity) } returns beagleActivityMock
+            every { toolbar.title } returns title
+            every { beagleActivityMock.getToolbar() } returns toolbar
+            every { navigationBar.styleId } returns null
+            every { toolbar.visibility = View.VISIBLE } just runs
+            every { toolbar.menu } returns menu
+            every { toolbar.navigationIcon = null } just runs
+            every { toolbar.findViewById<TextView>(any()) } returns textView
+            every { toolbar.removeView(textView) } just runs
+            every { toolbar.title  = title } just runs
+            every { navigationBar.title } returns title
+
+            // WHEN
+            toolbarManager.configureToolbar(rootView, navigationBar, beagleFlexView, screenComponent)
+
+            // THEN
+            assertEquals(title, toolbar.title.toString())
         }
     }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ToolbarManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/utils/ToolbarManagerTest.kt
@@ -285,7 +285,7 @@ internal class ToolbarManagerTest : BaseTest() {
 
         @Test
         @DisplayName("Then you should check if the title and the style have been applied")
-        fun checkIfTheTitleAndStyleHasBeenApplied() {
+        fun shouldToolbarWithTitleAndStyleWhenCallConfigureToolbarThenTheToolbarMustHaveATitleAndStyle() {
             // GIVEN
             toolbar = mockk()
             val beagleActivityMock = mockk<BeagleActivity>(relaxed = true)
@@ -319,14 +319,13 @@ internal class ToolbarManagerTest : BaseTest() {
 
         @Test
         @DisplayName("Then you should check if the title has been applied")
-        fun checkIfTheTitleHasBeenApplied() {
+        fun shouldToolbarWithTitleWhenCallConfigureToolbarThenTheToolbarMustHaveATitle() {
             // GIVEN
             toolbar = mockk()
             val beagleActivityMock = mockk<BeagleActivity>(relaxed = true)
             every { (rootView.getContext() as BeagleActivity) } returns beagleActivityMock
             every { toolbar.title } returns title
             every { beagleActivityMock.getToolbar() } returns toolbar
-            every { navigationBar.styleId } returns null
             every { toolbar.visibility = View.VISIBLE } just runs
             every { toolbar.menu } returns menu
             every { toolbar.navigationIcon = null } just runs


### PR DESCRIPTION
### Related Issues
Closes #1487 

### Description and Example
Toolbar component does not render the title when it is not passed style. 
The expected behavior  should always render the title.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

