### PR TITLE
fix: support expression in action AddChildren

### DIFF
--- a/iOS/Sources/Beagle/BeagleTests/Action/Types/__Snapshots__/AddChildrenTests/testDecodingAddChildren.1.txt
+++ b/iOS/Sources/Beagle/BeagleTests/Action/Types/__Snapshots__/AddChildrenTests/testDecodingAddChildren.1.txt
@@ -2,14 +2,5 @@
   - analytics: Optional<ActionAnalyticsConfig>.none
   - componentId: "id"
   - mode: Mode.prepend
-  ▿ value: 1 element
-    ▿ Text
-      - alignment: Optional<Expression<Alignment>>.none
-      - styleId: Optional<String>.none
-      ▿ text: Expression<String>
-        - value: "sample"
-      - textColor: Optional<Expression<String>>.none
-      ▿ widgetProperties: WidgetProperties
-        - accessibility: Optional<Accessibility>.none
-        - id: Optional<String>.none
-        - style: Optional<Style>.none
+  - staticValue: Optional<Array<ServerDrivenComponent>>.none
+  - value: [[_beagleComponent_: beagle:text, text: sample]]

--- a/iOS/Sources/Beagle/BeagleTests/Action/Types/__Snapshots__/AddChildrenTests/testDecodingAddChildrenWithDefaultMode.1.txt
+++ b/iOS/Sources/Beagle/BeagleTests/Action/Types/__Snapshots__/AddChildrenTests/testDecodingAddChildrenWithDefaultMode.1.txt
@@ -2,14 +2,5 @@
   - analytics: Optional<ActionAnalyticsConfig>.none
   - componentId: "id"
   - mode: Mode.append
-  ▿ value: 1 element
-    ▿ Text
-      - alignment: Optional<Expression<Alignment>>.none
-      - styleId: Optional<String>.none
-      ▿ text: Expression<String>
-        - value: "sample"
-      - textColor: Optional<Expression<String>>.none
-      ▿ widgetProperties: WidgetProperties
-        - accessibility: Optional<Accessibility>.none
-        - id: Optional<String>.none
-        - style: Optional<Style>.none
+  - staticValue: Optional<Array<ServerDrivenComponent>>.none
+  - value: [[_beagleComponent_: beagle:text, text: sample]]

--- a/iOS/Sources/Beagle/CodeGeneration/Generated/AutoDecodable.generated.swift
+++ b/iOS/Sources/Beagle/CodeGeneration/Generated/AutoDecodable.generated.swift
@@ -17,26 +17,6 @@
 * limitations under the License.
 */
 
-// MARK: AddChildren Decodable
-extension AddChildren {
-
-    enum CodingKeys: String, CodingKey {
-        case componentId
-        case value
-        case mode
-        case analytics
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        componentId = try container.decode(String.self, forKey: .componentId)
-        value = try container.decode(forKey: .value)
-        mode = try container.decodeIfPresent(Mode.self, forKey: .mode) ?? .append
-        analytics = try container.decodeIfPresent(ActionAnalyticsConfig.self, forKey: .analytics)
-    }
-}
-
 // MARK: Alert Decodable
 extension Alert {
 


### PR DESCRIPTION
### Related Issues

#1535

### Description and Example

Add support to expression in action AddChildren. See #1535.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [ ] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

BREAKING CHANGE: `AddChildren.value`  type changed from `[ServerDrivenComponent]` to `DynamicObject`

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
