### PR TITLE
fix: image resize behaviour

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -74,6 +74,7 @@ data class Image constructor(
 
     private fun getImageView(rootView: RootView) = viewFactory.makeImageView(rootView.getContext(),
         style?.cornerRadius?.radius ?: 0.0).apply {
+        adjustViewBounds = true
         scaleType = viewMapper.toScaleType(mode ?: ImageContentMode.FIT_CENTER)
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/ImageTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/ImageTest.kt
@@ -18,10 +18,7 @@ package br.com.zup.beagle.android.components
 
 import android.widget.ImageView
 import br.com.zup.beagle.android.components.utils.RoundedImageView
-import br.com.zup.beagle.android.extensions.once
 import br.com.zup.beagle.android.setup.BeagleEnvironment
-import br.com.zup.beagle.android.testutil.CoroutinesTestExtension
-import br.com.zup.beagle.android.testutil.InstantExecutorExtension
 import br.com.zup.beagle.android.testutil.RandomData
 import br.com.zup.beagle.android.view.ViewFactory
 import br.com.zup.beagle.core.Style
@@ -35,19 +32,18 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Assert
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
 private val IMAGE_RES = RandomData.int()
 private const val DEFAULT_URL = "http://teste.com/test.png"
 
-@ExperimentalCoroutinesApi
-@ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
-class ImageViewRendererTest : BaseComponentTest() {
+@DisplayName("Given an Image")
+internal class ImageTest : BaseComponentTest() {
 
     private val imageView: RoundedImageView = mockk(relaxed = true, relaxUnitFun = true)
     private val scaleTypeSlot = slot<ImageView.ScaleType>()
@@ -69,82 +65,109 @@ class ImageViewRendererTest : BaseComponentTest() {
         imageRemote = Image(ImagePath.Remote(DEFAULT_URL, ImagePath.Local("imageName"))).applyStyle(style)
     }
 
-    @Test
-    fun build_should_return_a_image_view_instance_and_set_data_when_path_is_local() {
-        // When
-        val view = imageLocal.buildView(rootView)
+    @DisplayName("When an imageView is built")
+    @Nested
+    inner class BuildingImageViews {
 
-        // Then
-        assertTrue(view is ImageView)
-    }
+        @Test
+        @DisplayName("Then it should return a imageView if imagePath is local")
+        fun testsIfViewIsBuiltAsImageViewWhenImagePathIsLocal() {
+            // When
+            val view = imageLocal.buildView(rootView)
 
-    @Test
-    fun build_should_return_a_beagle_image_view_instance_and_set_data_when_path_is_remote() {
-        //Given
-        imageRemote = Image(ImagePath.Remote(""))
-
-        // When
-        val view = imageRemote.buildView(rootView)
-
-        // Then
-        assertTrue(view is ImageView)
-    }
-
-    @Test
-    fun build_with_image_should_set_fit_center_when_content_mode_is_null_and_design_system_is_not_null() {
-        // Given
-        every { imageView.scaleType = capture(scaleTypeSlot) } just Runs
-        imageLocal = imageLocal.copy(mode = ImageContentMode.FIT_CENTER)
-
-        // When
-        imageLocal.buildView(rootView)
-
-        // Then
-        Assert.assertEquals(scaleType, scaleTypeSlot.captured)
-        verify(exactly = once()) { imageView.setImageResource(IMAGE_RES) }
-    }
-
-    @Test
-    fun build_with_image_should_set_desired_scaleType_and_design_system_is_null() {
-        // Given
-        every { BeagleEnvironment.beagleSdk.designSystem } returns null
-        every { imageView.scaleType = capture(scaleTypeSlot) } just Runs
-        imageLocal = imageLocal.copy(mode = ImageContentMode.FIT_CENTER)
-
-        // When
-        imageLocal.buildView(rootView)
-
-        // Then
-        Assert.assertEquals(scaleType, scaleTypeSlot.captured)
-        verify(exactly = 0) { imageView.setImageResource(IMAGE_RES) }
-    }
-
-    @Test
-    fun build_should_return_a_ImageView_with_desired_scaleType() {
-        // Given
-        val scaleTypeSlot = slot<ImageView.ScaleType>()
-        every { imageView.scaleType = capture(scaleTypeSlot) } just Runs
-
-        // When
-        val view = imageRemote.buildView(rootView)
-
-        // Then
-        Assert.assertTrue(view is ImageView)
-        Assert.assertEquals(scaleType, scaleTypeSlot.captured)
-    }
-
-    @Test
-    fun build_should_setPlaceholder_when_imagePath_is_remote_and_placeholder_is_declared() {
-        imageRemote.style = null
-
-        // When
-        imageRemote.buildView(rootView)
-
-        // Then
-        verify(exactly = once()) {
-            imageView.setImageResource(any())
+            // Then
+            assertTrue(view is ImageView)
         }
 
+        @Test
+        @DisplayName("Then it should return a imageView if imagePath is remote")
+        fun testsIfViewIsBuiltAsImageViewWhenImagePathIsRemote() {
+            //Given
+            imageRemote = Image(ImagePath.Remote(""))
+
+            // When
+            val view = imageRemote.buildView(rootView)
+
+            // Then
+            assertTrue(view is ImageView)
+        }
     }
 
+    @DisplayName("When setting imageView properties")
+    @Nested
+    inner class SettingProperties {
+
+        @Test
+        @DisplayName("Then scaleType should be FIT_CENTER if content mode is NULL and design system is NOT_NULL")
+        fun testsIfTheScaleTypeSetIsFitCenter() {
+            // Given
+            every { imageView.scaleType = capture(scaleTypeSlot) } just Runs
+            imageLocal = imageLocal.copy(mode = ImageContentMode.FIT_CENTER)
+
+            // When
+            imageLocal.buildView(rootView)
+
+            // Then
+            assertEquals(scaleType, scaleTypeSlot.captured)
+            verify(exactly = 1) { imageView.setImageResource(IMAGE_RES) }
+        }
+
+        @Test
+        @DisplayName("Then adjustViewBounds should be TRUE as default")
+        fun testsIfTheAdjustViewBoundsIsSetTrue() {
+            // Given
+            val adjustViewBoundsSlot = slot<Boolean>()
+            every { imageView.adjustViewBounds = capture(adjustViewBoundsSlot) } just Runs
+
+            // When
+            imageLocal.buildView(rootView)
+
+            // Then
+            assertEquals(true, adjustViewBoundsSlot.captured)
+        }
+
+        @Test
+        @DisplayName("Then scaleType should be set as desired if design system is NULL")
+        fun testsTheScaleTypeSetIfDesignSystemIsNull() {
+            // Given
+            val scaleType = ImageView.ScaleType.CENTER_CROP
+            every { BeagleEnvironment.beagleSdk.designSystem } returns null
+            every { imageView.scaleType = capture(scaleTypeSlot) } just Runs
+            imageLocal = imageLocal.copy(mode = ImageContentMode.CENTER_CROP)
+
+            // When
+            imageLocal.buildView(rootView)
+
+            // Then
+            assertEquals(scaleType, scaleTypeSlot.captured)
+            verify(exactly = 0) { imageView.setImageResource(IMAGE_RES) }
+        }
+
+        @Test
+        @DisplayName("Then the scale type should be set as requested")
+        fun testsTheScaleTypeSet() {
+            // Given
+            val scaleTypeSlot = slot<ImageView.ScaleType>()
+            every { imageView.scaleType = capture(scaleTypeSlot) } just Runs
+
+            // When
+            imageRemote.buildView(rootView)
+
+            // Then
+            assertEquals(scaleType, scaleTypeSlot.captured)
+        }
+
+        @Test
+        @DisplayName("Then the placeHolder for a remote image should set a Local Image path")
+        fun testsIfTheSetImageResourceForALocalImageIsCalled() {
+            //Given
+            imageRemote = Image(ImagePath.Remote("", ImagePath.Local("imageName")))
+
+            // When
+            imageRemote.buildView(rootView)
+
+            // Then
+            verify(exactly = 1) { imageView.setImageResource(IMAGE_RES) }
+        }
+    }
 }


### PR DESCRIPTION
### Related Issues
Closes #1525

### Description and Example

When the HEIGHT property is not set for an imageView on Beagle and just a WIDTH is set, some image resize may occur and the imageView created on **Android** will get its HEIGTH according to the imageSource original HEIGHT. That could add some blank spaces inside the image view since the WIDTH set could be lower than the original source image, what will resize the image to keep its aspect ratio.

This PR fixes this behaviour by adding a property for _Android ImageViews_ called **_"adjustViewBounds"_** . This property adjusts the view bounds from imageView according to the resized image as shown below:
 
<img width="374" alt="andImage" src="https://user-images.githubusercontent.com/60155378/117512815-b994e500-af66-11eb-89e3-3ac1c92d11be.png">

This PR also adds:
* A test to check tha this property is set when a imageView is created in Android ("Then adjustViewBounds should be TRUE as default")
* REFACTOR the ImageTest class.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
