### PR TITLE
fix: android RequestData constructor and utilization

### DIFF
--- a/android/automated-tests/src/main/kotlin/br/com/zup/beagle/automatedTests/config/HttpClientDefault.kt
+++ b/android/automated-tests/src/main/kotlin/br/com/zup/beagle/automatedTests/config/HttpClientDefault.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.EOFException
 import java.net.HttpURLConnection
+import java.net.URI
 
 typealias OnSuccess = (responseData: ResponseData) -> Unit
 typealias OnError = (responseData: ResponseData) -> Unit
@@ -75,18 +76,19 @@ class HttpClientDefault : HttpClient, CoroutineScope {
         val urlConnection: HttpURLConnection
 
         try {
-            urlConnection = request.uri.toURL().openConnection() as HttpURLConnection
+            val uri = URI(request.url)
+            urlConnection = uri.toURL().openConnection() as HttpURLConnection
         } catch (e: Exception) {
             throw BeagleApiException(ResponseData(-1, data = byteArrayOf()), request)
         }
 
-        request.headers.forEach {
+        request.httpAdditionalData.headers.forEach {
             urlConnection.setRequestProperty(it.key, it.value)
         }
 
-        addRequestMethod(urlConnection, request.method)
+        addRequestMethod(urlConnection, request.httpAdditionalData.method)
 
-        if (request.body != null) {
+        if (request.httpAdditionalData.body != null) {
             setRequestBody(urlConnection, request)
         }
 
@@ -121,9 +123,9 @@ class HttpClientDefault : HttpClient, CoroutineScope {
     }
 
     private fun setRequestBody(urlConnection: HttpURLConnection, request: RequestData) {
-        urlConnection.setRequestProperty("Content-Length", request.body?.length.toString())
+        urlConnection.setRequestProperty("Content-Length", request.httpAdditionalData.body?.length.toString())
         try {
-            urlConnection.outputStream.write(request.body?.toByteArray())
+            urlConnection.outputStream.write(request.httpAdditionalData.body?.toByteArray())
         } catch (e: Exception) {
             throw BeagleApiException(ResponseData(-1, data = byteArrayOf()), request)
         }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/form/core/FormSubmitter.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/form/core/FormSubmitter.kt
@@ -20,18 +20,18 @@ import android.net.Uri
 import br.com.zup.beagle.android.action.FormMethodType
 import br.com.zup.beagle.android.action.FormRemoteAction
 import br.com.zup.beagle.android.data.BeagleApi
+import br.com.zup.beagle.android.data.formatUrl
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.exception.BeagleException
+import br.com.zup.beagle.android.networking.HttpAdditionalData
 import br.com.zup.beagle.android.networking.HttpMethod
 import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.networking.urlbuilder.UrlBuilder
 import br.com.zup.beagle.android.networking.urlbuilder.UrlBuilderFactory
-import br.com.zup.beagle.android.setup.BeagleEnvironment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import java.net.URI
 import kotlin.coroutines.CoroutineContext
 
 @Deprecated(Constants.FORM_DEPRECATED_MESSAGE)
@@ -62,17 +62,19 @@ internal class FormSubmitter(
 
     private fun createRequestData(form: FormRemoteAction, formsValue: Map<String, String>): RequestData {
         val action = createUrl(form, formsValue)
-        val newUrl = urlBuilder.format(BeagleEnvironment.beagleSdk.config.baseUrl, action)
+        val newUrl = action.formatUrl(urlBuilder = urlBuilder)
 
         return RequestData(
-            uri = URI(newUrl),
-            method = when (form.method) {
-                FormMethodType.POST -> HttpMethod.POST
-                FormMethodType.GET -> HttpMethod.GET
-                FormMethodType.PUT -> HttpMethod.PUT
-                FormMethodType.DELETE -> HttpMethod.DELETE
-            },
-            body = createBody(form, formsValue)
+            url = newUrl,
+            httpAdditionalData = HttpAdditionalData(
+                method = when (form.method) {
+                    FormMethodType.POST -> HttpMethod.POST
+                    FormMethodType.GET -> HttpMethod.GET
+                    FormMethodType.PUT -> HttpMethod.PUT
+                    FormMethodType.DELETE -> HttpMethod.DELETE
+                },
+                body = createBody(form, formsValue)
+            )
         )
     }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/BeagleApi.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/BeagleApi.kt
@@ -57,12 +57,11 @@ internal class BeagleApi(
             val exception = BeagleApiException(
                 response,
                 request,
-                genericErrorMessage(transformedRequest.url ?: ""))
+                genericErrorMessage(transformedRequest.url),
+            )
 
             BeagleMessageLogs.logUnknownHttpError(exception)
-            cont.resumeWithException(
-                exception
-            )
+            cont.resumeWithException(exception)
         })
         cont.invokeOnCancellation {
             call.cancel()
@@ -71,12 +70,12 @@ internal class BeagleApi(
 
     private fun mapperDeprecatedFields(request: RequestData): RequestData {
         val headers = request.headers + FIXED_HEADERS
-        val url = request.url?.formatUrl() ?: ""
+        val url = request.url.formatUrl()
         val uri = if (url.isNotEmpty()) URI(url) else request.uri
         var additionalData = request.httpAdditionalData
 
         additionalData = additionalData.copy(
-            headers = (additionalData.headers ?: hashMapOf()) + FIXED_HEADERS,
+            headers = (additionalData.headers) + FIXED_HEADERS,
         )
 
         return request.copy(

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/ComponentRequester.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/ComponentRequester.kt
@@ -31,7 +31,7 @@ internal class ComponentRequester(
 
     @Throws(BeagleException::class)
     suspend fun fetchComponent(requestData: RequestData): ServerDrivenComponent {
-        val url = requestData.url ?: ""
+        val url = requestData.url
         val beagleCache = cacheManager.restoreBeagleCacheForUrl(url)
         val responseBody = if (beagleCache?.isExpired() == false) {
             beagleCache.json

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/data/StringExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/data/StringExtensions.kt
@@ -16,24 +16,24 @@
 
 package br.com.zup.beagle.android.data
 
+import br.com.zup.beagle.android.networking.HttpAdditionalData
 import br.com.zup.beagle.android.networking.HttpMethod
 import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.networking.urlbuilder.UrlBuilder
 import br.com.zup.beagle.android.networking.urlbuilder.UrlBuilderFactory
 import br.com.zup.beagle.android.setup.BeagleEnvironment
-import java.net.URI
 
 internal fun String.toRequestData(urlBuilder: UrlBuilder = UrlBuilderFactory().make(),
                                   beagleEnvironment: BeagleEnvironment = BeagleEnvironment,
                                   method: HttpMethod = HttpMethod.GET): RequestData {
     val newUrl = this.formatUrl(urlBuilder, beagleEnvironment)
     return RequestData(
-        uri = URI(newUrl),
-        method = method
+        url = newUrl,
+        httpAdditionalData = HttpAdditionalData(method = method)
     )
 }
 
-internal fun String.formatUrl(urlBuilder: UrlBuilder = UrlBuilderFactory().make(),
-                              beagleEnvironment: BeagleEnvironment = BeagleEnvironment): String? {
-    return urlBuilder.format(beagleEnvironment.beagleSdk.config.baseUrl, this)
-}
+internal fun String.formatUrl(
+    urlBuilder: UrlBuilder = UrlBuilderFactory().make(),
+    beagleEnvironment: BeagleEnvironment = BeagleEnvironment,
+) = urlBuilder.format(beagleEnvironment.beagleSdk.config.baseUrl, this) ?: ""

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/imagedownloader/DefaultImageDownloader.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/imagedownloader/DefaultImageDownloader.kt
@@ -36,7 +36,8 @@ internal class DefaultImageDownloader : BeagleImageDownloader {
         imageView.post {
             rootView.getLifecycleOwner().lifecycleScope.launch(CoroutineDispatchers.IO) {
                 val bitmap = try {
-                    imageDownloader.getRemoteImage(url.formatUrl() ?: url, imageView.width, imageView.height)
+                    val formattedUrl = url.formatUrl().takeIf { it.isNotEmpty() } ?: url
+                    imageDownloader.getRemoteImage(formattedUrl, imageView.width, imageView.height)
                 } catch (e: Exception) {
                     BeagleMessageLogs.errorWhileTryingToDownloadImage(url, e)
                     null

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/logger/BeagleMessageLogs.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/logger/BeagleMessageLogs.kt
@@ -25,10 +25,10 @@ internal object BeagleMessageLogs {
     fun logHttpRequestData(requestData: RequestData) {
         BeagleLoggerProxy.info("""
             *** HTTP REQUEST ***
-            Uri=${requestData.uri}
-            Method=${requestData.method}
-            Headers=${requestData.headers}
-            Body=${requestData.body}
+            Url=${requestData.url}
+            Method=${requestData.httpAdditionalData.method}
+            Headers=${requestData.httpAdditionalData.headers}
+            Body=${requestData.httpAdditionalData.body}
         """.trimIndent())
     }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpAdditionalData.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/networking/HttpAdditionalData.kt
@@ -29,7 +29,7 @@ import kotlinx.android.parcel.Parcelize
 @BeagleJson
 @Parcelize
 data class HttpAdditionalData(
-    val method: HttpMethod? = HttpMethod.GET,
-    val headers: Map<String, String>? = hashMapOf(),
+    val method: HttpMethod = HttpMethod.GET,
+    val headers: Map<String, String> = hashMapOf(),
     val body: String? = null,
 ) : Parcelable

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/utils/ViewGroupExtensions.kt
@@ -47,7 +47,7 @@ fun ViewGroup.loadView(
 ) {
     loadView(
         viewGroup = this,
-        rootView = ActivityRootView(activity, this.id, requestData.url ?: ""),
+        rootView = ActivityRootView(activity, this.id, requestData.url),
         requestData = requestData,
         listener = null,
         newListener = null,
@@ -65,7 +65,7 @@ fun ViewGroup.loadView(
 ) {
     loadView(
         viewGroup = this,
-        rootView = FragmentRootView(fragment, this.id, requestData.url ?: ""),
+        rootView = FragmentRootView(fragment, this.id, requestData.url),
         requestData = requestData,
         listener = null,
         newListener = null,
@@ -85,7 +85,7 @@ fun ViewGroup.loadView(
 ) {
     loadView(
         this,
-        ActivityRootView(activity, this.id, requestData.url ?: ""),
+        ActivityRootView(activity, this.id, requestData.url),
         requestData,
         null,
         listener,
@@ -104,7 +104,7 @@ fun ViewGroup.loadView(
     listener: OnServerStateChanged? = null,
 ) {
     loadView(this,
-        FragmentRootView(fragment, this.id, requestData.url ?: ""),
+        FragmentRootView(fragment, this.id, requestData.url),
         requestData,
         null,
         listener

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/BeagleActivity.kt
@@ -35,13 +35,12 @@ import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.utils.BeagleRetry
-import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.android.utils.toComponent
 import br.com.zup.beagle.android.view.mapper.toRequestData
 import br.com.zup.beagle.android.view.viewmodel.BeagleScreenViewModel
 import br.com.zup.beagle.android.view.viewmodel.ViewState
+import br.com.zup.beagle.core.ServerDrivenComponent
 import kotlinx.android.parcel.Parcelize
-import java.net.URI
 
 sealed class ServerDrivenState {
 
@@ -310,7 +309,7 @@ abstract class BeagleActivity : AppCompatActivity() {
         if (supportFragmentManager.fragments.size == 0) {
             screen?.let { screen ->
                 fetch(
-                    RequestData(uri = URI.create("")),
+                    RequestData(url = ""),
                     beagleSerializer.deserializeComponent(screen)
                 )
             } ?: run {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleNavigator.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleNavigator.kt
@@ -33,7 +33,6 @@ import br.com.zup.beagle.android.networking.urlbuilder.UrlBuilderFactory
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.view.BeagleActivity
 import br.com.zup.beagle.android.widget.RootView
-import java.net.URI
 
 internal object BeagleNavigator {
 
@@ -73,9 +72,7 @@ internal object BeagleNavigator {
                     route.fallback,
                 )
                 is Route.Local -> context.navigateTo(
-                    RequestData(
-                        URI(""),
-                    ),
+                    RequestData(url = ""),
                     route.screen,
                 )
             }
@@ -170,12 +167,7 @@ internal object BeagleNavigator {
         val url = (route.url.value as String).formatUrl()
         return RequestData(
             url = url,
-            method = httpAdditionalData.method ?: HttpMethod.GET,
-            body = httpAdditionalData.body,
-            headers = httpAdditionalData.headers ?: hashMapOf(),
             httpAdditionalData = httpAdditionalData,
-            uri = URI(url),
         )
     }
-
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/custom/BeagleView.kt
@@ -30,7 +30,6 @@ import br.com.zup.beagle.android.view.viewmodel.BeagleViewModel
 import br.com.zup.beagle.android.view.viewmodel.ViewState
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.core.ServerDrivenComponent
-import java.net.URI
 
 @Deprecated("It was deprecated in version 1.2.0 and will be removed in a future version." +
     " Use OnServerStateChanged instead.", replaceWith = ReplaceWith("OnServerStateChanged",
@@ -75,7 +74,7 @@ internal class BeagleView(
 
     fun updateView(url: String, view: View) {
         val urlFormatted = url.formatUrl()
-        loadView(RequestData(url = urlFormatted, uri = URI(urlFormatted)), view)
+        loadView(RequestData(url = urlFormatted), view)
     }
 
     private fun loadView(requestData: RequestData, view: View?) {

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/mapper/ScreenRequestMapper.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/mapper/ScreenRequestMapper.kt
@@ -25,14 +25,16 @@ import br.com.zup.beagle.android.networking.urlbuilder.UrlBuilderFactory
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.view.ScreenMethod
 import br.com.zup.beagle.android.view.ScreenRequest
-import java.net.URI
 
 internal fun ScreenRequest.toRequestData(
     urlBuilder: UrlBuilder = UrlBuilderFactory().make(),
     beagleEnvironment: BeagleEnvironment = BeagleEnvironment,
 ): RequestData {
-    return ScreenRequestMapper.toRequestData(urlBuilder = urlBuilder,
-        beagleEnvironment = beagleEnvironment, screenRequest = this)
+    return ScreenRequestMapper.toRequestData(
+        urlBuilder = urlBuilder,
+        beagleEnvironment = beagleEnvironment,
+        screenRequest = this,
+    )
 }
 
 internal object ScreenRequestMapper {
@@ -45,11 +47,7 @@ internal object ScreenRequestMapper {
         val newUrl = screenRequest.url.formatUrl(urlBuilder, beagleEnvironment)
         val method = generateRequestDataMethod(screenRequest.method)
         return RequestData(
-            uri = URI(newUrl),
-            method = method,
-            headers = screenRequest.headers,
-            body = screenRequest.body,
-            url = newUrl ?: "",
+            url = newUrl,
             httpAdditionalData = HttpAdditionalData(
                 method = method,
                 headers = screenRequest.headers,

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/mapper/SendRequestActionMapper.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/mapper/SendRequestActionMapper.kt
@@ -25,7 +25,6 @@ import br.com.zup.beagle.android.networking.HttpMethod
 import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.networking.ResponseData
 import br.com.zup.beagle.android.view.viewmodel.Response
-import java.net.URI
 
 internal fun SendRequestInternal.toRequestData(): RequestData = SendRequestActionMapper.toRequestData(this)
 
@@ -37,11 +36,7 @@ internal object SendRequestActionMapper {
         val headers = sendRequest.headers ?: mapOf()
         val urlFormatted = sendRequest.url.formatUrl()
         return RequestData(
-            uri = URI(urlFormatted),
-            method = method,
-            headers = headers,
-            body = sendRequest.data?.toString(),
-            url = urlFormatted ?: "",
+            url = urlFormatted,
             httpAdditionalData = HttpAdditionalData(
                 method = method,
                 body = sendRequest.data?.toString(),

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
@@ -28,13 +28,12 @@ import br.com.zup.beagle.android.utils.BeagleRetry
 import br.com.zup.beagle.android.utils.CoroutineDispatchers
 import br.com.zup.beagle.core.IdentifierComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
-import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.net.URI
+import java.util.concurrent.atomic.AtomicReference
 
 sealed class ViewState {
     data class Error(val throwable: Throwable, val retry: BeagleRetry) : ViewState()
@@ -61,7 +60,7 @@ internal open class BeagleViewModel(
 
     fun fetchForCache(url: String) = viewModelScope.launch(ioDispatcher) {
         try {
-            componentRequester.fetchComponent(RequestData(url = url, uri = URI(url)))
+            componentRequester.fetchComponent(RequestData(url = url))
         } catch (exception: BeagleException) {
             BeagleLoggerProxy.warning(exception.message)
         }
@@ -91,7 +90,7 @@ internal open class BeagleViewModel(
         private fun fetchComponents() {
             job = coroutineScope.launch(ioDispatcher) {
                 val identifier = getComponentIdentifier()
-                if (requestData.url?.isNotEmpty() == true) {
+                if (requestData.url.isNotEmpty()) {
                     try {
                         setLoading(true)
                         val component = componentRequester.fetchComponent(requestData)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/cache/CacheManagerTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/cache/CacheManagerTest.kt
@@ -35,14 +35,13 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import io.mockk.verifySequence
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
-import java.net.URI
+import org.junit.jupiter.api.Test
 
 private val URL = RandomData.string()
 private val BEAGLE_HASH_KEY = "$URL#hash"
@@ -50,7 +49,7 @@ private val BEAGLE_JSON_KEY = "$URL#json"
 private val BEAGLE_TIME_KEY = "$URL#time"
 private val BEAGLE_HASH_VALUE = RandomData.string()
 private val BEAGLE_JSON_VALUE = RandomData.string()
-private val REQUEST_DATA = RequestData(uri = URI(""), url = URL)
+private val REQUEST_DATA = RequestData(url = URL)
 private val RESPONSE_BODY = RandomData.string()
 private const val BEAGLE_HASH = "beagle-hash"
 private const val INVALIDATION_TIME: Long = 0

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/data/ComponentRequesterTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/data/ComponentRequesterTest.kt
@@ -32,15 +32,14 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
-import java.net.URI
+import org.junit.jupiter.api.Test
 
 private val URL = RandomData.string()
-private val REQUEST_DATA = RequestData(url = URL, uri = URI(""))
+private val REQUEST_DATA = RequestData(url = URL)
 
 @DisplayName("Given a Component Requester")
 @ExperimentalCoroutinesApi

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/RequestDataFactory.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/mockdata/RequestDataFactory.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.android.mockdata
 
 import br.com.zup.beagle.android.data.serializer.makeButtonJson
+import br.com.zup.beagle.android.networking.HttpAdditionalData
 import br.com.zup.beagle.android.networking.HttpMethod
 import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.networking.ResponseData
@@ -30,8 +31,10 @@ fun makeResponseData() = ResponseData(
 )
 
 fun makeRequestData() = RequestData(
-    uri = URI(RandomData.string()),
-    method =  HttpMethod.GET,
-    headers = mapOf("Authorization" to RandomData.string()),
-    body = makeButtonJson()
+    url = RandomData.string(),
+    httpAdditionalData = HttpAdditionalData(
+        method =  HttpMethod.GET,
+        headers = mapOf("Authorization" to RandomData.string()),
+        body = makeButtonJson()
+    )
 )

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/BeagleActivityTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/BeagleActivityTest.kt
@@ -17,37 +17,29 @@
 package br.com.zup.beagle.android.view
 
 import android.app.Application
-import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import br.com.zup.beagle.R
 import br.com.zup.beagle.android.BaseSoLoaderTest
-import br.com.zup.beagle.android.BaseTest
-import br.com.zup.beagle.android.MyBeagleSetup
 import br.com.zup.beagle.android.components.Text
 import br.com.zup.beagle.android.components.layout.Screen
 import br.com.zup.beagle.android.data.ComponentRequester
 import br.com.zup.beagle.android.networking.RequestData
-import br.com.zup.beagle.android.setup.BeagleSdk
 import br.com.zup.beagle.android.testutil.CoroutinesTestExtension
 import br.com.zup.beagle.android.testutil.InstantExecutorExtension
 import br.com.zup.beagle.android.view.viewmodel.AnalyticsViewModel
 import br.com.zup.beagle.android.view.viewmodel.BeagleScreenViewModel
-import com.facebook.yoga.YogaNode
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -55,7 +47,6 @@ import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.net.URI
 
 @Config(application = ApplicationTest::class)
 @RunWith(AndroidJUnit4::class)
@@ -75,7 +66,7 @@ class BeagleActivityTest : BaseSoLoaderTest() {
 
     @Before
     fun mockBeforeTest() {
-        coEvery { componentRequester.fetchComponent(RequestData(uri = URI(""), url = "/url")) } returns component
+        coEvery { componentRequester.fetchComponent(RequestData(url = "/url")) } returns component
         beagleViewModel = BeagleScreenViewModel(ioDispatcher = TestCoroutineDispatcher(), componentRequester)
         prepareViewModelMock(beagleViewModel)
         val activityScenario: ActivityScenario<ServerDrivenActivity> = ActivityScenario.launch(ServerDrivenActivity::class.java)
@@ -89,7 +80,7 @@ class BeagleActivityTest : BaseSoLoaderTest() {
     fun `Given a screen request When navigate to Then should call BeagleFragment newInstance with right parameters`() = runBlockingTest {
         // Given
         val url = "/url"
-        val screenRequest = RequestData(uri = URI(""), url = url)
+        val screenRequest = RequestData(url = url)
         prepareViewModelMock(analyticsViewModel)
         every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot)) } just Runs
 
@@ -104,7 +95,7 @@ class BeagleActivityTest : BaseSoLoaderTest() {
     @Test
     fun `Given a screen with id When navigate to Then should call BeagleFragment newInstance with right parameters`() = runBlockingTest {
         // Given
-        val screenRequest = RequestData(uri = URI(""), url = "")
+        val screenRequest = RequestData(url = "")
         val screenId = "myScreen"
         val screen = Screen(id = screenId, child = component)
 
@@ -122,7 +113,7 @@ class BeagleActivityTest : BaseSoLoaderTest() {
     @Test
     fun `Given a screen with identifier When navigate to Then should call BeagleFragment newInstance with right parameters`() = runBlockingTest {
         // Given
-        val screenRequest = RequestData(uri = URI(""), url = "")
+        val screenRequest = RequestData(url = "")
         val screenIdentifier = "myScreen"
         val screen = Screen(identifier = screenIdentifier, child = component)
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/BeagleNavigatorTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/BeagleNavigatorTest.kt
@@ -34,21 +34,26 @@ import br.com.zup.beagle.android.logger.BeagleLoggerProxy
 import br.com.zup.beagle.android.navigation.DeepLinkHandler
 import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.networking.urlbuilder.UrlBuilder
-import br.com.zup.beagle.android.networking.urlbuilder.UrlBuilderDefault
 import br.com.zup.beagle.android.setup.BeagleEnvironment
-import br.com.zup.beagle.android.setup.BeagleSdk
 import br.com.zup.beagle.android.testutil.RandomData
 import br.com.zup.beagle.android.view.custom.BeagleNavigator
-import br.com.zup.beagle.android.widget.RootView
-import io.mockk.*
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
-import java.net.URI
+import org.junit.jupiter.api.Test
 
 private val route = Route.Remote(RandomData.httpUrl())
 private val url = RandomData.httpUrl()
@@ -220,7 +225,7 @@ class BeagleNavigatorTest : BaseTest() {
             // Given
             val url = (route.url.value as String).formatUrl()
 
-            val requestData = RequestData(url = url, uri = URI(url))
+            val requestData = RequestData(url = url)
             every { context.navigateTo(requestData, null) } just Runs
 
             // When

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/custom/BeagleViewTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/custom/BeagleViewTest.kt
@@ -53,7 +53,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.net.URI
 
 @Config(application = ApplicationTest::class)
 @RunWith(AndroidJUnit4::class)
@@ -131,7 +130,7 @@ internal class BeagleViewTest : BaseTest() {
     @Test
     fun `Given a Beagle View When loadView with Request Data Then should call fetch component`() {
         // Given
-        val requestDataFake = RequestData(url = url, uri = URI(url))
+        val requestDataFake = RequestData(url = url)
 
         // when
         beagleView.loadView(requestDataFake)

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/mapper/ScreenRequestMapperTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/mapper/ScreenRequestMapperTest.kt
@@ -27,11 +27,12 @@ import br.com.zup.beagle.android.view.ScreenRequest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
-import org.junit.jupiter.api.AfterEach
 import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.net.URI
 
 private val PATH = RandomData.httpUrl()
 private val SCREEN_REQUEST = ScreenRequest(
@@ -40,15 +41,14 @@ private val SCREEN_REQUEST = ScreenRequest(
     headers = mapOf("header" to "teste"),
 )
 private val EXPECTED_RESULT = RequestData(
-    uri = URI(""),
-    body = "body",
-    headers = mapOf("header" to "teste"),
+    url = PATH,
     httpAdditionalData = HttpAdditionalData(
         headers = mapOf("header" to "teste"),
         body = "body",
     ),
 )
 
+@DisplayName("Given a ScreenRequestMapper")
 class ScreenRequestMapperTest {
 
     private val urlBuilder: UrlBuilder = mockk()
@@ -56,7 +56,7 @@ class ScreenRequestMapperTest {
 
     @BeforeEach
     fun setUp() {
-        every { urlBuilder.format(environment.beagleSdk.config.baseUrl, SCREEN_REQUEST.url) } returns ""
+        every { urlBuilder.format(environment.beagleSdk.config.baseUrl, SCREEN_REQUEST.url) } returns PATH
     }
 
     @AfterEach
@@ -64,49 +64,56 @@ class ScreenRequestMapperTest {
         unmockkAll()
     }
 
-    @Test
-    fun `should return request data when using extension function to mapper`() {
-        // When
-        val requestData = SCREEN_REQUEST.toRequestData(urlBuilder, environment)
+    @Nested
+    @DisplayName("When toRequestData is called")
+    inner class ToRequestData {
 
-        // Then
-        assertEquals(EXPECTED_RESULT, requestData)
-    }
+        @Test
+        @DisplayName("Then should convert to RequestData via extension function")
+        fun requestDataViaExtension() {
+            // When
+            val requestData = SCREEN_REQUEST.toRequestData(urlBuilder, environment)
 
-    @Test
-    fun `should return request data when mapper`() {
-        // When
-        val requestData = ScreenRequestMapper.toRequestData(urlBuilder, environment, SCREEN_REQUEST)
-
-        // Then
-        assertEquals(EXPECTED_RESULT, requestData)
-    }
-
-    @Test
-    fun `should return request data with correct method when mapper`() {
-        // Given
-        val screenRequests = listOf(
-            SCREEN_REQUEST.copy(method = ScreenMethod.GET),
-            SCREEN_REQUEST.copy(method = ScreenMethod.POST),
-            SCREEN_REQUEST.copy(method = ScreenMethod.PUT),
-            SCREEN_REQUEST.copy(method = ScreenMethod.DELETE),
-            SCREEN_REQUEST.copy(method = ScreenMethod.HEAD),
-            SCREEN_REQUEST.copy(method = ScreenMethod.PATCH)
-        )
-
-        // When
-        val result = mutableListOf<RequestData>()
-        screenRequests.forEach {
-            result.add(ScreenRequestMapper.toRequestData(urlBuilder, environment, it))
+            // Then
+            assertEquals(EXPECTED_RESULT, requestData)
         }
 
-        // Then
-        val expectedResult = screenRequests.map {
-            val method = HttpMethod.valueOf(it.method.name)
-            val httpAdditionalData = EXPECTED_RESULT.httpAdditionalData.copy(method = method)
-            EXPECTED_RESULT.copy(method = method, httpAdditionalData = httpAdditionalData)
-        }
-        assertEquals(expectedResult, result)
-    }
+        @Test
+        @DisplayName("Then should return RequestData via mapper")
+        fun requestDataViaMapper() {
+            // When
+            val requestData = ScreenRequestMapper.toRequestData(urlBuilder, environment, SCREEN_REQUEST)
 
+            // Then
+            assertEquals(EXPECTED_RESULT, requestData)
+        }
+
+        @Test
+        @DisplayName("Then should return RequestData with correct method")
+        fun requestDataMethod() {
+            // Given
+            val screenRequests = listOf(
+                SCREEN_REQUEST.copy(method = ScreenMethod.GET),
+                SCREEN_REQUEST.copy(method = ScreenMethod.POST),
+                SCREEN_REQUEST.copy(method = ScreenMethod.PUT),
+                SCREEN_REQUEST.copy(method = ScreenMethod.DELETE),
+                SCREEN_REQUEST.copy(method = ScreenMethod.HEAD),
+                SCREEN_REQUEST.copy(method = ScreenMethod.PATCH)
+            )
+
+            // When
+            val result = mutableListOf<RequestData>()
+            screenRequests.forEach {
+                result.add(ScreenRequestMapper.toRequestData(urlBuilder, environment, it))
+            }
+
+            // Then
+            val expectedResult = screenRequests.map {
+                val method = HttpMethod.valueOf(it.method.name)
+                val httpAdditionalData = EXPECTED_RESULT.httpAdditionalData.copy(method = method)
+                EXPECTED_RESULT.copy(method = method, httpAdditionalData = httpAdditionalData)
+            }
+            assertEquals(expectedResult, result)
+        }
+    }
 }

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModelTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/view/viewmodel/BeagleViewModelTest.kt
@@ -28,7 +28,6 @@ import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.testutil.CoroutinesTestExtension
 import br.com.zup.beagle.android.testutil.InstantExecutorExtension
 import br.com.zup.beagle.android.testutil.RandomData
-import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.core.IdentifierComponent
 import br.com.zup.beagle.core.ServerDrivenComponent
 import io.mockk.Runs
@@ -42,14 +41,13 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import java.net.URI
 
 @DisplayName("Given a BeagleViewModel")
 @ExperimentalCoroutinesApi
@@ -95,7 +93,7 @@ class BeagleViewModelTest : BaseTest() {
         @Suppress("UNCHECKED_CAST")
         fun testGivenAScreenRequestWhenFetchComponentShouldPostRenderViewState() {
             // Given
-            val screenRequest = RequestData(uri = URI(""), url = RandomData.httpUrl())
+            val screenRequest = RequestData(url = RandomData.httpUrl())
 
             // When
             beagleUIViewModel.fetchComponent(screenRequest).observeForever(observer)
@@ -112,7 +110,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenAScreenRequestThrowsExceptionWhenFetchShouldPostAErrorViewState() {
             // Given
-            val screenRequest = RequestData(uri = URI(""), url = RandomData.httpUrl())
+            val screenRequest = RequestData(url = RandomData.httpUrl())
             val exception = BeagleException("Error")
             coEvery { componentRequester.fetchComponent(any()) } throws exception
 
@@ -131,7 +129,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenAScreenRequestThrowsExceptionWhenFetchShouldPostAErrorViewStateRetry() {
             // Given
-            val screenRequest = RequestData(uri = URI(""), url = RandomData.httpUrl())
+            val screenRequest = RequestData(url = RandomData.httpUrl())
             val exception = BeagleException("Error")
 
             coEvery { componentRequester.fetchComponent(any()) } throws exception andThen component
@@ -155,7 +153,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenAServerDrivenComponentWhenFetchComponentsCalledShouldPostViewStateDoRender() {
             //GIVEN
-            val screenRequest = RequestData(uri = URI(""), url = "")
+            val screenRequest = RequestData(url = "")
 
             //WHEN
             beagleUIViewModel.fetchComponent(screenRequest, component).observeForever(observer)
@@ -168,7 +166,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenAIdentifierComponentWhenFetchComponentsCalledShouldPostViewStateDoRender() {
             //GIVEN
-            val screenRequest = RequestData(uri = URI(""), url = "")
+            val screenRequest = RequestData(url = "")
             val component: IdentifierComponent = mockk()
             val id = "id"
             every { component.id } returns id
@@ -184,7 +182,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenANullScreenComponentWhenFetchComponentsCalledShouldPostViewStateDoRender() {
             //GIVEN
-            val screenRequest = RequestData(uri = URI(""), url = "url")
+            val screenRequest = RequestData(url = "url")
 
 
             //WHEN
@@ -200,7 +198,7 @@ class BeagleViewModelTest : BaseTest() {
             //GIVEN
             every { beagleSdk.config.baseUrl } returns "http://localhost:2020/"
 
-            val screenRequest = RequestData(uri = URI(""), url = "http://localhost:2020/test")
+            val screenRequest = RequestData(url = "http://localhost:2020/test")
 
             //WHEN
             beagleUIViewModel.fetchComponent(screenRequest, null).observeForever(observer)
@@ -213,7 +211,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenAScreenComponentWhenFetchComponentCalledShouldPostViewStateDoRenderUsingIdentifierAsScreenId() {
             //Given
-            val screenRequest = RequestData(uri = URI(""), url = "")
+            val screenRequest = RequestData(url = "")
             val component: ScreenComponent = mockk()
             val id = "id"
             val identifier = "identifier"
@@ -251,7 +249,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenANullJobInFetchComponentLiveDataWhenIsFetchComponentCalledShouldReturnFalse() {
             //Given
-            val screenRequest = RequestData(uri = URI(""), url = "")
+            val screenRequest = RequestData(url = "")
 
             beagleUIViewModel.fetchComponent(screenRequest)
             beagleUIViewModel.fetchComponent?.job = null
@@ -267,7 +265,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenAJobCompletedInFetchComponentLiveDataWhenIsFetchComponentCalledShouldReturnFalse() {
             //Given
-            val screenRequest = RequestData(uri = URI(""), url = "")
+            val screenRequest = RequestData(url = "")
             val mockJob = Job()
             mockJob.complete()
 
@@ -285,7 +283,7 @@ class BeagleViewModelTest : BaseTest() {
         @Test
         fun testGivenAJobNotCompletedInFetchComponentLiveDataWhenIsFetchComponentCalledShouldPostViewStateDoCancelAndReturnTrue() {
             //Given
-            val screenRequest = RequestData(uri = URI(""), url = "")
+            val screenRequest = RequestData(url = "")
             val mockJob = Job()
 
             beagleUIViewModel.fetchComponent(screenRequest).observeForever(observer)

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/MainActivity.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/MainActivity.kt
@@ -20,8 +20,8 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.utils.newServerDrivenIntent
-import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.android.view.ServerDrivenActivity
 import br.com.zup.beagle.sample.activities.NavigationBarActivity
 import br.com.zup.beagle.sample.constants.SAMPLE_ENDPOINT
@@ -71,7 +71,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
             R.id.gridView -> goToFragment(GridViewFragment.newInstance())
             R.id.webView -> goToFragment(WebViewFragment.newInstance())
             R.id.composeComponent -> goToFragment(ComposeComponentFragment.newInstance())
-            R.id.sampleBff -> startActivity(newServerDrivenIntent<ServerDrivenActivity>(ScreenRequest(SAMPLE_ENDPOINT)))
+            R.id.sampleBff -> startActivity(newServerDrivenIntent<ServerDrivenActivity>(RequestData(SAMPLE_ENDPOINT)))
         }
     }
 

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/config/HttpClientDefault.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/config/HttpClientDefault.kt
@@ -80,19 +80,18 @@ class HttpClientDefault : HttpClient, CoroutineScope {
 
         try {
             val uri = URI(request.url)
-
             urlConnection = uri.toURL().openConnection() as HttpURLConnection
         } catch (e: Exception) {
             throw BeagleApiException(ResponseData(-1, data = byteArrayOf()), request)
         }
         
-        request.httpAdditionalData.headers?.forEach {
+        request.httpAdditionalData.headers.forEach {
             urlConnection.setRequestProperty(it.key, it.value)
         }
 
-        addRequestMethod(urlConnection, request.method)
+        addRequestMethod(urlConnection, request.httpAdditionalData.method)
 
-        val body = request.httpAdditionalData?.body ?: request.body
+        val body = request.httpAdditionalData.body
         if (body != null) {
             setRequestBody(urlConnection, request)
         }
@@ -128,9 +127,9 @@ class HttpClientDefault : HttpClient, CoroutineScope {
     }
 
     private fun setRequestBody(urlConnection: HttpURLConnection, request: RequestData) {
-        urlConnection.setRequestProperty("Content-Length", request.body?.length.toString())
+        urlConnection.setRequestProperty("Content-Length", request.httpAdditionalData.body?.length.toString())
         try {
-            urlConnection.outputStream.write(request.body?.toByteArray())
+            urlConnection.outputStream.write(request.httpAdditionalData.body?.toByteArray())
         } catch (e: Exception) {
             throw BeagleApiException(ResponseData(-1, data = byteArrayOf()), request)
         }


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>


### Related Issues

Fixes #1540 

### Description and Example

This PR fixes the `RequestData` class constructor and remove all utilization of deprecated params. This will help to change it in 2.0 version.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
