### PR TITLE
fix: Android GlobalContext set object

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/context/GlobalContext.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/context/GlobalContext.kt
@@ -54,7 +54,7 @@ object GlobalContext {
      * @param path represents the path that it will save this information.
      */
     fun set(value: Any, path: String? = null) {
-        val result = contextDataManipulator.set(globalContext, path, value)
+        val result = contextDataManipulator.set(globalContext, path, value.normalizeContextValue())
         notifyContextChanges(result)
     }
 

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/context/GlobalContextTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/context/GlobalContextTest.kt
@@ -18,10 +18,19 @@ package br.com.zup.beagle.android.context
 
 import br.com.zup.beagle.android.BaseTest
 import br.com.zup.beagle.android.testutil.RandomData
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+data class User(
+    val id: String,
+)
+
+@DisplayName("Given a GlobalContext")
 class GlobalContextTest : BaseTest() {
 
     @BeforeEach
@@ -31,156 +40,203 @@ class GlobalContextTest : BaseTest() {
         GlobalContext.clear()
     }
 
-    @Test
-    fun get_should_return_context_root_when_no_path_is_listed() {
-        val value = GlobalContext.get()
+    @Nested
+    @DisplayName("When get is called")
+    inner class GetContext {
 
-        assertEquals("", value)
+        @Test
+        @DisplayName("Then should return root if path is empty")
+        fun getRootPath() {
+            // When
+            val value = GlobalContext.get()
+
+            // Then
+            assertEquals("", value)
+        }
+
+        @Test
+        @DisplayName("Then should return value with path")
+        fun getValueWithPath() {
+            // Given
+            val path = RandomData.string()
+            val value = RandomData.string()
+            GlobalContext.set(value = value, path = path)
+
+            // When
+            val result = GlobalContext.get(path)
+
+            // Then
+            assertEquals(value, result)
+        }
+
+        @Test
+        @DisplayName("Then should return null if path does not exist")
+        fun getNullInvalidPath() {
+            // Given
+            val path = RandomData.string()
+
+            // Then
+            val value = GlobalContext.get(path)
+
+            // Then
+            assertNull(value)
+        }
     }
 
-    @Test
-    fun get_should_return_context_with_path() {
-        // Given
-        val path = RandomData.string()
-        val value = RandomData.string()
-        GlobalContext.set(value = value, path = path)
+    @Nested
+    @DisplayName("When set is called")
+    inner class SetContext {
 
-        // When
-        val result = GlobalContext.get(path)
+        @Test
+        @DisplayName("Then should set value to root if path is null")
+        fun setValueToRoot() {
+            // Given
+            val value = RandomData.string()
 
-        // Then
-        assertEquals(value, result)
+            // When
+            GlobalContext.set(value = value)
+            val result = GlobalContext.get()
+
+            // Then
+            assertEquals(value, result)
+        }
+
+        @Test
+        @DisplayName("Then should set value to the given path")
+        fun setValueToPath() {
+            // Given
+            val value = RandomData.string()
+            val path = RandomData.string()
+
+            // When
+            GlobalContext.set(value = value, path = path)
+            val result = GlobalContext.get(path)
+
+            // Then
+            assertEquals(value, result)
+        }
+
+        @Test
+        @DisplayName("Then should not override other paths")
+        fun setShouldNotOverride() {
+            // Given
+            val valueOne = RandomData.string()
+            val pathOne = RandomData.string()
+            GlobalContext.set(valueOne, pathOne)
+            val valueTwo = RandomData.string()
+            val pathTwo = RandomData.string()
+
+            // When
+            GlobalContext.set(value = valueTwo, path = pathTwo)
+            val resultOne = GlobalContext.get(pathOne)
+            val resultTwo = GlobalContext.get(pathTwo)
+
+            // Then
+            assertEquals(valueTwo, resultTwo)
+            assertEquals(valueOne, resultOne)
+        }
+
+        @Test
+        @DisplayName("Then should set objects and navigate them")
+        fun setObject() {
+            // Given
+            val user = User(id = "identifier")
+
+            // When
+            GlobalContext.set(value = user, path = "user")
+
+            // Then
+            val result = GlobalContext.get("user.id")
+            assertEquals(user.id, result)
+        }
     }
 
-    @Test
-    fun get_should_return_null_when_path_does_not_exist() {
-        // Given
-        val path = RandomData.string()
+    @Nested
+    @DisplayName("When clear is called")
+    inner class ClearContext {
 
-        // Then
-        val value = GlobalContext.get(path)
+        @Test
+        @DisplayName("Then should set empty string to root if path is null")
+        fun clearEmptyStringRoot() {
+            // Given
+            val pathForSet = RandomData.string()
+            val value = RandomData.string()
+            val valueAfterClear = ""
+            GlobalContext.set(value = value, path = pathForSet)
+            val path = null
 
-        // Then
-        assertNull(value)
-    }
+            // When
+            GlobalContext.clear(path)
+            val result = GlobalContext.get()
 
-    @Test
-    fun set_should_set_global_context_value_at_root_when_path_is_null() {
-        // Given
-        val value = RandomData.string()
+            // Then
+            assertEquals(valueAfterClear, result)
+        }
 
-        // When
-        GlobalContext.set(value = value)
-        val result = GlobalContext.get()
+        @Test
+        @DisplayName("Then should set null to context with a path")
+        fun clearContextWithPath() {
+            // Given
+            val path = RandomData.string()
+            val value = RandomData.string()
+            GlobalContext.set(value = value, path = path)
 
-        // Then
-        assertEquals(value, result)
-    }
+            // When
+            GlobalContext.clear(path)
+            val result = GlobalContext.get(path)
 
-    @Test
-    fun set_should_set_global_context_value_at_a_specific_path() {
+            // Then
+            assertNull(result)
+        }
 
-        val value = RandomData.string()
-        val path = RandomData.string()
+        @Test
+        @DisplayName("Then should remove attribute from Json Object")
+        fun clearJsonObjectAttribute() {
+            // Given
+            val attributeContent = RandomData.string()
+            GlobalContext.set(value = attributeContent, path = "a.b")
+            GlobalContext.set(value = attributeContent, path = "a.c")
 
-        GlobalContext.set(value = value, path = path)
-        val result = GlobalContext.get(path)
+            // When
+            GlobalContext.clear("a.b")
+            val attr1 = GlobalContext.get("a.b")
+            val attr2 = GlobalContext.get("a.c")
+            val containsRemovedAttribute = GlobalContext.get().toString().contains("\"b\":", true)
 
-        assertEquals(value, result)
-    }
+            // Then
+            assertNull(attr1)
+            assertEquals(attributeContent, attr2)
+            assertFalse(containsRemovedAttribute)
+        }
 
-    @Test
-    fun set_should_not_override_other_paths_in_global_context_root() {
+        @Test
+        @DisplayName("Then should not clear a path that does not exist")
+        fun clearNonexistentPath() {
+            // Given
+            val objectPath = "a.b.c"
 
-        val valueOne = RandomData.string()
-        val pathOne = RandomData.string()
-        GlobalContext.set(valueOne, pathOne)
-        val valueTwo = RandomData.string()
-        val pathTwo = RandomData.string()
+            // When
+            GlobalContext.clear(objectPath)
 
-        GlobalContext.set(value = valueTwo, path = pathTwo)
-        val resultOne = GlobalContext.get(pathOne)
-        val resultTwo = GlobalContext.get(pathTwo)
+            // Then
+            assertNull(GlobalContext.get("a"))
+            assertNull(GlobalContext.get("a.b"))
+            assertNull(GlobalContext.get("a.b.c"))
+        }
 
-        assertEquals(valueTwo, resultTwo)
-        assertEquals(valueOne, resultOne)
-    }
+        @Test
+        @DisplayName("Then should not clear a path that does not exist in Json Array")
+        fun clearNonexistentJsonArrayPath() {
+            // Given
+            GlobalContext.set(true, "f.e")
+            val objectPath = "a[0].c.e"
 
-    @Test
-    fun clear_should_set_empty_string_value_at_global_context_root_when_path_is_null() {
+            // When
+            GlobalContext.clear(objectPath)
 
-        val pathForSet = RandomData.string()
-        val value = RandomData.string()
-        val valueAfterClear = ""
-        GlobalContext.set(value = value, path = pathForSet)
-        val path = null
-
-        GlobalContext.clear(path)
-        val result = GlobalContext.get()
-
-        assertEquals(valueAfterClear, result)
-    }
-
-    @Test
-    fun clear_should_set_null_to_context_with_a_path() {
-        // Given
-        val path = RandomData.string()
-        val value = RandomData.string()
-        GlobalContext.set(value = value, path = path)
-
-        // When
-        GlobalContext.clear(path)
-        val result = GlobalContext.get(path)
-
-        // Then
-        assertNull(result)
-    }
-
-    @Test
-    fun clear_should_remove_attribute_from_JSON_object() {
-        //Given
-        val attributeContent = RandomData.string()
-        GlobalContext.set(value = attributeContent, path = "a.b")
-        GlobalContext.set(value = attributeContent, path = "a.c")
-
-        //When
-        GlobalContext.clear("a.b")
-
-        //Then
-        val attr1 = GlobalContext.get("a.b")
-        val attr2 = GlobalContext.get("a.c")
-        val containsRemovedAttribute = GlobalContext.get().toString().contains("\"b\":", true)
-
-        assertNull(attr1)
-        assertEquals(attributeContent, attr2)
-        assertFalse(containsRemovedAttribute)
-    }
-
-    @Test
-    fun clear_should_not_clear_a_path_that_does_not_exist() {
-        //Given
-        val objectPath = "a.b.c"
-
-        //When
-        GlobalContext.clear(objectPath)
-
-        //Then
-        assertNull(GlobalContext.get("a"))
-        assertNull(GlobalContext.get("a.b"))
-        assertNull(GlobalContext.get("a.b.c"))
-    }
-
-    @Test
-    fun clear_should_not_clear_a_path_that_does_not_exist_in_JSONObject() {
-        //Given
-        GlobalContext.set(true, "f.e")
-        val objectPath = "a[0].c.e"
-
-        //When
-        GlobalContext.clear(objectPath)
-
-        //Then
-        assertNull(GlobalContext.get("c"))
-        assertNull(GlobalContext.get("c.e"))
+            // Then
+            assertNull(GlobalContext.get("c"))
+            assertNull(GlobalContext.get("c.e"))
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>


### Related Issues

Fixes #1560 

### Description and Example

This PR enables `GlobalContext.set` to save any object has a `JsonObject`.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
