### PR TITLE
fix: android image placeholder reset

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/Image.kt
@@ -59,7 +59,6 @@ data class Image constructor(
         val imageView: RoundedImageView = getImageView(rootView)
 
         observeBindChanges(rootView, imageView, path) { pathType ->
-
             when (pathType) {
                 is ImagePath.Local -> {
                     loadLocalImage(rootView, imageView, pathType)
@@ -94,19 +93,29 @@ data class Image constructor(
                     }
                 }
             }
-
         }
     }
 
     private fun loadRemoteImage(rootView: RootView, imageView: ImageView, pathType: ImagePath.Remote) {
-        pathType.placeholder?.let { local ->
-            loadLocalImage(rootView, imageView, local)
-        }
+        loadPlaceholder(pathType, rootView, imageView)
 
         observeBindChanges(rootView, imageView, pathType.url) { url ->
-            imageView.setImageDrawable(null)
+            loadPlaceholder(pathType, rootView, imageView) {
+                imageView.setImageDrawable(null)
+            }
             downloadImage(imageView, url ?: "", rootView)
         }
+    }
+
+    private fun loadPlaceholder(
+        pathType: ImagePath.Remote,
+        rootView: RootView,
+        imageView: ImageView,
+        fallback: (() -> Unit)? = null,
+    ) {
+        pathType.placeholder?.let { local ->
+            loadLocalImage(rootView, imageView, local)
+        } ?: fallback?.invoke()
     }
 
     private fun downloadImage(imageView: ImageView, url: String, rootView: RootView) =

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/ImageTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/ImageTest.kt
@@ -89,7 +89,7 @@ internal class ImageTest : BaseComponentTest() {
         @Test
         @DisplayName("Then it should return a imageView if imagePath is remote")
         fun testsIfViewIsBuiltAsImageViewWhenImagePathIsRemote() {
-            //Given
+            // Given
             imageRemote = Image(ImagePath.Remote(""))
 
             // When
@@ -97,7 +97,32 @@ internal class ImageTest : BaseComponentTest() {
 
             // Then
             assertTrue(view is ImageView)
-            verify (exactly = 1) { (view as ImageView).setImageDrawable(null)  }
+        }
+
+        @Test
+        @DisplayName("Then it should clear drawable if placeholder is null")
+        fun testsIfClearDrawableWhenPlaceholderIsNull() {
+            // Given
+            imageRemote = Image(ImagePath.Remote(url = ""))
+
+            // When
+            val view = imageRemote.buildView(rootView)
+
+            // Then
+            verify(exactly = 1) { (view as ImageView).setImageDrawable(null) }
+        }
+
+        @Test
+        @DisplayName("Then it should not clear drawable with placeholder")
+        fun testsIfDrawableNullWasNotCalledWithPlaceholder() {
+            // Given
+            imageRemote = Image(ImagePath.Remote(url = "", placeholder = ImagePath.Local("imageName")))
+
+            // When
+            val view = imageRemote.buildView(rootView)
+
+            // Then
+            verify(exactly = 0) { (view as ImageView).setImageDrawable(null) }
         }
     }
 
@@ -175,7 +200,7 @@ internal class ImageTest : BaseComponentTest() {
             imageRemote.buildView(rootView)
 
             // Then
-            verify(exactly = 1) { imageView.setImageResource(IMAGE_RES) }
+            verify(atLeast = 1) { imageView.setImageResource(IMAGE_RES) }
         }
 
         @Test

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
@@ -29,19 +29,29 @@ import br.com.zup.beagle.android.components.layout.Screen
 import br.com.zup.beagle.android.utils.toView
 import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.ext.applyStyle
+import br.com.zup.beagle.ext.unitReal
+import br.com.zup.beagle.widget.core.Size
 
 class ImageViewFragment : Fragment() {
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         val declarative = Screen(
             child = Container(
                 children = listOf(
                     Image(
                         path = ImagePath.Remote(
-                            "https://cdn-images-1.medium.com/max/1200/1*kjiNJPB3Y-ZVmjxco_bORA.png",
+                            url = "https://cdn-images-1.medium.com/max/1200/1*kjiNJPB3Y-ZVmjxco_bORA.png",
                             placeholder = ImagePath.Local("imageBeagle")
+                        )
+                    ).applyStyle(
+                        Style(
+                            size = Size(
+                                width = 100.unitReal(),
+                                height = 100.unitReal()
+                            )
                         )
                     ),
                     Text(text = "Test!!!").applyStyle(

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/ImageViewFragment.kt
@@ -29,8 +29,6 @@ import br.com.zup.beagle.android.components.layout.Screen
 import br.com.zup.beagle.android.utils.toView
 import br.com.zup.beagle.core.Style
 import br.com.zup.beagle.ext.applyStyle
-import br.com.zup.beagle.ext.unitReal
-import br.com.zup.beagle.widget.core.Size
 
 class ImageViewFragment : Fragment() {
 
@@ -45,13 +43,6 @@ class ImageViewFragment : Fragment() {
                         path = ImagePath.Remote(
                             url = "https://cdn-images-1.medium.com/max/1200/1*kjiNJPB3Y-ZVmjxco_bORA.png",
                             placeholder = ImagePath.Local("imageBeagle")
-                        )
-                    ).applyStyle(
-                        Style(
-                            size = Size(
-                                width = 100.unitReal(),
-                                height = 100.unitReal()
-                            )
                         )
                     ),
                     Text(text = "Test!!!").applyStyle(


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>


### Related Issues

Fixes #1568

### Description and Example

Whenever an image is being downloaded or the context of the url is being evaluated or if there is an error in requesting a remote image, the `placeholder` is set, and if there is no drawable, it is removed. This behavior is necessary to prevent previously downloaded images from being displayed in new instances of `ImageView` erroneously. This PR fixes the behavior that removed the drawable from the image when there was a `placeholder` and assigns it instead.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
