### PR TITLE
fix: allow to use applyStyle and applyFlex in the same implementation

### DIFF
--- a/backend/kotlin-core/src/main/kotlin/br/com/zup/beagle/ext/WidgetExtensions.kt
+++ b/backend/kotlin-core/src/main/kotlin/br/com/zup/beagle/ext/WidgetExtensions.kt
@@ -57,7 +57,20 @@ fun <T : StyleComponent> T.flex(block: Flex.() -> Unit): T = setFlex(block)
 @Deprecated("It was deprecated in version 1.7.0 and will be removed in a future version.",
     ReplaceWith("Styled(component, { })"))
 fun <T : Widget> T.applyStyle(style: Style) = this.apply {
-    this.style = style
+    this.style = style.copy(
+        flex = Flex(
+            flexDirection = style.flex.flexDirection ?: this.style?.flex?.flexDirection,
+            flexWrap = style.flex.flexWrap ?: this.style?.flex?.flexWrap ,
+            justifyContent = style.flex.justifyContent ?: this.style?.flex?.justifyContent,
+            alignItems = style.flex.alignItems ?: this.style?.flex?.alignItems,
+            alignSelf = style.flex.alignSelf ?: this.style?.flex?.alignSelf,
+            alignContent = style.flex.alignContent ?: this.style?.flex?.alignContent,
+            basis = style.flex.basis ?: this.style?.flex?.basis,
+            flex = style.flex.flex ?: this.style?.flex?.flex,
+            grow = style.flex.grow ?: this.style?.flex?.grow,
+            shrink = style.flex.shrink ?: this.style?.flex?.shrink
+        )
+    )
 }
 
 @Deprecated("It was deprecated in version 1.7.0 and will be removed in a future version.",

--- a/backend/kotlin-core/src/test/kotlin/br/com/zup/beagle/ext/WidgetExtensionsTest.kt
+++ b/backend/kotlin-core/src/test/kotlin/br/com/zup/beagle/ext/WidgetExtensionsTest.kt
@@ -47,7 +47,7 @@ class WidgetExtensionsTest {
 
             // Then
             assertNotNull(result)
-            assertEquals(result.style, style)
+            assertEquals(style, result.style)
         }
     }
 
@@ -70,7 +70,7 @@ class WidgetExtensionsTest {
 
             // Then
             assertNotNull(result)
-            assertEquals(result.style, styleResult)
+            assertEquals(styleResult, result.style)
         }
     }
 
@@ -91,7 +91,7 @@ class WidgetExtensionsTest {
 
             // Then
             assertNotNull(result)
-            assertEquals(result.style, styleResult)
+            assertEquals(styleResult, result.style)
         }
     }
 
@@ -110,7 +110,7 @@ class WidgetExtensionsTest {
 
             // Then
             assertNotNull(result)
-            assertEquals(result.accessibility, accessibility)
+            assertEquals(accessibility, result.accessibility)
         }
 
         @Test
@@ -124,7 +124,7 @@ class WidgetExtensionsTest {
 
             // Then
             assertNotNull(result)
-            assertEquals(result.accessibility, accessibility)
+            assertEquals(accessibility, result.accessibility)
         }
     }
 

--- a/backend/kotlin-core/src/test/kotlin/br/com/zup/beagle/ext/WidgetExtensionsTest.kt
+++ b/backend/kotlin-core/src/test/kotlin/br/com/zup/beagle/ext/WidgetExtensionsTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.ext
+
+import br.com.zup.beagle.core.Accessibility
+import br.com.zup.beagle.core.Style
+import br.com.zup.beagle.widget.Widget
+import br.com.zup.beagle.widget.core.Flex
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@DisplayName("Given an Style Component")
+class WidgetExtensionsTest {
+
+    private val widget: Widget = object : Widget() {}
+
+    @DisplayName("When call applyStyle")
+    @Nested
+    inner class StyleTest {
+
+        @Test
+        @DisplayName("Then should return the current widget with instance of style")
+        fun testWidgetApplyStyle() {
+            // Given
+            val backgroundColor = "#fafafa"
+            val style = Style(backgroundColor = backgroundColor)
+
+            // When
+            val result = widget.applyStyle(style)
+
+            // Then
+            assertNotNull(result)
+            assertEquals(result.style, style)
+        }
+    }
+
+    @DisplayName("When call applyStyle and applyFlex")
+    @Nested
+    inner class StyleAndFlexTest {
+
+        @Test
+        @DisplayName("Then should return the current widget with instance of style")
+        fun testWidgetApplyStyleAndApplyFlex() {
+            // Given
+            val backgroundColor = "#fafafa"
+            val grow = 1.0
+            val flex = Flex(grow = grow)
+            val style = Style(backgroundColor = backgroundColor)
+            val styleResult = Style(backgroundColor = backgroundColor, flex = flex)
+
+            // When
+            val result = widget.applyFlex(flex).applyStyle(style)
+
+            // Then
+            assertNotNull(result)
+            assertEquals(result.style, styleResult)
+        }
+    }
+
+    @DisplayName("When call applyFlex")
+    @Nested
+    inner class StyleWithFlexTest {
+
+        @Test
+        @DisplayName("Then should return the current widget with instance of style")
+        fun testWidgetApplyFlex() {
+            // Given
+            val grow = 1.0
+            val flex = Flex(grow = grow)
+            val styleResult = Style(flex = flex)
+
+            // When
+            val result = widget.applyFlex(flex)
+
+            // Then
+            assertNotNull(result)
+            assertEquals(result.style, styleResult)
+        }
+    }
+
+    @DisplayName("")
+    @Nested
+    inner class AccessibilityTest {
+
+        @Test
+        @DisplayName("Then should return the current widget with instance of accessibility")
+        fun testWidgetApplyAccessibility() {
+            // Given
+            val accessibility = Accessibility(accessible = true, accessibilityLabel = "", isHeader = true)
+
+            // When
+            val result = widget.applyAccessibility(accessibility)
+
+            // Then
+            assertNotNull(result)
+            assertEquals(result.accessibility, accessibility)
+        }
+
+        @Test
+        @DisplayName("Then should return the current widget with instance of accessibility")
+        fun testWidgetApplyAccessibilityDefault() {
+            // Given
+            val accessibility = Accessibility()
+
+            // When
+            val result = widget.applyAccessibility(accessibility)
+
+            // Then
+            assertNotNull(result)
+            assertEquals(result.accessibility, accessibility)
+        }
+    }
+
+    @DisplayName("When call id")
+    @Nested
+    inner class WidgetIdTest {
+
+        @Test
+        @DisplayName("Then should return widget")
+        fun testWidgetSetId() {
+            // GIVEN
+            val id = "id"
+
+            // WHEN
+            val result = widget.setId(id)
+
+
+            // THEN
+            assertNotNull(result)
+            assertEquals(id, result.id)
+        }
+
+        @Test
+        @DisplayName("Then should return widget")
+        fun testWidgetId() {
+            // GIVEN
+            val id = "id"
+
+            // WHEN
+            val result = widget.id { id }
+
+
+            // THEN
+            assertNotNull(result)
+            assertEquals(id, result.id)
+        }
+    }
+}


### PR DESCRIPTION
### Related Issues
Closes #1570

### Description and Example
Changed to allow use applyStyle and applyFlex in the same implementation.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
