### PR TITLE
fix: ListView's manager id and GridView contract

### DIFF
--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/GridView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/GridView.kt
@@ -18,20 +18,22 @@ package br.com.zup.beagle.android.components
 
 import android.view.View
 import br.com.zup.beagle.android.action.Action
+import br.com.zup.beagle.android.components.utils.Template
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextComponent
 import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.WidgetView
 import br.com.zup.beagle.annotation.RegisterWidget
-import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.widget.core.ListDirection
 
 /**
  * @param context define the contextData that be set to component.
  * @param onInit allows to define a list of actions to be performed when the Widget is displayed.
  * @param dataSource it's an expression that points to a list of values used to populate the Widget.
- * @param template represents each cell in the list through a ServerDrivenComponent.
+ * @param templates Multiple templates support. The template to use will be decided according to the property `case`
+ * of the template. The first template where `case` is `true` is the template chosen to render an item. If for every
+ * template `case` is `false`, then, the first template where `case` is omitted (default template) is used.
  * @param onScrollEnd list of actions performed when the list is scrolled to the end.
  * @param scrollEndThreshold sets the scrolled percentage of the list to trigger onScrollEnd.
  * @param isScrollIndicatorVisible this attribute enables or disables the scroll bar.
@@ -45,7 +47,7 @@ data class GridView(
     override val context: ContextData? = null,
     val onInit: List<Action>? = null,
     val dataSource: Bind<List<Any>>? = null,
-    val template: ServerDrivenComponent? = null,
+    val templates: List<Template>? = null,
     val onScrollEnd: List<Action>? = null,
     val scrollEndThreshold: Int? = null,
     val isScrollIndicatorVisible: Boolean = false,
@@ -60,7 +62,7 @@ data class GridView(
             context = context,
             onInit = onInit,
             dataSource = dataSource,
-            template = template,
+            templates = templates,
             onScrollEnd = onScrollEnd,
             scrollEndThreshold = scrollEndThreshold,
             isScrollIndicatorVisible = isScrollIndicatorVisible,

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/ListView.kt
@@ -27,7 +27,7 @@ import androidx.recyclerview.widget.RecyclerView
 import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.components.list.ListAdapter
 import br.com.zup.beagle.android.components.list.ListViewModels
-import br.com.zup.beagle.android.components.list.ListViewTemplate
+import br.com.zup.beagle.android.components.utils.Template
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextComponent
 import br.com.zup.beagle.android.context.ContextData
@@ -69,7 +69,7 @@ constructor(
     val isScrollIndicatorVisible: Boolean = false,
     val iteratorName: String = "item",
     val key: String? = null,
-    val templates: List<ListViewTemplate>? = null,
+    val templates: List<Template>? = null,
 ) : WidgetView(), ContextComponent, OnInitiableComponent by OnInitiableComponentImpl(onInit) {
 
     /**
@@ -159,7 +159,7 @@ constructor(
         isScrollIndicatorVisible: Boolean = false,
         iteratorName: String = "item",
         key: String? = null,
-        templates: List<ListViewTemplate>,
+        templates: List<Template>,
     ) : this(
         null,
         direction,

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListAdapter.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/list/ListAdapter.kt
@@ -22,6 +22,8 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView
 import br.com.zup.beagle.android.action.AsyncAction
 import br.com.zup.beagle.android.action.AsyncActionStatus
+import br.com.zup.beagle.android.components.utils.Template
+import br.com.zup.beagle.android.components.utils.TemplateJson
 import br.com.zup.beagle.android.context.AsyncActionData
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.ContextData
@@ -40,7 +42,7 @@ internal class ListAdapter(
     val key: String? = null,
     val viewFactory: ViewFactory,
     val listViewModels: ListViewModels,
-    val templateList: List<ListViewTemplate>? = null,
+    val templateList: List<Template>? = null,
     val originView: View,
 ) : RecyclerView.Adapter<ListViewHolder>() {
 
@@ -67,7 +69,7 @@ internal class ListAdapter(
     // Each access generate a new instance of the template to avoid reference conflict
     private val templateJsonList = templateList?.let {
         it.map { template ->
-            ListViewTemplateJson(template.case, serializer.serializeComponent(template.view))
+            TemplateJson(template.case, serializer.serializeComponent(template.view))
         }
     }
 
@@ -264,7 +266,9 @@ internal class ListAdapter(
     private fun getRecyclerId(componentId: String?): Int {
         val id = recyclerId.takeIf {
             it != View.NO_ID
-        } ?: componentId?.toAndroidId()
+        } ?: componentId?.toAndroidId()?.takeIf {
+            it != View.NO_ID
+        }
         return id ?: createTempId()
     }
 

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/Template.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/Template.kt
@@ -14,24 +14,27 @@
  * limitations under the License.
  */
 
-package br.com.zup.beagle.android.components.list
+package br.com.zup.beagle.android.components.utils
 
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.expressionOrValueOf
+import br.com.zup.beagle.android.context.valueOf
 import br.com.zup.beagle.core.BeagleJson
 import br.com.zup.beagle.core.ServerDrivenComponent
 
 @BeagleJson
-data class ListViewTemplate (
+data class Template(
     /**
      * Condition to tell if this is the template to render or not. Optional. If omitted, we consider it to be the
      * default template, i.e, it's used whenever no other template can be used.
      */
-    val case: Bind<Boolean>?,
+    val case: Bind<Boolean>? = null,
     /**
      * The template itself: view to render
      */
     val view: ServerDrivenComponent,
-){
-    constructor(case: String, view: ServerDrivenComponent): this(expressionOrValueOf(case), view)
+) {
+    constructor(case: String, view: ServerDrivenComponent) : this(expressionOrValueOf(case), view)
+
+    constructor(case: Boolean, view: ServerDrivenComponent) : this(valueOf(case), view)
 }

--- a/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/TemplateJson.kt
+++ b/android/beagle/src/main/java/br/com/zup/beagle/android/components/utils/TemplateJson.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package br.com.zup.beagle.android.components.list
+package br.com.zup.beagle.android.components.utils
 
 import br.com.zup.beagle.android.context.Bind
 
-data class ListViewTemplateJson (
+data class TemplateJson(
     /**
      * Condition to tell if this is the template to render or not. Optional. If omitted, we consider it to be the
      * default template, i.e, it's used whenever no other template can be used.

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/GridViewTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/GridViewTest.kt
@@ -21,6 +21,7 @@ import androidx.recyclerview.widget.RecyclerView
 import br.com.zup.beagle.android.action.Action
 import br.com.zup.beagle.android.action.SendRequest
 import br.com.zup.beagle.android.components.layout.Container
+import br.com.zup.beagle.android.components.utils.Template
 import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.context.expressionOf
 import br.com.zup.beagle.android.testutil.InstantExecutorExtension
@@ -55,7 +56,7 @@ class GridViewTest : BaseComponentTest() {
     )
     private val onInit = listOf(SendRequest("http://www.init.com"))
     private val dataSource = expressionOf<List<Any>>("@{context}")
-    private val template by lazy { Container(children = listOf(Text(expressionOf("@{item.name}")))) }
+    private val templates by lazy { listOf(Template(view = Container(children = listOf(Text(expressionOf("@{item.name}")))))) }
     private val onScrollEnd = listOf(mockk<Action>(relaxed = true))
     private val iteratorName = "list"
     private val key = "id"
@@ -67,7 +68,7 @@ class GridViewTest : BaseComponentTest() {
     override fun setUp() {
         super.setUp()
 
-        gridView = GridView(context, onInit, dataSource, template, onScrollEnd, iteratorName = iteratorName, key = key, numColumns = numColumns)
+        gridView = GridView(context, onInit, dataSource, templates, onScrollEnd, iteratorName = iteratorName, key = key, numColumns = numColumns)
 
         every { anyConstructed<ViewFactory>().makeBeagleRecyclerView(rootView.getContext()) } returns beagleRecyclerView
         every { beagleRecyclerView.layoutManager = capture(layoutManagerSlot) } just Runs

--- a/android/beagle/src/test/java/br/com/zup/beagle/android/components/list/ListAdapterTest.kt
+++ b/android/beagle/src/test/java/br/com/zup/beagle/android/components/list/ListAdapterTest.kt
@@ -32,6 +32,7 @@ import br.com.zup.beagle.android.components.Image
 import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.Text
 import br.com.zup.beagle.android.components.layout.Container
+import br.com.zup.beagle.android.components.utils.Template
 import br.com.zup.beagle.android.context.AsyncActionData
 import br.com.zup.beagle.android.context.Bind
 import br.com.zup.beagle.android.context.expressionOf
@@ -87,19 +88,19 @@ class ListAdapterTest : BaseTest() {
     private val observerSlot = slot<Observer<AsyncActionData>>()
     private val templateList by lazy {
         listOf(
-            ListViewTemplate(
+            Template(
                 case = expressionOf("@{eq(item, 'stub 1')}"),
                 view = Container(children = listOf(Text(text = "test")))
             ),
-            ListViewTemplate(
+            Template(
                 case = expressionOf("@{eq(item, 'stub 2')}"),
                 view = Text(text = "test")
             ),
-            ListViewTemplate(
+            Template(
                 case = null,
                 view = Button(text = "button test")
             ),
-            ListViewTemplate(
+            Template(
                 case = expressionOf("@{eq(item, 'stub 5')}"),
                 view = Image(ImagePath.Remote(url = "test"))
             ),
@@ -302,15 +303,15 @@ class ListAdapterTest : BaseTest() {
     fun `Given a ListAdapter When call getItemViewType Then should return -1 when there is no default template`() {
         val expectedIndex = -1
         val templateList = listOf(
-            ListViewTemplate(
+            Template(
                 case = expressionOf("@{eq(item, 'stub 1')}"),
                 view = Container(children = listOf())
             ),
-            ListViewTemplate(
+            Template(
                 case = expressionOf("@{eq(item, 'stub 2')}"),
                 view = Container(children = listOf())
             ),
-            ListViewTemplate(
+            Template(
                 case = expressionOf("@{eq(item, 'stub 5')}"),
                 view = Container(children = listOf())
             ),
@@ -418,7 +419,7 @@ class ListAdapterTest : BaseTest() {
         val expectedTemplate = Container()
         val expectedViewType = -1
         val templateListWithNoDefault = listOf(
-            ListViewTemplate(
+            Template(
                 case = expressionOf("@{eq(item, 'stub 1')}"),
                 view = Container(children = listOf(Text(text = "test")))
             ),

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/GridViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/GridViewFragment.kt
@@ -27,6 +27,7 @@ import br.com.zup.beagle.android.components.ImagePath
 import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.components.layout.NavigationBar
 import br.com.zup.beagle.android.components.layout.Screen
+import br.com.zup.beagle.android.components.utils.Template
 import br.com.zup.beagle.android.context.ContextData
 import br.com.zup.beagle.android.context.expressionOf
 import br.com.zup.beagle.android.utils.toView
@@ -57,20 +58,24 @@ class GridViewFragment : Fragment() {
                 "16", "17", "18", "19", "20")
         ),
         dataSource = expressionOf("@{outsideContext}"),
-        template = Container(
-            children = listOf(
-                Image(
-                    ImagePath.Local("imageBeagle"),
-                    mode = ImageContentMode.FIT_CENTER
+        templates = listOf(
+            Template(
+                view = Container(
+                    children = listOf(
+                        Image(
+                            ImagePath.Local("imageBeagle"),
+                            mode = ImageContentMode.FIT_CENTER
+                        ).applyStyle(
+                            Style(
+                                margin = EdgeValue(all = 5.unitReal())
+                            )
+                        )
+                    )
                 ).applyStyle(
                     Style(
-                        margin = EdgeValue(all = 5.unitReal())
+                        size = Size(width = 100.unitReal(), height = 100.unitReal())
                     )
                 )
-            )
-        ).applyStyle(
-            Style(
-                size = Size(width = 100.unitReal(), height = 100.unitReal())
             )
         )
     )

--- a/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/list/ListViewFragment.kt
+++ b/android/sample/src/main/java/br/com/zup/beagle/sample/fragment/list/ListViewFragment.kt
@@ -46,7 +46,7 @@ class ListViewFragment : Fragment(R.layout.fragment_list_view) {
         btNestedImageList.setOnClickListener {
             startActivity(
                 context?.newServerDrivenIntent<ServerDrivenActivity>(
-                    ScreenRequest("https://run.mocky.io/v3/9df55f30-9c82-4837-988d-f3d751d6f4e6")
+                    ScreenRequest("https://run.mocky.io/v3/9aa31d46-15c8-4bdf-95a3-01491e468846")
                 )
             )
         }

--- a/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/GridView.kt
+++ b/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/GridView.kt
@@ -16,7 +16,6 @@
 
 package br.com.zup.beagle.widget.ui
 
-import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.widget.Widget
 import br.com.zup.beagle.widget.action.Action
 import br.com.zup.beagle.widget.context.Bind
@@ -27,7 +26,9 @@ import br.com.zup.beagle.widget.context.ContextData
  * @param context define the contextData that be set to component.
  * @param onInit allows to define a list of actions to be performed when the Widget is displayed.
  * @param dataSource it's an expression that points to a list of values used to populate the Widget.
- * @param template represents each cell in the list through a ServerDrivenComponent.
+ * @param templates Multiple templates support. The template to use will be decided according to the property `case`
+ * of the template. The first template where `case` is `true` is the template chosen to render an item. If for every
+ * template `case` is `false`, then, the first template where `case` is omitted (default template) is used.
  * @param onScrollEnd list of actions performed when the list is scrolled to the end.
  * @param scrollEndThreshold sets the scrolled percentage of the list to trigger onScrollEnd.
  * @param isScrollIndicatorVisible this attribute enables or disables the scroll bar.
@@ -40,7 +41,7 @@ data class GridView(
     override val context: ContextData? = null,
     val onInit: List<Action>? = null,
     val dataSource: Bind<List<Any>>? = null,
-    val template: ServerDrivenComponent? = null,
+    val templates: List<Template>? = null,
     val onScrollEnd: List<Action>? = null,
     val scrollEndThreshold: Int? = null,
     val isScrollIndicatorVisible: Boolean = false,

--- a/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/ListView.kt
+++ b/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/ListView.kt
@@ -46,7 +46,7 @@ data class ListView(
     val isScrollIndicatorVisible: Boolean = false,
     val key: String? = null,
     val useParentScroll: Boolean? = null,
-    val templates: List<ListViewTemplate>? = null,
+    val templates: List<Template>? = null,
 ) : Widget(), ContextComponent {
 
     /**
@@ -139,7 +139,7 @@ data class ListView(
         iteratorName: String = "item",
         key: String? = null,
         useParentScroll: Boolean? = null,
-        templates: List<ListViewTemplate>,
+        templates: List<Template>,
     ) : this(
         null,
         direction,

--- a/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/Template.kt
+++ b/backend/widgets/src/main/kotlin/br/com/zup/beagle/widget/ui/Template.kt
@@ -20,16 +20,16 @@ import br.com.zup.beagle.core.ServerDrivenComponent
 import br.com.zup.beagle.widget.context.Bind
 import br.com.zup.beagle.widget.context.valueOfNullable
 
-data class ListViewTemplate (
+data class Template(
     /**
      * Condition to tell if this is the template to render or not. Optional. If omitted, we consider it to be the
      * default template, i.e, it's used whenever no other template can be used.
      */
-    val case: Bind<Boolean>?,
+    val case: Bind<Boolean>? = null,
     /**
      * The template itself: view to render
      */
     val view: ServerDrivenComponent,
-){
-    constructor(case: Boolean, view: ServerDrivenComponent): this(valueOfNullable(case), view)
+) {
+    constructor(case: Boolean, view: ServerDrivenComponent) : this(valueOfNullable(case), view)
 }


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

### Description and Example

Changes the `GridView` property `template: ServerDrivenComponent? = null` to `templates: List<Template>? = null` and fixes a bug on `ListView` id manager.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
