### PR TITLE
feat: improve Appium tests CI/CD strategy

### DIFF
--- a/.github/workflows/automated_tests_appium_android.yml
+++ b/.github/workflows/automated_tests_appium_android.yml
@@ -17,9 +17,9 @@
 name: Beagle Appium Android Tests
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
   workflow_run:
-    workflows: [ "Beagle Appium Tests" ]
+    workflows: [ "Beagle Appium tests trigger" ]
     types:
       - completed
 

--- a/.github/workflows/automated_tests_appium_android.yml
+++ b/.github/workflows/automated_tests_appium_android.yml
@@ -17,6 +17,7 @@
 name: Beagle Appium Android Tests
 
 on:
+  workflow_dispatch
   workflow_run:
     workflows: [ "Beagle Appium Tests" ]
     types:

--- a/.github/workflows/automated_tests_appium_ios.yml
+++ b/.github/workflows/automated_tests_appium_ios.yml
@@ -17,6 +17,7 @@
 name: Beagle Appium iOS Tests
 
 on:
+  workflow_dispatch
   workflow_run:
     workflows: ["Beagle Appium Tests"]
     types:

--- a/.github/workflows/automated_tests_appium_ios.yml
+++ b/.github/workflows/automated_tests_appium_ios.yml
@@ -17,9 +17,9 @@
 name: Beagle Appium iOS Tests
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
   workflow_run:
-    workflows: ["Beagle Appium Tests"]
+    workflows: ["Beagle Appium tests trigger"]
     types:
       - completed
 

--- a/.github/workflows/automated_tests_appium_mobile.yml
+++ b/.github/workflows/automated_tests_appium_mobile.yml
@@ -18,7 +18,7 @@ name: Beagle Appium tests trigger
 on:
   workflow_dispatch:
   # invoked by merges to master (pushing a branch to master)
-  # src: https://github:community/t/trigger-workflow-only-on-pull-request-merge/17359/2:
+  # src: https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/2
   push:
     branches:
       - master

--- a/.github/workflows/automated_tests_appium_mobile.yml
+++ b/.github/workflows/automated_tests_appium_mobile.yml
@@ -15,7 +15,17 @@
 
 # Workflow used as a reference for triggering Appium tests
 name: Beagle Appium Tests
-on: workflow_dispatch
+on:
+  workflow_dispatch
+  push:
+    branches:
+      - master
+    paths:
+      - 'android/**'
+      - 'common/**'
+      - 'backend/**'
+      - 'tests/**'
+      - 'iOS/**'
 
 jobs:
   appium_tests:

--- a/.github/workflows/automated_tests_appium_mobile.yml
+++ b/.github/workflows/automated_tests_appium_mobile.yml
@@ -14,9 +14,11 @@
 #
 
 # Workflow used as a reference for triggering Appium tests
-name: Beagle Appium Tests
+name: Beagle Appium tests trigger
 on:
-  workflow_dispatch
+  workflow_dispatch:
+  # invoked by merges to master (pushing a branch to master)
+  # src: https://github:community/t/trigger-workflow-only-on-pull-request-merge/17359/2:
   push:
     branches:
       - master


### PR DESCRIPTION
### Related Issues

#1538 

### Description and Example

- Make Appium tests run after every merge to Master branch. 

src: https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/2
><img width="738" alt="Screen Shot 2021-06-01 at 12 01 41" src="https://user-images.githubusercontent.com/73198010/120346909-2f743e00-c2d2-11eb-8f3d-944ee29c0ccf.png">



- Enable manually start of Android and iOS Appium tests, because sometimes we need to check specific SO tests under a custom branch

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
