### PR TITLE
fix: popView with a single view in stack

### DIFF
--- a/iOS/Sources/Beagle/BeagleTests/Logger/BeagleLoggerProxyTests.swift
+++ b/iOS/Sources/Beagle/BeagleTests/Logger/BeagleLoggerProxyTests.swift
@@ -24,30 +24,30 @@ class BeagleLoggerProxyTests: XCTestCase {
 
     func testLog_WhenLogEnableIsFalse() {
 
-        //Given
+        // Given
         let spy = BeagleLoggerSpy()
         let sut = BeagleLoggerProxy(logger: spy, dependencies: dependencies)
 
-        //When
+        // When
         dependencies.isLoggingEnabled = false
         Beagle.dependencies = dependencies
-        sut.log(Log.navigation(.errorTryingToPopScreenOnNavigatorWithJustOneScreen))
+        sut.log(Log.navigation(.routeDoesNotExistInTheCurrentStack(path: "route")))
 
-        //Then
+        // Then
         XCTAssert(spy.didCalledLog == false)
     }
 
     func testLog_WhenLogEnableIsTrue() {
 
-        //Given
+        // Given
         let spy = BeagleLoggerSpy()
         let sut = BeagleLoggerProxy(logger: spy, dependencies: dependencies)
 
-        //When
+        // When
         dependencies.isLoggingEnabled = true
-        sut.log(Log.navigation(.errorTryingToPopScreenOnNavigatorWithJustOneScreen))
+        sut.log(Log.navigation(.routeDoesNotExistInTheCurrentStack(path: "route")))
 
-        //Then
+        // Then
         XCTAssert(spy.didCalledLog)
     }
 

--- a/iOS/Sources/Beagle/BeagleTests/Logger/BeagleLoggerTests.swift
+++ b/iOS/Sources/Beagle/BeagleTests/Logger/BeagleLoggerTests.swift
@@ -44,7 +44,6 @@ class BeagleLoggerTests: XCTestCase {
             Log.navigation(.didReceiveAction(Navigate.pushView(.remote(.init(url: path))))),
             Log.navigation(.didReceiveAction(Navigate.openNativeRoute(.init(route: path)))),
             Log.navigation(.didReceiveAction(Navigate.openNativeRoute(.init(route: path, data: ["key": "value"])))),
-            Log.navigation(.errorTryingToPopScreenOnNavigatorWithJustOneScreen),
             Log.navigation(.unableToPrefetchWhenUrlIsExpression),
             Log.navigation(.didNotFindDeepLinkScreen(path: path)),
 

--- a/iOS/Sources/Beagle/BeagleTests/Logger/__Snapshots__/BeagleLoggerTests/testLogs.1.txt
+++ b/iOS/Sources/Beagle/BeagleTests/Logger/__Snapshots__/BeagleLoggerTests/testLogs.1.txt
@@ -39,8 +39,6 @@ didReceiveAction(Beagle.Navigate(_beagleAction_: "beagle:opennativeroute", analy
 
 didReceiveAction(Beagle.Navigate(_beagleAction_: "beagle:opennativeroute", analytics: nil, route: Beagle.Expression<Swift.String>.value("path"), data: Optional(["key": "value"]), shouldResetApplication: false))
 
-errorTryingToPopScreenOnNavigatorWithJustOneScreen
-
 unableToPrefetchWhenUrlIsExpression
 
 Beagle Navigator couldn't find a deep link screen with path: path. Check your deep link handler, or the path in the navigate action

--- a/iOS/Sources/Beagle/BeagleTests/Navigation/BeagleNavigatorTests.swift
+++ b/iOS/Sources/Beagle/BeagleTests/Navigation/BeagleNavigatorTests.swift
@@ -161,6 +161,21 @@ final class BeagleNavigatorTests: XCTestCase {
         // Then
         XCTAssert(navigation.viewControllers.count == 2)
     }
+    
+    func test_popViewWithOneViewInStack_shouldPopTheStack() {
+        // Given
+        let sut = BeagleNavigator()
+        let action = Navigate.popView()
+        let navigationSpy = BeagleControllerNavigationSpy()
+        let navigation = BeagleNavigationController()
+        navigation.viewControllers = [navigationSpy]
+
+        // When
+        sut.navigate(action: action, controller: navigationSpy, origin: nil)
+
+        // Then
+        XCTAssert(navigationSpy.dismissViewControllerCalled)
+    }
 
     func test_popToView_shouldNotNavigateWhenScreenIsNotFound() {
         

--- a/iOS/Sources/Beagle/Sources/Logger/BeagleMessageLogs.swift
+++ b/iOS/Sources/Beagle/Sources/Logger/BeagleMessageLogs.swift
@@ -63,7 +63,6 @@ public enum Log {
     public enum Navigator {
         case didReceiveAction(Navigate)
         case unableToPrefetchWhenUrlIsExpression
-        case errorTryingToPopScreenOnNavigatorWithJustOneScreen
         case didNotFindDeepLinkScreen(path: String)
         case routeDoesNotExistInTheCurrentStack(path: String)
         case didNavigateToExternalUrl(path: String)
@@ -231,7 +230,7 @@ extension Log: LogType {
 
         case .navigation(let nav):
             switch nav {
-            case .errorTryingToPopScreenOnNavigatorWithJustOneScreen, .didNotFindDeepLinkScreen, .routeDoesNotExistInTheCurrentStack, .invalidExternalUrl, .unableToOpenExternalUrl, .unableToPrefetchWhenUrlIsExpression:
+            case .didNotFindDeepLinkScreen, .routeDoesNotExistInTheCurrentStack, .invalidExternalUrl, .unableToOpenExternalUrl, .unableToPrefetchWhenUrlIsExpression:
                 return .error
             case .didReceiveAction, .didNavigateToExternalUrl:
                 return .info

--- a/iOS/Sources/Beagle/Sources/Navigation/BeagleNavigator.swift
+++ b/iOS/Sources/Beagle/Sources/Navigation/BeagleNavigator.swift
@@ -182,13 +182,14 @@ class BeagleNavigator: BeagleNavigation {
     }
     
     private func popView(controller: BeagleController, animated: Bool) {
-        if controller.navigationController?.viewControllers.count == 1 {
-            controller.dependencies.logger.log(Log.navigation(.errorTryingToPopScreenOnNavigatorWithJustOneScreen))
+        guard let navigation = controller.navigationController, navigation.viewControllers.count > 1 else {
+            popStack(controller: controller, animated: animated)
+            return
         }
         if let transition = defaultAnimation?.getTransition(.pop) {
-            controller.navigationController?.view.layer.add(transition, forKey: nil)
+            navigation.view.layer.add(transition, forKey: nil)
         }
-        controller.navigationController?.popViewController(animated: animated)
+        navigation.popViewController(animated: animated)
     }
     
     private func popToView(identifier: String, controller: BeagleController, animated: Bool) {


### PR DESCRIPTION
### Related Issues

Closes #1612
Closes #1617

### Description and Example

Navigation popView changed to pop the stack when there is only one screen in the stack. See #1612 for an example.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
