### PR TITLE
feat: removes module dependency from Beagle and uses lib import instead

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -33,7 +33,7 @@ POM_URL=https\://github.com/ZupIT/beagle
 
 GROUP=br.com.zup.beagle
 POM_ARTIFACT_ID=""
-VERSION_NAME=1.5.1
+VERSION_NAME=1.0.0-automated
 
 # Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
 systemProp.org.gradle.internal.http.socketTimeout=120000

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,6 +62,11 @@ platform :android do
     deploy_to_stage
     gradle(project_dir: "android", task: "closeAndReleaseRepository")
   end
+
+  lane :deploy_to_local do
+    gradle(project_dir: "android", task: "assemble")
+    gradle(project_dir: "android", task: "publishToMavenLocal")
+  end
 end
 
 ###

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,11 +62,6 @@ platform :android do
     deploy_to_stage
     gradle(project_dir: "android", task: "closeAndReleaseRepository")
   end
-
-  lane :deploy_to_local do
-    gradle(project_dir: "android", task: "assemble")
-    gradle(project_dir: "android", task: "publishToMavenLocal")
-  end
 end
 
 ###

--- a/maven-publish.gradle
+++ b/maven-publish.gradle
@@ -21,6 +21,7 @@ def versionName = System.env.VERSION_DEPLOY != null ? System.env.VERSION_DEPLOY 
 version = versionName
 
 mavenPublish {
+    releaseSigningEnabled = System.env.VERSION_DEPLOY != null ? true : false
     nexus {
         stagingProfile = "br.com.zup"
     }

--- a/tests/appium/app-android/app/build.gradle
+++ b/tests/appium/app-android/app/build.gradle
@@ -57,8 +57,9 @@ android {
 
 dependencies {
 
-    implementation project(Dependencies.Modules.core)
-    kapt project(Dependencies.Modules.processor)
+    implementation "br.com.zup.beagle:android:1.8.1"
+    kapt "br.com.zup.beagle:android-processor:1.8.1"
+
     implementation Dependencies.GsonLibraries.gson
     implementation Dependencies.AndroidxLibraries.coreKtx
     implementation Dependencies.AndroidxLibraries.appcompat

--- a/tests/appium/app-android/app/build.gradle
+++ b/tests/appium/app-android/app/build.gradle
@@ -68,14 +68,14 @@ dependencies {
 }
 
 
-task buildAndPublishBeagleAndroidLocally{
-    doLast{
+task buildAndPublishBeagleAndroidLocally {
+    doLast {
         def workingDirVar = "${projectDir}/../../../../android"
         def executableVar = ''
 
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             executableVar = 'gradlew.bat'
-        }else{
+        } else {
             executableVar = './gradlew'
         }
 

--- a/tests/appium/app-android/app/build.gradle
+++ b/tests/appium/app-android/app/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import br.com.zup.beagle.Dependencies
+import org.apache.tools.ant.taskdefs.condition.Os
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
@@ -54,11 +55,10 @@ android {
     }
 }
 
-
 dependencies {
 
-    implementation "br.com.zup.beagle:android:1.8.1"
-    kapt "br.com.zup.beagle:android-processor:1.8.1"
+    implementation "br.com.zup.beagle:android:1.0.0-automated"
+    kapt "br.com.zup.beagle:android-processor:1.0.0-automated"
 
     implementation Dependencies.GsonLibraries.gson
     implementation Dependencies.AndroidxLibraries.coreKtx
@@ -66,3 +66,31 @@ dependencies {
     implementation Dependencies.GeneralLibraries.kotlinCoroutines
     implementation Dependencies.GoogleLibraries.materialDesign
 }
+
+
+task buildAndPublishBeagleAndroidLocally{
+    doLast{
+        def workingDirVar = "${projectDir}/../../../../android"
+        def executableVar = ''
+
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            executableVar = 'gradlew.bat'
+        }else{
+            executableVar = './gradlew'
+        }
+
+        exec {
+            workingDir "${workingDirVar}"
+            executable "${executableVar}"
+            args "assemble"
+        }
+
+        exec {
+            workingDir "${workingDirVar}"
+            executable "${executableVar}"
+            args 'publishToMavenLocal'
+        }
+    }
+}
+preBuild.dependsOn buildAndPublishBeagleAndroidLocally
+

--- a/tests/appium/app-android/build.gradle
+++ b/tests/appium/app-android/build.gradle
@@ -35,12 +35,13 @@ plugins {
 }
 
 allprojects {
-    apply from: "$rootDir/../../../detekt.gradle"
+    // apply from: "$rootDir/../../../detekt.gradle"
 
     apply plugin: "br.com.zup.beagle.dependencies"
     apply plugin: "org.jetbrains.dokka"
 
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
     }

--- a/tests/appium/app-android/build.gradle
+++ b/tests/appium/app-android/build.gradle
@@ -35,8 +35,6 @@ plugins {
 }
 
 allprojects {
-    // apply from: "$rootDir/../../../detekt.gradle"
-
     apply plugin: "br.com.zup.beagle.dependencies"
     apply plugin: "org.jetbrains.dokka"
 

--- a/tests/appium/app-android/build.gradle
+++ b/tests/appium/app-android/build.gradle
@@ -18,7 +18,6 @@ buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -43,7 +42,7 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/tests/appium/app-android/buildSrc/src/main/kotlin/br/com/zup/beagle/Dependencies.kt
+++ b/tests/appium/app-android/buildSrc/src/main/kotlin/br/com/zup/beagle/Dependencies.kt
@@ -22,16 +22,6 @@ import org.gradle.api.Project
 class Dependencies : Plugin<Project> {
     override fun apply(project: Project) {}
 
-    object Modules {
-        const val androidSample = ":sample"
-        const val core = ":beagle"
-        const val processor = ":processor"
-        const val internalProcessor = ":internal-processor"
-        const val androidAnnotation = ":android-annotation"
-        const val preview = ":preview"
-        const val commonProcessorSharedCode = ":processor-shared-code"
-    }
-
     object Releases {
         const val versionCode = 1
         const val versionName = "1.0"
@@ -44,85 +34,18 @@ class Dependencies : Plugin<Project> {
         const val targetSdk = 30
         const val buildTools = "30.0.0"
         const val kotlin = "1.4.10"
-
         const val kotlinCoroutines = "1.3.9"
-
-        const val kotlinPoet = "1.7.1"
-        const val okio = "2.9.0"
-
         const val appcompat = "1.2.0"
         const val viewModel = "2.2.0"
         const val recyclerView = "1.1.0"
-
-        const val moshi = "1.11.0"
-
-        const val soLoader = "0.9.0"
-
         const val junit5 = "5.7.0"
-        const val junit4 = "4.13"
-
-        const val yoga = "1.16.0"
-
-        const val jni = "0.0.4"
-
-        const val webSocket = "1.5.1"
-        const val simpleLogger = "1.7.30"
-
-        const val kotlinCoroutinesTest = "1.3.9"
         const val materialDesign = "1.2.1"
-        const val googleCompileTesting = "0.18"
-        const val googleAutoService = "1.0-rc7"
-
-        const val jsonObject = "20200518"
-
-        const val mockk = "1.10.2"
-
-        const val testRunner = "1.3.1-alpha02"
-        const val testExt = "1.1.3-alpha02"
-        const val espresso = "3.4.0-alpha02"
-        const val archCoreTesting = "2.1.0"
-        const val testRules = "1.3.1-alpha02"
-        const val testCore = "1.3.1-alpha02"
-        const val robolectric = "4.4"
-
-        const val incap = "0.3"
-
-        const val cucumber = "1.2.6"
-        const val kotlinCompileTesting = "1.3.1"
-
         const val gson = "2.8.6"
     }
 
-    object GeneralNames {
-        const val testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        const val sampleTestInstrumentationRunner = "br.com.zup.beagle.sample.SampleTestRunner"
-        const val consumerProguard = "consumer-rules.pro"
-    }
-
-    object ProcessorLibraries {
-        const val autoService = "com.google.auto.service:auto-service:${Versions.googleAutoService}"
-        const val incap = "net.ltgt.gradle.incap:incap:${Versions.incap}"
-        const val incapPrcessor = "net.ltgt.gradle.incap:incap-processor:${Versions.incap}"
-
-        const val kotlinPoet = "com.squareup:kotlinpoet:${Versions.kotlinPoet}"
-        const val okio = "com.squareup.okio:okio:${Versions.okio}"
-    }
-
     object GeneralLibraries {
-        const val kotlin = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
         const val kotlinCoroutines =
             "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.kotlinCoroutines}"
-
-        const val soLoader = "com.facebook.soloader:soloader:${Versions.soLoader}"
-
-        const val yoga = "com.facebook.yoga.android:yoga-layout:${Versions.yoga}"
-
-        const val jni = "com.facebook.fbjni:fbjni:${Versions.jni}"
-
-        const val webSocket = "org.java-websocket:Java-WebSocket:${Versions.webSocket}"
-        const val simpleLogger = "org.slf4j:slf4j-simple:${Versions.simpleLogger}"
-
-        const val jsonObject = "org.json:json:${Versions.jsonObject}"
     }
 
     object GoogleLibraries {
@@ -132,39 +55,11 @@ class Dependencies : Plugin<Project> {
     object AndroidxLibraries {
         const val appcompat = "androidx.appcompat:appcompat:${Versions.appcompat}"
         const val coreKtx = "androidx.core:core-ktx:${Versions.appcompat}"
-        const val recyclerView = "androidx.recyclerview:recyclerview:${Versions.recyclerView}"
-        const val viewModel = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.viewModel}"
-        const val viewModelExtensions = "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.viewModel}"
-    }
-
-    object MoshiLibraries {
-        const val moshi = "com.squareup.moshi:moshi:${Versions.moshi}"
-        const val kotlin = "com.squareup.moshi:moshi-kotlin:${Versions.moshi}"
-        const val adapters = "com.squareup.moshi:moshi-adapters:${Versions.moshi}"
     }
 
     object GsonLibraries{
         const val gson = "com.google.code.gson:gson:${Versions.gson}"
     }
-    object TestLibraries {
-        const val junit4 = "junit:junit:${Versions.junit4}"
-        const val junitApi = "org.junit.jupiter:junit-jupiter-api:${Versions.junit5}"
-        const val junitEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junit5}"
-        const val junitVintageEngine = "org.junit.vintage:junit-vintage-engine:${Versions.junit5}"
-        const val mockk = "io.mockk:mockk:${Versions.mockk}"
-        const val kotlinCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinCoroutinesTest}"
-        const val googleCompileTesting = "com.google.testing.compile:compile-testing:${Versions.googleCompileTesting}"
-        const val archCoreTesting = "androidx.arch.core:core-testing:${Versions.archCoreTesting}"
-        const val testRunner = "androidx.test:runner:${Versions.testRunner}"
-        const val testExt = "androidx.test.ext:junit:${Versions.testExt}"
-        const val testCore = "androidx.test:core:${Versions.testCore}"
-        const val espressoCore = "androidx.test.espresso:espresso-core:${Versions.espresso}"
-        const val espressoContrib = "androidx.test.espresso:espresso-contrib:${Versions.espresso}"
-        const val testRules = "androidx.test:rules:${Versions.testRules}"
-        const val cucumberAndroid = "info.cukes:cucumber-android:${Versions.cucumber}"
-        const val cucumberPicocontainer = "info.cukes:cucumber-picocontainer:${Versions.cucumber}"
-        const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
-        const val kotlinCompileTesting = "com.github.tschuchortdev:kotlin-compile-testing:${Versions.kotlinCompileTesting}"
-    }
+
 
 }

--- a/tests/appium/app-android/jacoco-android.gradle
+++ b/tests/appium/app-android/jacoco-android.gradle
@@ -1,1 +1,0 @@
-// temp script until issue #1620 is done

--- a/tests/appium/app-android/settings.gradle
+++ b/tests/appium/app-android/settings.gradle
@@ -15,15 +15,5 @@
  */
 
 rootProject.name = "Appium App"
-
-include ":beagle"
-include ":processor"
-include ":internal-processor"
-include ":android-annotation"
-include ":processor-shared-code"
 include ":app"
-project(":beagle").projectDir = new File('../../../android/beagle')
-project(":processor").projectDir = new File('../../../android/processor')
-project(":internal-processor").projectDir = new File('../../../android/internal-processor')
-project(":android-annotation").projectDir = new File('../../../android/android-annotation')
-project(":processor-shared-code").projectDir = new File('../../../android/processor-shared-code')
+

--- a/tests/appium/jacoco.gradle
+++ b/tests/appium/jacoco.gradle
@@ -1,1 +1,0 @@
-// temp script until issue #1620 is done


### PR DESCRIPTION
### Related Issues

#1620 

### Description and Example

[Appium Android app](https://github.com/ZupIT/beagle/tree/master/tests/appium/app-android) no longer includes [Beagle Android](https://github.com/ZupIT/beagle/tree/master/android) modules. The dependency now is through library import. The lib is build and published locally when Appium Android app is compiled. 

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md