### PR TITLE
feat: improve Appium iOS tests speed

### DIFF
--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
@@ -420,6 +420,16 @@ abstract class AbstractStep {
         }
     }
 
+    /**
+     * Waits a short time before clicking on the element. This is necessary because Appium sometimes returns
+     * an element as clickable, but when the element is clicked, nothing happens. A possible cause to this might be that
+     * the element is inside another element (ex an alert) that is still loading when the click takes place.
+     */
+    protected fun safeClickOnElement(elementToBeClicked: MobileElement){
+        sleep(200)
+        elementToBeClicked.click()
+    }
+
     private fun getSearchByImageXpath(): By {
         val xpath: By
         if (SuiteSetup.isAndroid()) {

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
@@ -388,8 +388,9 @@ abstract class AbstractStep {
     }
 
     /**
-     * Explain native locators vs xpath ...
-     * explain that the caching strategy of native locators might change depending on a certain capability (https://github.com/appium/WebDriverAgent/pull/516)
+     * Native locators are faster than XPath. Only use XPath (nativeLocator = false) for situations where the property
+     * used to locate an element is changed and the element object is still required afterwards. More details on
+     * https://discuss.appium.io/t/elements-state-coming-from-xpath-vs-ios-predicate-string/34016
      */
     private fun getPropertyLocator(
         elementProperty: String,
@@ -403,7 +404,7 @@ abstract class AbstractStep {
             return if (SuiteSetup.isAndroid()) {
 
                 /**
-                 *  TODO: still retuning xpath, should be changed for Android's native locator, UISelector.
+                 *  TODO: still using xpath, should be changed for Android's native locator, UISelector.
                  *  src: http://appium.io/docs/en/writing-running-appium/android/uiautomator-uiselector/
                  */
                 AppiumUtil.getXpathLocator(elementProperty, escapedElementPropertyValue, likeSearch, ignoreCase)
@@ -425,7 +426,7 @@ abstract class AbstractStep {
      * an element as clickable, but when the element is clicked, nothing happens. A possible cause to this might be that
      * the element is inside another element (ex an alert) that is still loading when the click takes place.
      */
-    protected fun safeClickOnElement(elementToBeClicked: MobileElement){
+    protected fun safeClickOnElement(elementToBeClicked: MobileElement) {
         sleep(200)
         elementToBeClicked.click()
     }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
@@ -90,7 +90,7 @@ abstract class AbstractStep {
         likeSearch: Boolean,
         ignoreCase: Boolean
     ): MobileElement {
-        val xpath: By = getSearchByTextXpath(elementText, likeSearch, ignoreCase)
+        val xpath: By = getNamePropertyLocator(elementText, likeSearch, ignoreCase, nativeLocator = true)
         return AppiumUtil.waitForElementToBeClickable(
             getDriver(),
             xpath,
@@ -107,13 +107,24 @@ abstract class AbstractStep {
         likeSearch: Boolean,
         ignoreCase: Boolean
     ): MobileElement {
-        val xpath: By = getSearchByValueXpath(elementValue, likeSearch, ignoreCase)
+        return waitForElementWithValueToBeClickable(elementValue, likeSearch, ignoreCase, true)
+    }
+
+    /**
+     * Waits for an element to be visible and enabled (clickable)
+     */
+    protected fun waitForElementWithValueToBeClickable(
+        elementValue: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean,
+        nativeLocator: Boolean
+    ): MobileElement {
+        val xpath: By = getValuePropertyLocator(elementValue, likeSearch, ignoreCase, nativeLocator)
         return AppiumUtil.waitForElementToBeClickable(
             getDriver(),
             xpath,
             DEFAULT_ELEMENT_WAIT_TIME_IN_MILL
         )
-
     }
 
     /**
@@ -124,13 +135,12 @@ abstract class AbstractStep {
         likeSearch: Boolean,
         ignoreCase: Boolean
     ): MobileElement {
-        val xpath: By = getSearchByValueXpath(elementValue, likeSearch, ignoreCase)
+        val xpath: By = getValuePropertyLocator(elementValue, likeSearch, ignoreCase, true)
         return AppiumUtil.waitForElementToBePresent(
             getDriver(),
             xpath,
             DEFAULT_ELEMENT_WAIT_TIME_IN_MILL
         )
-
     }
 
     /**
@@ -141,7 +151,7 @@ abstract class AbstractStep {
         likeSearch: Boolean,
         ignoreCase: Boolean
     ): MobileElement {
-        val xpath: By = getSearchByTextXpath(elementValue, likeSearch, ignoreCase)
+        val xpath: By = getNamePropertyLocator(elementValue, likeSearch, ignoreCase, nativeLocator = true)
         return AppiumUtil.waitForElementToBePresent(
             getDriver(),
             xpath,
@@ -175,32 +185,48 @@ abstract class AbstractStep {
     /**
      * Waits for an element to be visible and disabled (not clickable)
      */
-    protected fun waitForElementWithTextToBeDisabled(elementText: String, likeSearch: Boolean, ignoreCase: Boolean) {
-        val xpath: By = getSearchByTextXpath(elementText, likeSearch, ignoreCase)
+    protected fun waitForElementWithTextToBeDisabled(
+        elementText: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean
+    ) {
+        val xpath: By = getNamePropertyLocator(elementText, likeSearch, ignoreCase, nativeLocator = true)
         AppiumUtil.waitForElementToBeDisabled(getDriver(), xpath, DEFAULT_ELEMENT_WAIT_TIME_IN_MILL)
     }
 
     /**
      * Waits for an element to be visible and disabled (not clickable)
      */
-    protected fun waitForElementWithValueToBeDisabled(elementValue: String, likeSearch: Boolean, ignoreCase: Boolean) {
-        val xpath: By = getSearchByValueXpath(elementValue, likeSearch, ignoreCase)
+    protected fun waitForElementWithValueToBeDisabled(
+        elementValue: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean
+    ) {
+        val xpath: By = getValuePropertyLocator(elementValue, likeSearch, ignoreCase, nativeLocator = true)
         AppiumUtil.waitForElementToBeDisabled(getDriver(), xpath, DEFAULT_ELEMENT_WAIT_TIME_IN_MILL)
     }
 
     /**
      * Waits for an element to be hidden or nonexistent
      */
-    protected fun waitForElementWithTextToBeInvisible(elementText: String, likeSearch: Boolean, ignoreCase: Boolean) {
-        val xpath: By = getSearchByTextXpath(elementText, likeSearch, ignoreCase)
+    protected fun waitForElementWithTextToBeInvisible(
+        elementText: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean
+    ) {
+        val xpath: By = getNamePropertyLocator(elementText, likeSearch, ignoreCase, nativeLocator = true)
         AppiumUtil.waitForElementToBeInvisible(getDriver(), xpath, DEFAULT_ELEMENT_WAIT_TIME_IN_MILL)
     }
 
     /**
      * Waits for an element to be hidden or nonexistent
      */
-    protected fun waitForElementWithValueToBeInvisible(elementValue: String, likeSearch: Boolean, ignoreCase: Boolean) {
-        val xpath: By = getSearchByValueXpath(elementValue, likeSearch, ignoreCase)
+    protected fun waitForElementWithValueToBeInvisible(
+        elementValue: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean
+    ) {
+        val xpath: By = getValuePropertyLocator(elementValue, likeSearch, ignoreCase, nativeLocator = true)
         AppiumUtil.waitForElementToBeInvisible(getDriver(), xpath, DEFAULT_ELEMENT_WAIT_TIME_IN_MILL)
     }
 
@@ -209,7 +235,7 @@ abstract class AbstractStep {
         likeSearch: Boolean,
         ignoreCase: Boolean
     ): MobileElement {
-        val locator = getSearchByTextXpath(elementText, likeSearch, ignoreCase)
+        val locator = getNamePropertyLocator(elementText, likeSearch, ignoreCase, false)
         return scrollToElement(locator, SwipeDirection.UP) // swiping up scrolls down...
     }
 
@@ -218,7 +244,7 @@ abstract class AbstractStep {
         likeSearch: Boolean,
         ignoreCase: Boolean
     ): MobileElement {
-        val locator = getSearchByValueXpath(elementValue, likeSearch, ignoreCase)
+        val locator = getValuePropertyLocator(elementValue, likeSearch, ignoreCase, false)
         return scrollToElement(locator, SwipeDirection.UP)
     }
 
@@ -227,7 +253,7 @@ abstract class AbstractStep {
         likeSearch: Boolean,
         ignoreCase: Boolean
     ): MobileElement {
-        val locator = getSearchByTextXpath(elementText, likeSearch, ignoreCase)
+        val locator = getNamePropertyLocator(elementText, likeSearch, ignoreCase, false)
         return scrollToElement(locator, SwipeDirection.DOWN) // swiping down scrolls up...
     }
 
@@ -236,7 +262,7 @@ abstract class AbstractStep {
         likeSearch: Boolean,
         ignoreCase: Boolean
     ): MobileElement {
-        val locator = getSearchByValueXpath(elementText, likeSearch, ignoreCase)
+        val locator = getValuePropertyLocator(elementText, likeSearch, ignoreCase, false)
         return scrollToElement(locator, SwipeDirection.DOWN) // swiping down scrolls up...
     }
 
@@ -328,28 +354,70 @@ abstract class AbstractStep {
 
 
     protected fun rotateToLandscapePosition() {
-        getDriver().rotate(ScreenOrientation.LANDSCAPE);
+        getDriver().rotate(ScreenOrientation.LANDSCAPE)
     }
 
     protected fun rotateToPortraitPosition() {
-        getDriver().rotate(ScreenOrientation.PORTRAIT);
+        getDriver().rotate(ScreenOrientation.PORTRAIT)
     }
 
-    private fun getSearchByTextXpath(elementText: String, likeSearch: Boolean, ignoreCase: Boolean): By {
-        val property = if (SuiteSetup.isAndroid())
+    private fun getNamePropertyLocator(
+        elementPropertyValue: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean,
+        nativeLocator: Boolean
+    ): By {
+        val elementProperty = if (SuiteSetup.isAndroid())
             "text"
         else
             "name"
-
-        return AppiumUtil.getPropertyXpath(property, elementText, likeSearch, ignoreCase)
+        return getPropertyLocator(elementProperty, elementPropertyValue, likeSearch, ignoreCase, nativeLocator)
     }
 
-    private fun getSearchByValueXpath(elementHint: String, likeSearch: Boolean, ignoreCase: Boolean): By {
-        val property = if (SuiteSetup.isAndroid())
+    private fun getValuePropertyLocator(
+        elementPropertyValue: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean,
+        nativeLocator: Boolean
+    ): By {
+        val elementProperty = if (SuiteSetup.isAndroid())
             "text"
         else
             "value"
-        return AppiumUtil.getPropertyXpath(property, elementHint, likeSearch, ignoreCase)
+        return getPropertyLocator(elementProperty, elementPropertyValue, likeSearch, ignoreCase, nativeLocator)
+    }
+
+    /**
+     * Explain native locators vs xpath ...
+     * explain that the caching strategy of native locators might change depending on a certain capability (https://github.com/appium/WebDriverAgent/pull/516)
+     */
+    private fun getPropertyLocator(
+        elementProperty: String,
+        elementPropertyValue: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean,
+        nativeLocator: Boolean
+    ): By {
+        if (nativeLocator) {
+            val escapedElementPropertyValue = elementPropertyValue.replace("'", "\\'")
+            return if (SuiteSetup.isAndroid()) {
+
+                /**
+                 *  TODO: still retuning xpath, should be changed for Android's native locator, UISelector.
+                 *  src: http://appium.io/docs/en/writing-running-appium/android/uiautomator-uiselector/
+                 */
+                AppiumUtil.getXpathLocator(elementProperty, escapedElementPropertyValue, likeSearch, ignoreCase)
+            } else {
+                AppiumUtil.getIOSNsPredicateLocator(
+                    elementProperty,
+                    escapedElementPropertyValue,
+                    likeSearch,
+                    ignoreCase
+                )
+            }
+        } else {
+            return AppiumUtil.getXpathLocator(elementProperty, elementPropertyValue, likeSearch, ignoreCase)
+        }
     }
 
     private fun getSearchByImageXpath(): By {
@@ -364,18 +432,18 @@ abstract class AbstractStep {
 
 
     protected fun isTextFieldNumeric(elementText: String): Boolean {
-        val textElement = waitForElementWithValueToBeClickable(elementText, false, false)
+        val textElement = waitForElementWithValueToBeClickable(elementText, false, false, false)
         textElement.click()
         sleep(1000) // TouchActions sometimes get called before an element is ready to write
         if (SuiteSetup.isAndroid()) {
-            var androidActions = AndroidTouchAction(getDriver())
+            val androidActions = AndroidTouchAction(getDriver())
             androidActions.press(PointOption.point(500, 1700)).release().perform() // digit 5
         } else {
-            var iosActions = IOSTouchAction(getDriver())
+            val iosActions = IOSTouchAction(getDriver())
             iosActions.press(PointOption.point(160, 660)).release().perform()
         }
 
-        var typedChar =
+        val typedChar =
             if (textElement.text.length > 1) textElement.text.substring(textElement.text.length - 1)
             else textElement.text
 
@@ -496,11 +564,11 @@ abstract class AbstractStep {
         SuiteSetup.restartApp()
     }
 
-    protected fun elementExists(locator: By): Boolean{
+    protected fun elementExists(locator: By): Boolean {
         return AppiumUtil.elementExists(getDriver(), locator, 2000)
     }
 
-    protected fun childElementExists(parentElement: MobileElement, childLocator: By): Boolean{
+    protected fun childElementExists(parentElement: MobileElement, childLocator: By): Boolean {
         return AppiumUtil.childElementExists(getDriver(), parentElement, childLocator, 2000)
     }
 

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
@@ -23,6 +23,7 @@ import br.com.zup.beagle.utils.AppiumUtil
 import br.com.zup.beagle.utils.ImageUtil
 import br.com.zup.beagle.utils.SwipeDirection
 import io.appium.java_client.AppiumDriver
+import io.appium.java_client.MobileBy
 import io.appium.java_client.MobileElement
 import io.appium.java_client.android.AndroidTouchAction
 import io.appium.java_client.ios.IOSTouchAction
@@ -34,7 +35,6 @@ import org.openqa.selenium.JavascriptExecutor
 import org.openqa.selenium.Point
 import org.openqa.selenium.ScreenOrientation
 import java.io.File
-import java.util.HashMap
 
 
 abstract class AbstractStep {
@@ -431,14 +431,12 @@ abstract class AbstractStep {
         elementToBeClicked.click()
     }
 
-    private fun getSearchByImageXpath(): By {
-        val xpath: By
-        if (SuiteSetup.isAndroid()) {
-            xpath = By.xpath("//*[contains(@class,'ImageView')]")
+    private fun getImageLocator(): By {
+        return if (SuiteSetup.isAndroid()) {
+            MobileBy.className("android.widget.ImageView")
         } else {
-            xpath = By.xpath("//*[contains(@type,'XCUIElementTypeImage')]")
+            MobileBy.className("XCUIElementTypeImage")
         }
-        return xpath
     }
 
 
@@ -483,8 +481,7 @@ abstract class AbstractStep {
      * @return all image elements
      */
     protected fun waitForImageElements(): List<MobileElement> {
-        val xpath = getSearchByImageXpath()
-        return getDriver().findElements(xpath) as List<MobileElement>
+        return getDriver().findElements(getImageLocator()) as List<MobileElement>
     }
 
     /**
@@ -583,4 +580,18 @@ abstract class AbstractStep {
         return AppiumUtil.childElementExists(getDriver(), parentElement, childLocator, 2000)
     }
 
+    protected fun goBack() {
+        if (SuiteSetup.isAndroid()) {
+            getDriver().navigate().back()
+        } else {
+            // caution: not all iOS bff screens have the back button.
+            var locator = By.xpath("//XCUIElementTypeNavigationBar//XCUIElementTypeButton[1]")
+            safeClickOnElement(
+                AppiumUtil.waitForElementToBeClickable(
+                    getDriver(), locator,
+                    DEFAULT_ELEMENT_WAIT_TIME_IN_MILL
+                )
+            )
+        }
+    }
 }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AbstractStep.kt
@@ -407,7 +407,7 @@ abstract class AbstractStep {
                  *  TODO: still using xpath, should be changed for Android's native locator, UISelector.
                  *  src: http://appium.io/docs/en/writing-running-appium/android/uiautomator-uiselector/
                  */
-                AppiumUtil.getXpathLocator(elementProperty, escapedElementPropertyValue, likeSearch, ignoreCase)
+                AppiumUtil.getXpathLocator(elementProperty, elementPropertyValue, likeSearch, ignoreCase)
             } else {
                 AppiumUtil.getIOSNsPredicateLocator(
                     elementProperty,

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ActionNotRegisteredScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ActionNotRegisteredScreenSteps.kt
@@ -23,7 +23,7 @@ import io.cucumber.java.en.Then
 class ActionNotRegisteredScreenSteps : AbstractStep() {
     override var bffRelativeUrlPath = "/action-not-registered"
 
-    @Before("@unregisteredaction")
+    @Before("@unregisteredAction")
     fun setup() {
         loadBffScreen()
     }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AddChildrenScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AddChildrenScreenSteps.kt
@@ -16,6 +16,7 @@
 
 package br.com.zup.beagle.cucumber.steps
 
+import io.cucumber.datatable.DataTable
 import io.cucumber.java.Before
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
@@ -37,31 +38,40 @@ class AddChildrenScreenSteps : AbstractStep() {
 
     @Given("^that I'm on the addChildren Screen$")
     fun checkImageScreen() {
-        waitForElementWithTextToBeClickable(ADD_CHILDREN_HEADER, false, false)
+        waitForElementWithTextToBeClickable(ADD_CHILDREN_HEADER, likeSearch = false, ignoreCase = false)
     }
 
-    @Then("^A Text needs to be added after the already existing one$")
+    @Then("^A text needs to be added after the already existing one$")
     fun checkTextAddedAfterTheExistedOrder() {
         waitForFixedAndAddedTexts()
-        Assert.assertTrue(isElementAbove(TEXT_FIXED, TEXT_ADDED, false, false))
+        Assert.assertTrue(isElementAbove(TEXT_FIXED, TEXT_ADDED, likeSearch = false, ignoreCase = false))
     }
 
-    @Then("^A Text needs to be added before the already existing one$")
+    @Then("^A text needs to be added before the already existing one$")
     fun checkTextAddedBeforeTheExistedOrder() {
         waitForFixedAndAddedTexts()
-        Assert.assertTrue(isElementAbove(TEXT_ADDED, TEXT_FIXED, false, false))
+        Assert.assertTrue(isElementAbove(TEXT_ADDED, TEXT_FIXED, likeSearch = false, ignoreCase = false))
     }
 
-    @Then("^A Text needs to replace the already existing one$")
+    @Then("^A text needs to replace the already existing one$")
     fun checkTextReplaceTheExistedOne() {
         waitForAddedText()
-        waitForElementWithTextToBeInvisible(TEXT_FIXED, false, false)
+        waitForElementWithTextToBeInvisible(TEXT_FIXED, likeSearch = false, ignoreCase = false)
     }
 
-    @Then("^Nothing should happen$")
-    fun checkTextAddedPositionIsNull() {
-        waitForFixedText()
-        waitForElementWithTextToBeInvisible(TEXT_ADDED, false, false)
+    @Then("^Nothing should happen when clicking in the following buttons and the component doesn't exist:$")
+    fun checkNothingHappens(dataTable: DataTable) {
+        val rows: List<List<String?>> = dataTable.asLists(String::class.java)
+        for ((lineCount, columns) in rows.withIndex()) {
+
+            if (lineCount == 0) // skip header
+                continue
+
+            var buttonTitle = columns[0]!!
+            safeClickOnElement(waitForElementWithTextToBeClickable(buttonTitle, likeSearch = false, ignoreCase = true))
+            waitForFixedText()
+            waitForElementWithTextToBeInvisible(TEXT_ADDED, likeSearch = false, ignoreCase = false)
+        }
     }
 
     private fun waitForFixedAndAddedTexts() {
@@ -70,10 +80,10 @@ class AddChildrenScreenSteps : AbstractStep() {
     }
 
     private fun waitForFixedText() {
-        waitForElementWithTextToBeClickable(TEXT_FIXED, false, false)
+        waitForElementWithTextToBeClickable(TEXT_FIXED, likeSearch = false, ignoreCase = false)
     }
 
     private fun waitForAddedText() {
-        waitForElementWithTextToBeClickable(TEXT_ADDED, false, false)
+        waitForElementWithTextToBeClickable(TEXT_ADDED, likeSearch = false, ignoreCase = false)
     }
 }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AlertScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AlertScreenSteps.kt
@@ -54,7 +54,7 @@ class AlertScreenSteps : AbstractStep() {
 
     @Then("^I press the confirmation (.*) button on the alert$")
     fun clickOnTheConfirmationActionButtonWithText(string: String) {
-        waitForElementWithTextToBeClickable(string, false, true).click()
+       safeClickOnElement(waitForElementWithTextToBeClickable(string, false, true))
     }
 
     @Then("^an alert with a confirmation button with (.*) label should appear$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AlertScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/AlertScreenSteps.kt
@@ -16,10 +16,12 @@
 
 package br.com.zup.beagle.cucumber.steps
 
+import io.cucumber.datatable.DataTable
 import io.cucumber.java.Before
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
+import org.junit.Assert
 
 
 class AlertScreenSteps : AbstractStep() {
@@ -36,29 +38,33 @@ class AlertScreenSteps : AbstractStep() {
         waitForElementWithTextToBeClickable("Alert Screen", false, false)
     }
 
-    @When("^I press an alert button with the (.*) title$")
-    fun clickOnButton(string: String) {
-        waitForElementWithTextToBeClickable(string, false, false).click()
+
+    @Then("^validate the invoked alerts and its properties:$")
+    fun checkAlertProperties(dataTable: DataTable) {
+        val rows: List<List<String?>> = dataTable.asLists(String::class.java)
+        for ((lineCount, columns) in rows.withIndex()) {
+
+            if (lineCount == 0) // skip header
+                continue
+
+            var buttonTitle = columns[0]!!
+            var alertTitle = columns[1]!!
+            var alertMessage: String? = columns[2]
+            var alertButtonTitle = columns[3]!!
+
+            safeClickOnElement(waitForElementWithTextToBeClickable(buttonTitle, likeSearch = false, ignoreCase = false))
+
+            // checks if the alert appeared on screen with the correct properties
+            waitForElementWithTextToBeClickable(alertTitle, likeSearch = false, ignoreCase = false)
+            if (alertMessage != null && alertMessage.trim().isNotEmpty()) {
+                waitForElementWithTextToBeClickable(alertMessage, likeSearch = false, ignoreCase = false)
+            }
+
+            // checks if clicking on the alert button closes it
+            safeClickOnElement(waitForElementWithTextToBeClickable(alertButtonTitle, likeSearch = false, ignoreCase = true))
+            waitForElementWithTextToBeInvisible(alertTitle, likeSearch = false, ignoreCase = false)
+        }
     }
 
-    @Then("^an alert with the (.*) message should appear on the screen$")
-    fun checkAlertMessage(string: String) {
-        waitForElementWithTextToBeClickable(string, false, false)
-    }
 
-    @Then("^an alert with the (.*) and (.*) should appear on the screen$")
-    fun checkAlertMessageAndTitle(string: String, string2: String) {
-        waitForElementWithTextToBeClickable(string, false, false)
-        waitForElementWithTextToBeClickable(string2, false, false)
-    }
-
-    @Then("^I press the confirmation (.*) button on the alert$")
-    fun clickOnTheConfirmationActionButtonWithText(string: String) {
-       safeClickOnElement(waitForElementWithTextToBeClickable(string, false, true))
-    }
-
-    @Then("^an alert with a confirmation button with (.*) label should appear$")
-    fun checkAlertConfirmationButtonLabelIsSetWithText(string: String) {
-        waitForElementWithTextToBeClickable(string, false, true)
-    }
 }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ButtonScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ButtonScreenSteps.kt
@@ -64,23 +64,4 @@ class ButtonScreenSteps : AbstractStep() {
         }
     }
 
-    /**
-     * TODO: include navigation bar on all iOS screens and make this method global in AbstractStep?
-     * That would help tests not to restart apps in many cases
-     */
-    private fun goBack() {
-        if (SuiteSetup.isAndroid()) {
-            getDriver().navigate().back()
-        } else {
-            safeClickOnElement(
-                waitForElementWithTextToBeClickable(
-                    "Beagle Button",
-                    likeSearch = false,
-                    ignoreCase = false
-                )
-            )
-        }
-    }
-
-
 }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ButtonScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ButtonScreenSteps.kt
@@ -57,7 +57,7 @@ class ButtonScreenSteps : AbstractStep() {
                 Assert.assertFalse(buttonElement.isEnabled)
             } else {
                 safeClickOnElement(buttonElement)
-                waitForElementWithTextToBePresent(ACTION_CLICK_TEXT, likeSearch = false, ignoreCase = false)
+                waitForElementWithTextToBeClickable(ACTION_CLICK_TEXT, likeSearch = false, ignoreCase = false)
                 goBack()
                 waitForElementWithTextToBeInvisible(ACTION_CLICK_TEXT, likeSearch = false, ignoreCase = false)
             }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConditionalScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConditionalScreenSteps.kt
@@ -16,6 +16,7 @@
 
 package br.com.zup.beagle.cucumber.steps
 
+import io.cucumber.datatable.DataTable
 import io.cucumber.java.Before
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
@@ -34,14 +35,21 @@ class ConditionalScreenSteps : AbstractStep() {
         waitForElementWithTextToBeClickable("Conditional Screen", false, false)
     }
 
-    @When("^I click in a conditional button with (.*) title$")
-    fun clickOnButton(string: String) {
-        waitForElementWithTextToBeClickable(string, false, false).click()
-    }
+    @Then("^validate the invoked alerts and its message:$")
+    fun checkAlertProperties(dataTable: DataTable) {
+        val rows: List<List<String?>> = dataTable.asLists(String::class.java)
+        for ((lineCount, columns) in rows.withIndex()) {
 
-    @Then("^an Alert action should pop up with a (.*) message$")
-    fun checkGlobalTextScreen(string2: String) {
-        waitForElementWithTextToBeClickable(string2, false, false)
-    }
+            if (lineCount == 0) // skip header
+                continue
 
+            var buttonTitle = columns[0]!!
+            var alertMessage = columns[1]!!
+
+            safeClickOnElement(waitForElementWithTextToBeClickable(buttonTitle, likeSearch = false, ignoreCase = false))
+            waitForElementWithTextToBeClickable(alertMessage, likeSearch = false, ignoreCase = false)
+            safeClickOnElement(waitForElementWithTextToBeClickable("OK", likeSearch = false, ignoreCase = true))
+            waitForElementWithTextToBeInvisible("OK", likeSearch = false, ignoreCase = true)
+        }
+    }
 }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConditionalScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConditionalScreenSteps.kt
@@ -20,7 +20,6 @@ import io.cucumber.datatable.DataTable
 import io.cucumber.java.Before
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
-import io.cucumber.java.en.When
 
 class ConditionalScreenSteps : AbstractStep() {
     override var bffRelativeUrlPath = "/conditional"

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConfirmScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/ConfirmScreenSteps.kt
@@ -52,7 +52,7 @@ class ConfirmScreenSteps : AbstractStep() {
 
     @Then("^I press the confirmation (.*) button on the confirm component$")
     fun clickOnTheConfirmationActionButtonWithText(string: String) {
-        waitForElementWithTextToBeClickable(string, false, true).click()
+        safeClickOnElement(waitForElementWithTextToBeClickable(string, false, true))
     }
 
     @Then("^a confirm with a button with (.*) label should appear$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/GenericSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/GenericSteps.kt
@@ -27,7 +27,7 @@ class GenericSteps : AbstractStep() {
 
     @When("^I click on button (.*)$")
     fun clickOnButton(string1: String) {
-        waitForElementWithTextToBeClickable(string1, likeSearch = false, ignoreCase = true).click()
+        safeClickOnElement(waitForElementWithTextToBeClickable(string1, likeSearch = false, ignoreCase = true))
     }
 
     @Then("^The Text should show (.*)$")
@@ -37,7 +37,7 @@ class GenericSteps : AbstractStep() {
 
     @When("^I click on text (.*)$")
     fun clickOnText(string1: String) {
-        waitForElementWithTextToBeClickable(string1, likeSearch = false, ignoreCase = true).click()
+        safeClickOnElement(waitForElementWithTextToBeClickable(string1, likeSearch = false, ignoreCase = true))
     }
 
     @When("^I click on input with hint (.*)$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/GenericSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/GenericSteps.kt
@@ -26,18 +26,18 @@ class GenericSteps : AbstractStep() {
     override var bffRelativeUrlPath = ""
 
     @When("^I click on button (.*)$")
-    fun clickOnButton(string1: String) {
-        safeClickOnElement(waitForElementWithTextToBeClickable(string1, likeSearch = false, ignoreCase = true))
+    fun clickOnButton(buttonText: String) {
+        safeClickOnElement(waitForElementWithTextToBeClickable(buttonText, likeSearch = false, ignoreCase = true))
     }
 
     @Then("^The Text should show (.*)$")
-    fun textShouldShow(string1: String) {
-        waitForElementWithTextToBeClickable(string1, likeSearch = false, ignoreCase = true)
+    fun textShouldShow(text: String) {
+        waitForElementWithTextToBeClickable(text, likeSearch = false, ignoreCase = true)
     }
 
     @When("^I click on text (.*)$")
-    fun clickOnText(string1: String) {
-        safeClickOnElement(waitForElementWithTextToBeClickable(string1, likeSearch = false, ignoreCase = true))
+    fun clickOnText(text: String) {
+        safeClickOnElement(waitForElementWithTextToBeClickable(text, likeSearch = false, ignoreCase = true))
     }
 
     @When("^I click on input with hint (.*)$")
@@ -51,8 +51,8 @@ class GenericSteps : AbstractStep() {
     }
 
     @Then("^a dialog should appear on the screen with text (.*)$")
-    fun checkDialog(string: String) {
-        waitForElementWithTextToBeClickable(string, likeSearch = true, ignoreCase = true)
+    fun checkDialog(text: String) {
+        waitForElementWithTextToBeClickable(text, likeSearch = true, ignoreCase = true)
     }
 
     @Then("^the screen should show an element with the place holder (.*)$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TextInputScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TextInputScreenSteps.kt
@@ -72,52 +72,56 @@ class TextInputScreenSteps : AbstractStep() {
     }
 
     @Then("^verify if the text (.*) is in the second plan$")
-    fun checkKeyboardFocus(string: String) {
-        val mobileElement = waitForElementWithValueToBeClickable(string, false, false)
-        Assert.assertTrue(string.equals(mobileElement.text))
+    fun checkKeyboardFocus(elementText: String) {
+        val mobileElement = waitForElementWithValueToBeClickable(elementText,
+            likeSearch = false,
+            ignoreCase = false,
+            nativeLocator = false
+        )
+        Assert.assertTrue(elementText.equals(mobileElement.text))
         mobileElement.sendKeys("a")
-        Assert.assertFalse(string.equals(mobileElement.text))
+        Assert.assertFalse(elementText.equals(mobileElement.text))
         mobileElement.clear()
-        Assert.assertTrue(string.equals(mobileElement.text))
+        Assert.assertTrue(elementText.equals(mobileElement.text))
     }
 
     @Then("^validate that the value of the text input component (.*) of type \"date\" is shown correctly$")
     fun checkDateWriting(string: String) {
-        val mobileElement = waitForElementWithValueToBeClickable(string, false, false)
+        val mobileElement = waitForElementWithValueToBeClickable(string,
+            likeSearch = false,
+            ignoreCase = false,
+            nativeLocator = false
+        )
         mobileElement.sendKeys("22/04/1500")
         waitForElementWithValueToBeClickable("22/04/1500", false, false)
     }
 
     @Then("^validate that the value of the text input component (.*) of type \"email\" is shown correctly$")
     fun checkEmailWriting(string: String) {
-        scrollUpToElementWithValue(string, false, false)
-        val mobileElement = waitForElementWithValueToBeClickable(string, false, false)
+        val mobileElement = scrollUpToElementWithValue(string, false, false)
         mobileElement.sendKeys("test@abc.com")
         waitForElementWithValueToBeClickable("test@abc.com", false, false)
     }
 
     @Then("^validate that the value of the text input component (.*) of type \"password\" is shown correctly$")
-    fun checkPasswordWriting(string: String) {
-        scrollDownToElementWithValue(string, false, false)
-        val mobileElement = waitForElementWithValueToBeClickable(string, false, false)
+    fun checkPasswordWriting(textElement: String) {
+        val mobileElement = scrollDownToElementWithValue(textElement, false, false)
         mobileElement.sendKeys("123")
         Assert.assertTrue("123" != mobileElement.text) // validates text is in password format
         Assert.assertTrue(mobileElement.text.length == 3)
-        Assert.assertTrue(string != mobileElement.text)
+        Assert.assertTrue(textElement != mobileElement.text)
     }
 
     @Then("^validate that the value of the text input component (.*) of type \"number\" is shown correctly$")
     fun checkNumberWriting(string: String) {
-        scrollDownToElementWithValue(string, false, false)
-        val mobileElement = waitForElementWithValueToBeClickable(string, false, false)
+        val mobileElement = scrollDownToElementWithValue(string, false, false)
         mobileElement.sendKeys("12345678")
         waitForElementWithValueToBeClickable("12345678", false, false)
     }
 
     @Then("^validate that the value of the text input component (.*) of type \"text\" is shown correctly$")
     fun checkTextWriting(string: String) {
-        scrollDownToElementWithValue(string, false, false)
-        val mobileElement = waitForElementWithValueToBeClickable(string, false, false)
+        val mobileElement = scrollDownToElementWithValue(string, false, false)
         mobileElement.sendKeys("This is a test!")
         waitForElementWithValueToBeClickable("This is a test!", false, false)
     }
@@ -130,8 +134,7 @@ class TextInputScreenSteps : AbstractStep() {
 
     @And("^I click the textInput with the placeholder (.*)$")
     fun textInputWithActionOfOnFocus(string: String) {
-        scrollDownToElementWithValue(string, false, false)
-        waitForElementWithValueToBeClickable(string, false, false).click()
+        scrollDownToElementWithValue(string, false, false).click()
     }
 
     @Then("^the textInput with the placeholder \"Ordered actions\" should have value (.*)$")
@@ -150,12 +153,11 @@ class TextInputScreenSteps : AbstractStep() {
     }
 
     @When("^I click to textInput (.*) then change to (.*) and to (.*)$")
-    fun textInoutWithActionOfOnFocusAndOnChange(string: String, string2: String, string3: String) {
-        scrollUpToElementWithValue(string, false, false)
-        val mobileElement = waitForElementWithValueToBeClickable(string, false, false)
-        waitForElementWithValueToBeClickable(string2, false, false)
-        mobileElement.sendKeys("a")
-        waitForElementWithValueToBeClickable(string3, false, false)
+    fun textInoutWithActionOfOnFocusAndOnChange(elementText1: String, elementText2: String, elementText3: String) {
+        val mobileElement = scrollUpToElementWithValue(elementText1, false, false)
+        waitForElementWithValueToBeClickable(elementText2, false, false, false)
+        mobileElement.sendKeys("a") // TODO: validar a'?
+        waitForElementWithValueToBeClickable(elementText3, false, false)
     }
 
     @Then("^the text (.*) should be appear in the correctly order$")

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TouchScreenSteps.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/cucumber/steps/TouchScreenSteps.kt
@@ -16,17 +16,13 @@
 
 package br.com.zup.beagle.cucumber.steps
 
+import io.cucumber.datatable.DataTable
 import io.cucumber.java.Before
-import io.cucumber.java.en.And
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
-import io.cucumber.java.en.When
 
 private const val TOUCHABLE_SCREEN_HEADER = "Beagle Touchable"
-private const val TOUCHABLE_TEXT_1 = "Text with Touchable"
-private const val TOUCHABLE_TEXT_2 = "Click here!"
-private const val TOUCHABLE_TEXT_3 = "Image with Touchable"
-private const val TOUCHABLE_TEXT_4 = "NetworkImage with Touchable"
+private const val TOUCHABLE_REDIRECT_TEXT = "You clicked right"
 
 class TouchScreenSteps : AbstractStep() {
     override var bffRelativeUrlPath = "/touchable"
@@ -41,33 +37,27 @@ class TouchScreenSteps : AbstractStep() {
         waitForElementWithTextToBeClickable(TOUCHABLE_SCREEN_HEADER, false, false)
     }
 
-    @And("^I have a text with touchable configured$")
-    fun checkTextWithTouchable() {
-        waitForElementWithTextToBeClickable(TOUCHABLE_TEXT_1, false, false)
-        waitForElementWithTextToBeClickable(TOUCHABLE_TEXT_2, false, false)
-    }
+    @Then("^validate touchable clicks:$")
+    fun checkTouchableCliks(dataTable: DataTable) {
+        val rows: List<List<String?>> = dataTable.asLists(String::class.java)
+        for ((lineCount, columns) in rows.withIndex()) {
 
-    @And("^I have an image with touchable configured$")
-    fun checkImageWithTouchable() {
-        waitForElementWithTextToBeClickable(TOUCHABLE_TEXT_3, false, false)
-    }
+            if (lineCount == 0) // skip header
+                continue
+            var touchableText = columns[0]!!
 
-    @When("^I click on touchable text (.*)$")
-    fun clickOnTouchableText(string1: String) {
-        waitForElementWithTextToBeClickable(string1, false, false).click()
-    }
+            if ("Text 1" == touchableText) {
+                waitForElementWithTextToBeClickable("Click here!", likeSearch = false, ignoreCase = false).click()
+            } else if ("Image 1" == touchableText) {
+                safeClickOnElement(waitForImageElements()[0])
+            } else if ("Image 2" == touchableText) {
+                safeClickOnElement(waitForImageElements()[1])
+            }
 
-    @When("^I click on touchable image$")
-    fun clickOnTouchableImage() {
-        waitForImageElementToBeVisible(0).click()
+            waitForElementWithTextToBeClickable(TOUCHABLE_REDIRECT_TEXT, likeSearch = false, ignoreCase = false)
+            goBack()
+            waitForElementWithTextToBeInvisible(TOUCHABLE_REDIRECT_TEXT, likeSearch = false, ignoreCase = false)
 
-    }
-
-    @Then("^touchable screen should render all text attributes correctly$")
-    fun checkTouchableScreenTexts() {
-        waitForElementWithTextToBeClickable(TOUCHABLE_TEXT_1, false, false)
-        waitForElementWithTextToBeClickable(TOUCHABLE_TEXT_2, false, false)
-        waitForElementWithTextToBeClickable(TOUCHABLE_TEXT_3, false, false)
-        waitForElementWithTextToBeClickable(TOUCHABLE_TEXT_4, false, false)
+        }
     }
 }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/utils/AppiumUtil.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/utils/AppiumUtil.kt
@@ -714,12 +714,12 @@ object AppiumUtil {
         ignoreCase: Boolean
     ): By {
 
-        return if (ignoreCase && likeSearch) {
+        return if (likeSearch && ignoreCase) {
             MobileBy.iOSNsPredicateString("$elementProperty CONTAINS[c] '${elementPropertyValue}'")
-        } else if (ignoreCase) {
-            MobileBy.iOSNsPredicateString("$elementProperty BEGINSWITH[c] '${elementPropertyValue}'")
         } else if (likeSearch) {
             MobileBy.iOSNsPredicateString("$elementProperty CONTAINS '${elementPropertyValue}'")
+        } else if (ignoreCase) {
+            MobileBy.iOSNsPredicateString("$elementProperty ==[c] '${elementPropertyValue}'")
         } else {
             MobileBy.iOSNsPredicateString("$elementProperty == '${elementPropertyValue}'")
         }

--- a/tests/appium/project/src/test/kotlin/br/com/zup/beagle/utils/AppiumUtil.kt
+++ b/tests/appium/project/src/test/kotlin/br/com/zup/beagle/utils/AppiumUtil.kt
@@ -683,7 +683,7 @@ object AppiumUtil {
     }
 
     @Synchronized
-    fun getPropertyXpath(property: String, propertyValue: String, likeSearch: Boolean, ignoreCase: Boolean): By {
+    fun getXpathLocator(property: String, propertyValue: String, likeSearch: Boolean, ignoreCase: Boolean): By {
         var key = "@$property"
         var value = "\"$propertyValue\""
 
@@ -696,6 +696,32 @@ object AppiumUtil {
             By.xpath("//*[contains($key, $value)]")
         } else {
             By.xpath("//*[$key=$value]")
+        }
+    }
+
+    /**
+     * Uses a native iOS locator strategy. Faster than XPath
+     *
+     * src:
+     *  https://github.com/facebookarchive/WebDriverAgent/wiki/Predicate-Queries-Construction-Rules
+     *  https://appium.io/docs/en/writing-running-appium/ios/ios-predicate/#ios-predicate
+     */
+    @Synchronized
+    fun getIOSNsPredicateLocator(
+        elementProperty: String,
+        elementPropertyValue: String,
+        likeSearch: Boolean,
+        ignoreCase: Boolean
+    ): By {
+
+        return if (ignoreCase && likeSearch) {
+            MobileBy.iOSNsPredicateString("$elementProperty CONTAINS[c] '${elementPropertyValue}'")
+        } else if (ignoreCase) {
+            MobileBy.iOSNsPredicateString("$elementProperty BEGINSWITH[c] '${elementPropertyValue}'")
+        } else if (likeSearch) {
+            MobileBy.iOSNsPredicateString("$elementProperty CONTAINS '${elementPropertyValue}'")
+        } else {
+            MobileBy.iOSNsPredicateString("$elementProperty == '${elementPropertyValue}'")
         }
     }
 

--- a/tests/appium/project/src/test/resources/features/ActionNotRegistered.feature
+++ b/tests/appium/project/src/test/resources/features/ActionNotRegistered.feature
@@ -14,16 +14,15 @@
 # limitations under the License.
 #
 
-@unregisteredaction @android @ios
+@unregisteredAction @android @ios
 Feature: Unregistered action Validation
 
     As a Beagle developer/user
     I'd like to make sure my application does not crash when an unregistered action is triggered
-    In order to guarantee that my application never fails
 
     Background:
         Given the Beagle application did launch with the ActionNotRegistered Screen url
 
     Scenario: Unregistered action 01 - The application mustn't crash when an unregistered action is triggered
         When I click on button ClickToCallActionNotRegistered
-        Then nothing happens and the ActionNotRegistered Screen should still be visible
+        Then the screen should show an element with the title ActionNotRegistered Screen

--- a/tests/appium/project/src/test/resources/features/AddChildren.feature
+++ b/tests/appium/project/src/test/resources/features/AddChildren.feature
@@ -16,37 +16,31 @@
 
 @addChildren @android @ios
 Feature: AddChildren validation
-    As a Beagle developer/user
-    I'd like to make sure my addChildren action works as expected
-    In order to guarantee that my application never fails
+  As a Beagle developer/user
+  I'd like to make sure my addChildren action works as expected
 
-    Background:
-        Given that I'm on the addChildren Screen
+  Background:
+    Given that I'm on the addChildren Screen
 
-    Scenario: Default - AddChildren append a Text in the container children
-        When I click on button DEFAULT
-        Then A Text needs to be added after the already existing one
+  Scenario: AddChildren 01 - Default - AddChildren append a Text in the container children
+    When I click on button DEFAULT
+    Then A text needs to be added after the already existing one
 
-    Scenario: Prepend - AddChildren prepend a Text in the container children
-        When I click on button PREPEND
-        Then A Text needs to be added before the already existing one
+  Scenario: AddChildren 02 - Prepend - AddChildren prepend a Text in the container children
+    When I click on button PREPEND
+    Then A text needs to be added before the already existing one
 
-    Scenario: Append - AddChildren append a Text in the container children
-        When I click on button APPEND
-        Then A Text needs to be added after the already existing one
+  Scenario: AddChildren 03 - Append - AddChildren append a Text in the container children
+    When I click on button APPEND
+    Then A text needs to be added after the already existing one
 
-    Scenario: Replace - AddChildren replace the children container to a Text
-        When I click on button REPLACE
-        Then A Text needs to replace the already existing one
+  Scenario: AddChildren 04 - Replace - AddChildren replace the children container to a Text
+    When I click on button REPLACE
+    Then A text needs to replace the already existing one
 
-    Scenario: Prepend component doesn't exist - AddChildren replace the children container to a Text
-        When I click on button PREPEND COMPONENT NULL
-        Then Nothing should happen
-
-    Scenario: Append component doesn't exist - AddChildren replace the children container to a Text
-        When I click on button APPEND COMPONENT NULL
-        Then Nothing should happen
-
-    Scenario: Replace component doesn't exist - AddChildren replace the children container to a Text
-        When I click on button REPLACE COMPONENT NULL
-        Then Nothing should happen
+  Scenario: AddChildren 05 - No actions when the component doesn't exist
+    Then Nothing should happen when clicking in the following buttons and the component doesn't exist:
+      | BUTTON                 |
+      | PREPEND COMPONENT NULL |
+      | APPEND COMPONENT NULL  |
+      | REPLACE COMPONENT NULL |

--- a/tests/appium/project/src/test/resources/features/Alert.feature
+++ b/tests/appium/project/src/test/resources/features/Alert.feature
@@ -17,37 +17,23 @@
 @alert @android @ios
 Feature: Alert Action Validation
 
-    As a Beagle developer/user
-    I'd like to make sure my alert actions work as expected
-    In order to guarantee that my application never fails
+  As a Beagle developer/user
+  I'd like to make sure my alert actions work as expected
 
-    Background:
-        Given the Beagle application did launch with the alert screen url
+  Background:
+    Given the Beagle application did launch with the alert screen url
 
-    Scenario Outline: Scenario Outline: Alert 01 - The alert should display a message
-        When I press an alert button with the <buttonTitle> title
-        Then an alert with the <message> message should appear on the screen
+  Scenario: Alert 01 - Validate alert properties
+    Then validate the invoked alerts and its properties:
+      | BUTTON-TITLE                 | ALERT-TITLE               | ALERT-MESSAGE             | ALERT-BUTTON-TITTLE |
+      | JustAMessage                 | AlertMessage              |                           | OK                  |
+      | JustAMessageViaExpression    | AlertMessageViaExpression |                           | OK                  |
+      | TitleAndMessage              | AlertTitle                | AlertMessage              | OK                  |
+      | TitleAndMessageViaExpression | AlertTitleViaExpression   | AlertMessageViaExpression | OK                  |
+      | CustomAlertButton            | AlertMessage              |                           | CUSTOMLABEL         |
 
-        Examples:
-            | buttonTitle               | message                   |
-            | JustAMessage              | AlertMessage              |
-            | JustAMessageViaExpression | AlertMessageViaExpression |
-
-
-    Scenario Outline: Alert 02 - The alert should display a title and a message
-        When I press an alert button with the <buttonTitle> title
-        Then an alert with the <title> and <message> should appear on the screen
-
-        Examples:
-            | buttonTitle                  | title                   | message                   |
-            | TitleAndMessage              | AlertTitle              | AlertMessage              |
-            | TitleAndMessageViaExpression | AlertTitleViaExpression | AlertMessageViaExpression |
-
-    Scenario: Alert 03 - The alert should display an action on a confirmation
-        When I press an alert button with the AlertTriggersAnAction title
-        Then I press the confirmation OK button on the alert
-        Then an alert with the SecondAlert message should appear on the screen
-
-    Scenario: Alert 04 - The alert should display an confirmation button with a custom label
-        When I press an alert button with the CustomAlertButton title
-        Then an alert with a confirmation button with CustomLabel label should appear
+  Scenario: Alert 02 - The alert should display an action on a confirmation
+    When I click on text AlertTriggersAnAction
+    And I click on button OK
+    Then a dialog should appear on the screen with text SecondAlert
+  

--- a/tests/appium/project/src/test/resources/features/Button.feature
+++ b/tests/appium/project/src/test/resources/features/Button.feature
@@ -13,26 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-    
+
 @button @android @ios
 Feature: Button Component Validation
 
-    As a Beagle developer/user
-    I'd like to make sure my button component works as expected
-    In order to guarantee that my application never fails
+  As a Beagle developer/user
+  I'd like to make sure my button component works as expected
 
-    Background:
-        Given that I'm on the button screen
+  Background:
+    Given that I'm on the button screen
 
-    Scenario: Button 01 - Button component renders text attribute correctly
-        Then all my button components should render their respective text attributes correctly
-
-    Scenario Outline: Button 02 - Button component renders action attribute correctly
-        When I click on button <buttonText>
-        Then component should render the action attribute correctly
-
-        Examples:
-            |buttonText                       |
-            |Button                           |
-            |Button with style                |
-            |Button with Appearance           |
+  Scenario: Button 01 - Button components render action attributes correctly
+    Then validate button clicks:
+      | BUTTON-TEXT                      | ACTION   |
+      | Button                           | New page |
+      | Button with style                | New page |
+      | Button with Appearance           | New page |
+      | BUTTON WITH APPEARANCE AND STYLE | New page |
+      | Disabled Button                  | Disabled |
+#      | Disabled Button by context | Disabled | TODO: investigate why on mobile this button is enabled!

--- a/tests/appium/project/src/test/resources/features/Conditional.feature
+++ b/tests/appium/project/src/test/resources/features/Conditional.feature
@@ -17,39 +17,19 @@
 @conditional @android @ios
 Feature: Conditional Action Validation
 
-    As a Beagle developer/user
-    I'd like to make sure my conditional actions work as expected
-    In order to guarantee that my application never fails
+  As a Beagle developer/user
+  I'd like to make sure my conditional actions work as expected
 
-    Background:
-        Given the Beagle application did launch with the conditional screen url
 
-    Scenario Outline: Conditional 01 - Checks that the onTrue method is triggered when the condition
-    is set TRUE HARDCODED and via EXPRESSION
-        When I click in a conditional button with <buttonTitle> title
-        Then an Alert action should pop up with a TrueCondition message
+  Background:
+    Given the Beagle application did launch with the conditional screen url
 
-        Examples:
-            | buttonTitle                   |
-            | Condition true                |
-            | Condition via expression true |
-
-    Scenario Outline: Conditional 02 - Checks that the onFalse method is triggered when the condition
-    is set FALSE HARDCODED and via EXPRESSION
-        When I click in a conditional button with <buttonTitle> title
-        Then an Alert action should pop up with a FalseCondition message
-
-        Examples:
-            | buttonTitle                    |
-            | Condition false                |
-            | Condition via expression false |
-
-    Scenario: Conditional 03 - Checks that the onTrue method is triggered when an operation returns TRUE
-    on the condition attribute
-        When I click in a conditional button with Condition via valid expression operation title
-        Then an Alert action should pop up with a TrueCondition message
-
-    Scenario: Conditional 04 -  Checks that the onFalse method is triggered when a invalid expression is set
-    on the condition attribute
-        When I click in a conditional button with Condition via invalid expression title
-        Then an Alert action should pop up with a FalseCondition message
+  Scenario: Conditional 01 - Validate alert conditions
+    Then validate the invoked alerts and its message:
+      | BUTTON-TITLE                             | ALERT-MESSAGE  |
+      | Condition true                           | TrueCondition  |
+      | Condition via expression true            | TrueCondition  |
+      | Condition false                          | FalseCondition |
+      | Condition via expression false           | FalseCondition |
+      | Condition via valid expression operation | TrueCondition  |
+      | Condition via invalid expression         | FalseCondition |

--- a/tests/appium/project/src/test/resources/features/Touchable.feature
+++ b/tests/appium/project/src/test/resources/features/Touchable.feature
@@ -17,22 +17,29 @@
 @touchable @android @ios
 Feature: Touchable Component Validation
 
-    As a Beagle developer/user
-    I'd like to make sure my touchable component works as expected
-    In order to guarantee that my application never fails
+  As a Beagle developer/user
+  I'd like to make sure my touchable component works as expected
 
-    Background:
-        Given that I'm on the touchable screen
+  Background:
+    Given that I'm on the touchable screen
 
-    Scenario: Touchable 01 - Touchable component renders text attribute correctly
-        Then touchable screen should render all text attributes correctly
+  Scenario: Touchable 01 - touchable should render correctly
+    Then validate touchable clicks:
+      | TOUCHABLE-ELEMENT |
+      | Text 1            |
+      | Image 1           |
+      | Image 2           |
 
-    Scenario: Touchable 02 - Touchable component performs action click on text correctly
-        And I have a text with touchable configured
-        When I click on touchable text Click here!
-        Then component should render the action attribute correctly
 
-    Scenario: Touchable 03 - Touchable component performs action click on image correctly
-        And I have an image with touchable configured
-        When I click on touchable image
-        Then component should render the action attribute correctly
+#    Scenario: Touchable 01 - Touchable component renders text attribute correctly
+#        Then touchable screen should render all text attributes correctly
+#
+#    Scenario: Touchable 02 - Touchable component performs action click on text correctly
+#        And I have a text with touchable configured
+#        When I click on touchable text Click here!
+#        Then component should render the action attribute correctly
+#
+#    Scenario: Touchable 03 - Touchable component performs action click on image correctly
+#        And I have an image with touchable configured
+#        When I click on touchable image
+#        Then component should render the action attribute correctly


### PR DESCRIPTION
### Related Issues

#1500 

### Description and Example

- Improved test scenarios (ActionNotRegistered, Alert, AddChildren, Button, Conditional and Touchable). More tests will be improved on future PRs

- Improved element locator strategy for iOS. 

<img width="923" alt="iOS-comparisson" src="https://user-images.githubusercontent.com/73198010/122931761-90c48580-d343-11eb-9d17-993f27fc24ce.png">
<img width="939" alt="android-comparisson" src="https://user-images.githubusercontent.com/73198010/122931770-93bf7600-d343-11eb-9e06-9666e7307c5c.png">


### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Added a notice at the XPath section, commenting about native locators on iOS: https://github.com/ZupIT/beagle/wiki/Mobile-tests-with-Appium#xpath-element-attributes

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md