### PR TITLE
fix: components and actions in Flutter are now case insensitive

### DIFF
--- a/flutter/.editorconfig
+++ b/flutter/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 2

--- a/flutter/beagle/lib/beagle_sdk.dart
+++ b/flutter/beagle/lib/beagle_sdk.dart
@@ -61,15 +61,23 @@ class BeagleSdk {
     Map<String, Operation> customOperations,
   }) {
     httpClient = httpClient ?? const DefaultHttpClient();
+    actions = actions == null ? defaultActions : { ...defaultActions, ...actions };
+
+    Map<String, ComponentBuilder> lowercaseComponents = components.map(
+      (key, value) => MapEntry(key.toLowerCase(), value)
+    );
+
+    Map<String, ActionHandler> lowercaseActions = actions.map(
+      (key, value) => MapEntry(key.toLowerCase(), value)
+    );
     
     setupServiceLocator(
       beagleConfig: beagleConfig ?? DefaultEmptyConfig(),
       httpClient: httpClient,
-      components: components,
+      components: lowercaseComponents,
       storage: storage ?? DefaultStorage(),
       useBeagleHeaders: useBeagleHeaders ?? true,
-      actions:
-          actions == null ? defaultActions : {...defaultActions, ...actions},
+      actions: lowercaseActions,
       navigationControllers: navigationControllers,
       designSystem: designSystem ?? DefaultEmptyDesignSystem(),
       imageDownloader: imageDownloader ?? DefaultBeagleImageDownloader(httpClient: httpClient),

--- a/flutter/beagle/lib/beagle_widget.dart
+++ b/flutter/beagle/lib/beagle_widget.dart
@@ -91,7 +91,7 @@ class _BeagleWidget extends State<BeagleWidget> {
       ..onAction(({action, element, view}) {
         final handler = service.actions[action.getType().toLowerCase()];
         if (handler == null) {
-          logger.error("Couldn't find action with name ${action.getType()}. It will be ignored.");
+          return logger.error("Couldn't find action with name ${action.getType()}. It will be ignored.");
         }
         handler(
           action: action,

--- a/flutter/beagle/lib/beagle_widget.dart
+++ b/flutter/beagle/lib/beagle_widget.dart
@@ -89,15 +89,16 @@ class _BeagleWidget extends State<BeagleWidget> {
         });
       })
       ..onAction(({action, element, view}) {
-        final handler = service.actions[action.getType()];
-        if (handler != null) {
-          handler(
-            action: action,
-            view: view,
-            element: element,
-            context: context.findBuildContextForWidgetKey(element.getId()),
-          );
+        final handler = service.actions[action.getType().toLowerCase()];
+        if (handler == null) {
+          logger.error("Couldn't find action with name ${action.getType()}. It will be ignored.");
         }
+        handler(
+          action: action,
+          view: view,
+          element: element,
+          context: context.findBuildContextForWidgetKey(element.getId()),
+        );
       });
 
     if (widget.screenRequest != null) {
@@ -111,7 +112,7 @@ class _BeagleWidget extends State<BeagleWidget> {
 
   Widget _buildViewFromTree(BeagleUIElement tree) {
     final widgetChildren = tree.getChildren().map(_buildViewFromTree).toList();
-    final builder = service.components[tree.getType()];
+    final builder = service.components[tree.getType().toLowerCase()];
     if (builder == null) {
       logger.error("Can't find builder for component ${tree.getType()}");
       return BeagleUndefinedWidget(

--- a/flutter/beagle_components/lib/default_components.dart
+++ b/flutter/beagle_components/lib/default_components.dart
@@ -45,6 +45,8 @@ final Map<String, ComponentBuilder> defaultComponents = {
   'beagle:pageIndicator': beaglePageIndicatorBuilder(),
   'beagle:touchable': beagleTouchableBuilder(),
   'beagle:webView': beagleWebViewBuilder(),
+  'beagle:screenComponent': beagleContainerBuilder(),
+  'beagle:scrollView': beagleContainerBuilder(),
 };
 
 ComponentBuilder beagleLoadingBuilder() {


### PR DESCRIPTION
### Related Issues

closes: #1642 

### Description and Example

Components and actions are now case-insensitive. Since there were no test-files for `beagle_sdk` and `beagle_widget`, I didn't create new tests for this. Tests for both these files are necessary and should be implemented in a future PR.

I have also:
- created an editorconfig file;
- interpreted some missing components as containers while they're not implemented;
- added an error log when an action is not found.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [ ] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
