### PR TITLE
feat: flutter/scrollView

### DIFF
--- a/flutter/beagle/lib/utils/enum.dart
+++ b/flutter/beagle/lib/utils/enum.dart
@@ -16,12 +16,14 @@
  */
 
 import 'package:beagle/utils/string_utils.dart';
+import 'dart:developer';
 
 class EnumUtils {
   static T fromString<T>(List<T> values, String str) {
-    return values.firstWhere(
+    return str == null ? null : values.firstWhere(
         (item) => getEnumValueName(item).toUpperCase() == str.toUpperCase(),
-        orElse: () => null);
+        orElse: () => null
+    );
   }
 
   static String getEnumValueName<T>(T enumValue) {

--- a/flutter/beagle/lib/utils/enum.dart
+++ b/flutter/beagle/lib/utils/enum.dart
@@ -16,7 +16,6 @@
  */
 
 import 'package:beagle/utils/string_utils.dart';
-import 'dart:developer';
 
 class EnumUtils {
   static T fromString<T>(List<T> values, String str) {

--- a/flutter/beagle_components/lib/beagle_scroll_view.dart
+++ b/flutter/beagle_components/lib/beagle_scroll_view.dart
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-import 'package:beagle/model/beagle_button_style.dart';
-import 'package:beagle/service_locator.dart';
-import 'package:beagle/setup/beagle_design_system.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'dart:developer';
 
 /// Defines a container that makes its content scrollable
 class BeagleScrollView extends StatelessWidget {

--- a/flutter/beagle_components/lib/beagle_scroll_view.dart
+++ b/flutter/beagle_components/lib/beagle_scroll_view.dart
@@ -31,14 +31,13 @@ class BeagleScrollView extends StatelessWidget {
     this.children,
   }) : super(key: key);
 
-  /// Define the button text content.
+  /// Defines if the content is scrollable in the vertical direction or horizontal. Default is vertical.
   final ScrollAxis scrollDirection;
 
-  /// References a [BeagleButtonStyle] declared natively and locally in [BeagleDesignSystem]
-  /// to be applied to this widget.
+  /// Shows or hide the scroll bar. By default, it's visible.
   final bool scrollBarEnabled;
 
-  /// The content of the scroll view
+  /// The content of the scroll view.
   final List<Widget> children;
 
   @override

--- a/flutter/beagle_components/lib/beagle_scroll_view.dart
+++ b/flutter/beagle_components/lib/beagle_scroll_view.dart
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:beagle/model/beagle_button_style.dart';
+import 'package:beagle/service_locator.dart';
+import 'package:beagle/setup/beagle_design_system.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'dart:developer';
+
+/// Defines a container that makes its content scrollable
+class BeagleScrollView extends StatelessWidget {
+  const BeagleScrollView({
+    Key key,
+    this.scrollDirection,
+    this.scrollBarEnabled,
+    this.children,
+  }) : super(key: key);
+
+  /// Define the button text content.
+  final ScrollAxis scrollDirection;
+
+  /// References a [BeagleButtonStyle] declared natively and locally in [BeagleDesignSystem]
+  /// to be applied to this widget.
+  final bool scrollBarEnabled;
+
+  /// The content of the scroll view
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final scrollView = ListView(
+      scrollDirection: scrollDirection == ScrollAxis.HORIZONTAL ? Axis.horizontal : Axis.vertical,
+      children: children,
+    );
+    return scrollBarEnabled == false ? scrollView : Scrollbar(child: scrollView);
+  }
+}
+
+enum ScrollAxis {
+  /// Creates a horizontal scroll bar
+  HORIZONTAL,
+
+  /// Creates a vertical scroll bar
+  VERTICAL
+}

--- a/flutter/beagle_components/lib/default_components.dart
+++ b/flutter/beagle_components/lib/default_components.dart
@@ -30,6 +30,7 @@ import 'package:beagle_components/beagle_text_input.dart';
 import 'package:beagle_components/beagle_touchable.dart';
 import 'package:beagle_components/beagle_webview.dart';
 import 'package:beagle_components/beagle_container.dart';
+import 'package:beagle_components/beagle_scroll_view.dart';
 import 'package:flutter/material.dart';
 
 final Map<String, ComponentBuilder> defaultComponents = {
@@ -47,7 +48,7 @@ final Map<String, ComponentBuilder> defaultComponents = {
   'beagle:touchable': beagleTouchableBuilder(),
   'beagle:webView': beagleWebViewBuilder(),
   'beagle:screenComponent': beagleContainerBuilder(),
-  'beagle:scrollView': beagleContainerBuilder(),
+  'beagle:scrollView': beagleScrollViewBuilder(),
 };
 
 ComponentBuilder beagleLoadingBuilder() {
@@ -81,6 +82,18 @@ ComponentBuilder beagleContainerBuilder() {
   return (element, children, _) => BeagleContainer(
     key: element.getKey(),
     onInit: element.getAttributeValue('onInit'),
+    children: children,
+  );
+}
+
+ComponentBuilder beagleScrollViewBuilder() {
+  return (element, children, _) => BeagleScrollView(
+    key: element.getKey(),
+    scrollDirection: EnumUtils.fromString(
+      ScrollAxis.values,
+      element.getAttributeValue('scrollDirection'),
+    ),
+    scrollBarEnabled: element.getAttributeValue('scrollBarEnabled'),
     children: children,
   );
 }

--- a/flutter/beagle_components/test/beagle_scroll_view_test.dart
+++ b/flutter/beagle_components/test/beagle_scroll_view_test.dart
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:beagle_components/beagle_scroll_view.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'service_locator/service_locator.dart';
+
+Widget createWidget({
+  ScrollAxis scrollDirection,
+  bool scrollBarEnabled,
+}) {
+  return MaterialApp(
+    home: BeagleScrollView(
+      key: Key('scrollKey'),
+      scrollBarEnabled: scrollBarEnabled,
+      scrollDirection: scrollDirection,
+      children: [Text('Scrollable content')],
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() async {
+    await testSetupServiceLocator();
+  });
+
+  group('Given a BeagleScrollView', () {
+    group('When the widget is created', () {
+      testWidgets(
+        'Then there should be a vertical ListView with a visible ScrollBar and a Text as its content',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(createWidget());
+
+          final scrollbarFinder = find.byType(Scrollbar);
+          final listViewFinder = find.byType(ListView);
+          final textFinder = find.byType(Text);
+
+          expect(scrollbarFinder, findsOneWidget);
+          expect(listViewFinder, findsOneWidget);
+          expect(textFinder, findsOneWidget);
+
+          final scrollbar = tester.widget<Scrollbar>(scrollbarFinder);
+          final ListView listView = scrollbar.child;
+          expect(listView.scrollDirection == Axis.vertical, isTrue);
+          expect(listView.semanticChildCount == 1, isTrue);
+        },
+      );
+    });
+
+    group('When the widget is created with a horizontal scroll', () {
+      testWidgets('Then the list view orientation should be horizontal', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(scrollDirection: ScrollAxis.HORIZONTAL));
+        final listViewFinder = find.byType(ListView);
+        final ListView listView = tester.widget<ListView>(listViewFinder);
+        expect(listView.scrollDirection == Axis.horizontal, isTrue);
+      });
+    });
+
+    group('When the widget is created with a hidden scroll bar', () {
+      testWidgets('Then there should be a ListView, but no ScrollBar', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(scrollBarEnabled: false));
+        final listViewFinder = find.byType(ListView);
+        final scrollbarFinder = find.byType(Scrollbar);
+        expect(listViewFinder, findsOneWidget);
+        expect(scrollbarFinder, findsNothing);
+      });
+    });
+  });
+}


### PR DESCRIPTION
### Description and Example

- Created the component BeagleScrollView.
- Fixed bug where null values would cause problems when parsing strings into enums.

I didn't chose between `MaterialScrollBar` and `CupertinoScrollBar` because the documentation of the ScrollBar from Material states that this is done by default:

> Dynamically changes to an iOS style scrollbar that looks like CupertinoScrollbar on the iOS platform.

Observation 1: The current example at `/sample` includes a `Column` as the first component. ScrollViews, in Flutter, don't work when wrapped in Columns. Remove the `Column` if you need the `ScrollView` to work.

Observation 2: Dart has a serious problem when dealing with default values and null values, in summary, it doesn't replace null values by the defaults, it has an implicit `undefined` type and only this type gets replaced by the default values. For this reason I did not use any defaults while implementing this component. More details [here](https://github.com/dart-lang/language/issues/1512).
### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [ ] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
