### PR TITLE
fix: text component when is aligned to center

### DIFF
--- a/flutter/beagle_components/lib/beagle_text.dart
+++ b/flutter/beagle_components/lib/beagle_text.dart
@@ -50,7 +50,7 @@ class BeagleText extends StatelessWidget {
       textAlign: getTextAlign(alignment),
       style: getTextStyle(),
     );
-    return alignment == TextAlignment.CENTER ? Center(child: beagleText) : text;
+    return alignment == TextAlignment.CENTER ? Center(child: beagleText) : beagleText;
   }
 
   TextAlign getTextAlign(TextAlignment alignment) {

--- a/flutter/beagle_components/lib/beagle_text.dart
+++ b/flutter/beagle_components/lib/beagle_text.dart
@@ -45,11 +45,12 @@ class BeagleText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
+    final beagleText = Text(
       text ?? '',
       textAlign: getTextAlign(alignment),
       style: getTextStyle(),
     );
+    return alignment == TextAlignment.CENTER ? Center(child: beagleText) : text;
   }
 
   TextAlign getTextAlign(TextAlignment alignment) {

--- a/flutter/beagle_components/test/beagle_text_test.dart
+++ b/flutter/beagle_components/test/beagle_text_test.dart
@@ -50,7 +50,6 @@ Widget createWidget({
 }
 
 void main() {
-
   setUpAll(() async {
     await testSetupServiceLocator();
   });
@@ -137,6 +136,25 @@ void main() {
       expect(textFinder, findsOneWidget);
       expect(textCreated.style.color, expectedTextColor);
       expect(textCreated.style.backgroundColor, textStyle.backgroundColor);
+    });
+  });
+
+  group('When set alignment to CENTER ', () {
+    testWidgets('Then it should be a Center Widget with text aligned to center',
+        (WidgetTester tester) async {
+      // WHEN
+      await tester.pumpWidget(createWidget(alignment: TextAlignment.CENTER));
+
+      //THEN
+      final textFinder = find.text(text);
+      final centerFinder = find.byType(Center);
+      final centerCreated = tester.widget<Center>(centerFinder);
+      final textCreated = centerCreated.child as Text;
+      const expectedTextAlign = TextAlign.center;
+
+      expect(centerFinder, findsOneWidget);
+      expect(textFinder, findsOneWidget);
+      expect(textCreated.textAlign, expectedTextAlign);
     });
   });
 }


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

### Description and Example

<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most imporant thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

When the `alignment` property is `CENTER` in `Text` component it must be centered both horizontally and vertically. To center the text vertically on Flutter, it must be placed inside a Center widget.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
