### PR TITLE
fix: flutter: webview component must react to changes in the url property

### DIFF
--- a/flutter/beagle_components/lib/beagle_webview.dart
+++ b/flutter/beagle_components/lib/beagle_webview.dart
@@ -46,15 +46,13 @@ class _BeagleWebView extends State<BeagleWebView> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: WebView(
-        initialUrl: widget.url,
-        javascriptMode: JavascriptMode.unrestricted,
-        onWebResourceError: _handleError,
-        onPageStarted: _handleLoading,
-        onPageFinished: _handleSuccess,
-        onWebViewCreated: (WebViewController webViewController) => _controller = webViewController,
-      ),
+    return WebView(
+      initialUrl: widget.url,
+      javascriptMode: JavascriptMode.unrestricted,
+      onWebResourceError: _handleError,
+      onPageStarted: _handleLoading,
+      onPageFinished: _handleSuccess,
+      onWebViewCreated: (WebViewController webViewController) => _controller = webViewController,
     );
   }
 

--- a/flutter/beagle_components/lib/beagle_webview.dart
+++ b/flutter/beagle_components/lib/beagle_webview.dart
@@ -18,8 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:webview_flutter/platform_interface.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
-/// A web view widget for showing html content.
-class BeagleWebView extends StatelessWidget {
+class BeagleWebView extends StatefulWidget {
   /// Creates a new web view.
   const BeagleWebView({
     Key key,
@@ -30,13 +29,32 @@ class BeagleWebView extends StatelessWidget {
   final String url;
 
   @override
+  _BeagleWebView createState() => _BeagleWebView();
+}
+
+/// A web view widget for showing html content.
+class _BeagleWebView extends State<BeagleWebView> {
+  WebViewController _controller;
+
+  @override
+  void didUpdateWidget(covariant BeagleWebView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.url != oldWidget.url) {
+      _controller.loadUrl(widget.url);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return WebView(
-      initialUrl: url,
-      javascriptMode: JavascriptMode.unrestricted,
-      onWebResourceError: _handleError,
-      onPageStarted: _handleLoading,
-      onPageFinished: _handleSuccess,
+    return Container(
+      child: WebView(
+        initialUrl: widget.url,
+        javascriptMode: JavascriptMode.unrestricted,
+        onWebResourceError: _handleError,
+        onPageStarted: _handleLoading,
+        onPageFinished: _handleSuccess,
+        onWebViewCreated: (WebViewController webViewController) => _controller = webViewController,
+      ),
     );
   }
 

--- a/flutter/beagle_components/lib/beagle_webview.dart
+++ b/flutter/beagle_components/lib/beagle_webview.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:webview_flutter/platform_interface.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+/// A web view widget for showing html content.
 class BeagleWebView extends StatefulWidget {
   /// Creates a new web view.
   const BeagleWebView({
@@ -32,7 +33,6 @@ class BeagleWebView extends StatefulWidget {
   _BeagleWebView createState() => _BeagleWebView();
 }
 
-/// A web view widget for showing html content.
 class _BeagleWebView extends State<BeagleWebView> {
   WebViewController _controller;
 


### PR DESCRIPTION
### Related Issues

#1643 

### Description and Example

- Fixed problem where the BeagleWebView wouldn't react to a change in the property `url`.

Attention: the example for the Appium tests still doesn't work because Yoga is not yet integrated and because of #1671. I tested the component by manually setting a height for the WebView inside the component BeagleWebView.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [ ] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
