### PR TITLE
fix: docs reference redirect to android page on s3 bucket

### DIFF
--- a/fastlane/kdocs/indexTemplate/index.html
+++ b/fastlane/kdocs/indexTemplate/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="refresh" content="0; url=/android" />
+  <meta http-equiv="refresh" content="0; url=/android/" />
   <title>Document</title>
 </head>
 <body>


### PR DESCRIPTION
### Description and Example

- The current cloud front configuration requires that the index.html exposed in bucket s3 of our webpage https://docs-reference.usebeagle.io contain a "/" at the end of the url property in the meta tag.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
