### PR TITLE
fix: flutter version and readme link

### DIFF
--- a/flutter/beagle/pubspec.yaml
+++ b/flutter/beagle/pubspec.yaml
@@ -1,6 +1,6 @@
 name: beagle
 description: Beagle is an open source framework for cross-platform development using the concept of Server-Driven UI.
-version: 0.1.9
+version: 0.9.0
 homepage: https://usebeagle.io/
 
 environment:

--- a/flutter/beagle_components/pubspec.yaml
+++ b/flutter/beagle_components/pubspec.yaml
@@ -1,7 +1,7 @@
 name: beagle_components
 description: Beagle Components is a set of tools and components to be used with the Beagle package
   wich is an open source framework for cross-platform development using the concept of Server-Driven UI.
-version: 0.1.9
+version: 0.9.0
 homepage: https://usebeagle.io/
 publish_to: none # remove this when beagle is published
 

--- a/flutter/readme.md
+++ b/flutter/readme.md
@@ -29,7 +29,7 @@ It's quite simple to configure and use the Beagle Flutter library. Follow the st
 All the configuration necessary for Beagle to work is centered on the parameters of the `BeagleSdk.init` startup 
 method. This params tells everything Beagle needs to know to render your widgets. Here we show only the basic options 
 `baseUrl` and `components`. For a list of all the available options, please check the 
-[documentation for the Beagle Initialization](todo).
+[documentation for the Beagle Initialization](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/configuration/).
 
 ### 2. Starting Beagle
 You can start Beagle at any point of the application. For this guide, we're going to start Beagle as soon as the app 


### PR DESCRIPTION
### Description and Example

- The first version of Beagle Flutter in alpha stage is `0.9.0`.
- A link in the `readme.md` file is fixed.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
