### PR TITLE
fix: temporary solution to adjust loop inside page docs

### DIFF
--- a/fastlane/kdocs/indexTemplate/index.html
+++ b/fastlane/kdocs/indexTemplate/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="refresh" content="0; url=/android/" />
+  <meta http-equiv="refresh" content="0; url=/backend/br.com.zup.beagle.analytics/" />
   <title>Document</title>
 </head>
 <body>


### PR DESCRIPTION
### Related Issues

issue: #1688

### Description and Example

- This file is responsible for redirecting the page access flow from docs-reference.usebeagle.io to docs-reference.usebeagle.io/backend/br.com.zup.beagle.analytics/. 
- This is due to a bug in Dokka that does not generate a home page for the documentation.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:
