### PR TITLE
fix: adds license, readme and http library

### DIFF
--- a/flutter/beagle/LICENSE
+++ b/flutter/beagle/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/flutter/beagle/README.md
+++ b/flutter/beagle/README.md
@@ -1,0 +1,175 @@
+# Beagle
+This is the library responsible for rendering a Beagle JSON in Flutter. It is currently in alpha stage, and
+most features are yet to be implemented. We welcome any help from the community in making improvements to the API -
+which isn't finished - and implementing features that are missing. At the end of this document you can find the
+session "State of development" where we show everything we have yet to do before releasing a stable version.
+
+## Versioning
+Every alpha and beta version of Beagle Flutter will follow the pattern `0.x.y`, where `x` is the version of [Beagle 
+Web](https://github.com/ZupIT/beagle-web-core) it's based on and `y` is every subsequent version where `x` 
+would be the same.
+
+In the version number, `x` refers to a version of the Beagle Web, because Beagle Flutter uses this lib under the hood.
+
+## Null safety compatibility
+For now, we'll not support null safety for the alpha versions, however this is a high priority implementation and 
+should be available in future versions.
+
+## Installation
+1. Open the file `pubspec.yaml` in the root of your project.
+2. Under `dependencies`, add `beagle: ^0.9.0-alpha`, or whatever the most recent version is.
+4. In your IDE (Android Studio or Visual Studio Code), click `pub get`. Or, from the terminal, type `flutter pub get`.
+
+## Usage
+It's quite simple to configure and use the Beagle Flutter library. Follow the steps bellow to be able to use it.
+
+### 1. The configuration
+All the configuration necessary for Beagle to work is centered on the parameters of the `BeagleSdk.init` startup 
+method. This params tells everything Beagle needs to know to render your widgets. Here we show only the basic options 
+`baseUrl` and `components`. For a list of all the available options, please check the 
+[documentation for the Beagle Initialization](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/configuration/).
+
+### 2. Starting Beagle
+You can start Beagle at any point of the application. For this guide, we're going to start Beagle as soon as the app 
+starts. For this, open the file `lib/main.dart` and import `package:beagle/beagle.dart`. After that, 
+inside the main function, before rendering anything, call `BeagleSdk.init` passing the parameter previously informed. 
+See the example below:
+
+```dart
+import 'package:beagle/beagle.dart';
+import 'package:beagle_components/beagle_components.dart';
+
+void main() {
+  Map<String, ComponentBuilder> components = {
+    'custom:loading': (element, _, __) {
+      return Center(
+        key: element.getKey(),
+        child: const Text('My custom loading.'),
+      );
+    }
+  };
+
+  BeagleSdk.init(
+    baseUrl: 'http://yourBffBaseUrl.io',
+    components: components,
+  );
+  // runApp();
+}
+```
+
+### 3. Rendering a remote widget
+To render a Beagle Widget, you must use the component `BeagleWidget` which is provided by the Beagle Library. This widget
+requires a single parameter, the `screenRequest`, which specifies the request to fetch the first server-driven view of
+the flow. See the example below:
+
+```dart
+import 'package:beagle/beagle.dart';
+import 'package:beagle_components/beagle_components.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  BeagleSdk.init(
+    baseUrl: 'http://yourBffBaseUrl.io',
+    components: components,
+  );
+  runApp(const BeagleSampleApp());
+}
+
+class BeagleSampleApp extends StatelessWidget {
+  const BeagleSampleApp({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Beagle Sample',
+      home: Scaffold(
+        body: BeagleWidget(
+          screenRequest: BeagleScreenRequest('welcome'),
+        ),
+      ),
+    );
+  }
+}
+```
+
+Above, we used a simple Material App to render our first server-driven widget! The important part here is the component 
+`BeagleWidget`, because it includes a remote view in the layout.
+
+### 4. Implementing your own Beagle application
+This example showed how to render a simple example available in the web. For real use case scenarios, you'll have your
+own backend server providing the views - check the
+[Beagle Backend Framework](https://docs.usebeagle.io/v1.9/get-started/installing-beagle/backend/) for more details. To
+make Beagle work with this backend, you only need to change the address in the field `baseUrl` of your configuration at
+`BeagleSdk.init` method.
+
+If you're testing it in the Android emulator and using a local backend server, don't forget to use the ip 10.0.2.2. 
+To build a `baseUrl` that works for both the Android and iOS emulator, you can use `Platform` from `dart:io`:
+
+```dart
+import 'dart:io' show Platform;
+
+final localhost = Platform.isAndroid ? '10.0.2.2' : 'localhost';
+final baseUrl = 'http://$localhost:8080';
+```
+
+## Configuration options
+Beagle lets you configure a lot of its behavior. Please, check 
+[this article](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/customization/overview/) 
+for a list of every option available.
+
+## The Beagle Widget
+The entry point for a Beagle remote view is the `BeagleWidget`. As mentioned before, it only requires a single 
+parameter, the url of the view to render, but much more can be customized, e.g. observe requests and parsing errors 
+rendering updates, make parametrized requests, etc. 
+[Check this doc](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/beagle-widget) for a list of 
+every option accepted by the `BeagleWidget`.
+
+## Beagle services
+These are services that must be provided to Beagle for it to work properly. For now, we're embedding default
+implementations within the library. This is probably not going to be the case in the future, since it may represent
+potential security issues. The Beagle services are:
+
+- [BeagleLogger](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/services/logger/): 
+provides a logger for Beagle to use.
+- [HttpClient](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/services/http-client/): 
+tells exactly how the network requests should be made, allowing custom headers and much more.
+- [BeagleImageDownloader](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/services/image-downloader/): 
+allows a custom logic for downloading network images.
+- [BeagleStorage](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/services/storage/): 
+persists data across multiple executions by stating exactly how Beagle should store data.
+
+You can set your own implementation of each of these services via `BeagleSdk.init`.
+
+## Customization
+Beagle is highly customizable because you can create your own components, actions and even operations. All of these 
+must be provided when calling `BeagleSdk.init`.
+
+- [Custom components](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/customization/components/): 
+create your own components.
+- [Custom actions](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/customization/actions/): 
+make the events in your components do exactly what you need.
+- [Custom operations](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/customization/operations/): 
+if the operations shipped with Beagle are not enough for your expressions, create your own.
+- [Design System](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/design-system/): 
+here you define all styles and local images that can be used by Beagle.
+
+## Other APIs
+- [Global context](https://docs.usebeagle.io/v1.9/api/context/global-context/): allows manipulation of the global 
+context in Beagle Flutter.
+- [Analytics](https://docs.usebeagle.io/v1.9/api/analytics/): gives information of every action executed, such as 
+navigation data.
+- [Renderer](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-web/advanced-topics/renderer-api/): sometimes it might be necessary to interact with Beagle while rendering a component or executing an 
+action. This article shows how to use the Renderer API to achieve complex behaviors.
+  
+## Current state of development
+Currently in alpha. It'll be moved to beta as soon as we have every layout tool (Yoga) working as expected. Here's
+a list of every feature we need to release a stable version of Beagle Flutter and its status.
+
+It's important to reiterate that Beagle is an open source project and every help is welcomed!
+
+### Major features
+todo: check https://docs.google.com/spreadsheets/d/1aSo7eZsj2lEnTG0kKzta-U4G9qkgA8v1w9kpyrPlVPA/edit?usp=sharing
+
+### Default actions
+todo: check https://docs.google.com/spreadsheets/d/1aSo7eZsj2lEnTG0kKzta-U4G9qkgA8v1w9kpyrPlVPA/edit?usp=sharing

--- a/flutter/beagle/pubspec.yaml
+++ b/flutter/beagle/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   flutter_js: ^0.5.0+0
   get_it: ^7.1.3
+  http: ^0.13.3
   url_launcher: ^6.0.6
   yoga_engine: ^0.0.1
 
@@ -21,15 +22,7 @@ dev_dependencies:
   lints: ^1.0.1
   mockito: ^5.0.10
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' and Android 'package' identifiers should not ordinarily
-  # be modified. They are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       android:
@@ -38,29 +31,3 @@ flutter:
 
   assets:
     - assets/js/beagle.js
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/flutter/beagle_components/LICENSE
+++ b/flutter/beagle_components/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/flutter/beagle_components/README.md
+++ b/flutter/beagle_components/README.md
@@ -1,0 +1,93 @@
+# Beagle Components
+This library provides the Beagle's base components. It is currently in alpha stage, and some components are yet to be 
+implemented. We welcome any help from the community in making improvements to the components with features that are 
+missing. At the end of this document you can find the session "State of development" where we show everything we have 
+yet to do before releasing a stable version.
+
+## Versioning
+Every alpha and beta version of Beagle Flutter will follow the pattern `0.x.y`, where `x` is the version of [Beagle 
+Web](https://github.com/ZupIT/beagle-web-core) it's based on and `y` is every subsequent version where `x` 
+would be the same.
+
+In the version number, `x` refers to a version of the Beagle Web, because Beagle Flutter uses this lib under the hood.
+
+## Null safety compatibility
+For now, we'll not support null safety for the alpha versions, however this is a high priority implementation and 
+should be available in future versions.
+
+## Installation
+1. Open the file `pubspec.yaml` in the root of your project.
+2. Under `dependencies`, add `beagle_components: ^0.9.0-alpha`, or whatever the most recent version is.
+4. In your IDE (Android Studio or Visual Studio Code), click `pub get`. Or, from the terminal, type `flutter pub get`.
+
+## Usage
+It's quite simple to use the Beagle Components library. Follow the steps bellow to be able to use it.
+
+### 1. The configuration
+There is no configuration required to use the Beagle Components library, but it is expected to use it with the 
+Beagle library. To learn how to configure Beagle, please check the 
+[documentation for the Beagle Initialization](https://docs.usebeagle.io/v1.9/resources/customization/beagle-for-flutter/configuration/).
+
+### 2. Using Beagle Components
+To use this library with Beagle, open the file `lib/main.dart`, import `package:beagle/beagle.dart` and 
+`package:beagle_components/beagle_components.dart` as well. After that, inside the main function, before rendering 
+anything, call `BeagleSdk.init` passing the `baseUrl` param with the `components: defaultComponents`. 
+See the example below:
+
+```dart
+import 'package:beagle/beagle.dart';
+import 'package:beagle_components/beagle_components.dart';
+
+void main() {
+  BeagleSdk.init(
+    baseUrl: 'http://yourBffBaseUrl.io',
+    components: defaultComponents,
+  );
+  // runApp();
+}
+```
+
+### 3. Rendering a remote widget
+To render a Beagle Widget, you must use the component `BeagleWidget` which is provided by the Beagle Library. This widget
+requires a single parameter, the `screenRequest`, which specifies the request to fetch the first server-driven view of
+the flow. See the example below:
+
+```dart
+import 'package:beagle/beagle.dart';
+import 'package:beagle_components/beagle_components.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  BeagleSdk.init(
+    baseUrl: 'http://yourBffBaseUrl.io',
+    components: defaultComponents,
+  );
+  runApp(const BeagleSampleApp());
+}
+
+class BeagleSampleApp extends StatelessWidget {
+  const BeagleSampleApp({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Beagle Sample',
+      home: Scaffold(
+        body: BeagleWidget(
+          screenRequest: BeagleScreenRequest('welcome'),
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Current state of development
+Currently in alpha. It'll be moved to beta as soon as we have every layout tool (Yoga) working as expected. Here's
+a list of every feature we need to release a stable version of Beagle Flutter and its status.
+
+It's important to reiterate that Beagle is an open source project and every help is welcomed!
+
+### Default components
+todo: check https://docs.google.com/spreadsheets/d/1aSo7eZsj2lEnTG0kKzta-U4G9qkgA8v1w9kpyrPlVPA/edit?usp=sharing

--- a/flutter/beagle_components/pubspec.yaml
+++ b/flutter/beagle_components/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   beagle:
-    path: '../beagle' # change this to ^0.1.9 when beagle is published
+    path: '../beagle' # change this to ^0.9.0-alpha when beagle is published
   flutter:
     sdk: flutter
   webview_flutter: ^2.0.8
@@ -22,10 +22,6 @@ dev_dependencies:
   lints: ^1.0.1
   mockito: ^5.0.10
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
   uses-material-design: true
   assets:


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

### Description and Example

To publish any library to pub.dev, it's necessary to follow some rules. This PR adds a license and a readme files and the http library.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
