### PR TITLE
chore: remove beagle local dependency from beagle_components

### DIFF
--- a/flutter/beagle_components/pubspec.yaml
+++ b/flutter/beagle_components/pubspec.yaml
@@ -1,17 +1,15 @@
 name: beagle_components
 description: Beagle Components is a set of tools and components to be used with the Beagle package
-  wich is an open source framework for cross-platform development using the concept of Server-Driven UI.
+  that is an open source framework for cross-platform development using the concept of Server-Driven UI.
 version: 0.9.0-alpha
 homepage: https://usebeagle.io/
-publish_to: none # remove this when beagle is published
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
   flutter: ">=1.22.5"
 
 dependencies:
-  beagle:
-    path: '../beagle' # change this to ^0.9.0-alpha when beagle is published
+  beagle: ^0.9.0-alpha
   flutter:
     sdk: flutter
   webview_flutter: ^2.0.8

--- a/flutter/sample/pubspec.yaml
+++ b/flutter/sample/pubspec.yaml
@@ -1,36 +1,16 @@
 name: sample
 description: A new Flutter application.
-
-# The following line prevents the package from being accidentally published to
-# pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 1.0.0
+publish_to: 'none'
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
   flutter: ">=1.22.5"
 
 dependencies:
-  beagle:
-    path: ../beagle
-  beagle_components:
-    path: ../beagle_components
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
+  beagle: ^0.9.0-alpha
+  beagle_components: ^0.9.0-alpha
   cupertino_icons: ^1.0.3
-
   flutter:
     sdk: flutter
 
@@ -39,15 +19,7 @@ dev_dependencies:
     sdk: flutter
   lints: ^1.0.1
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
   assets:
     - images/


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

### Description and Example
To publish any package in pub.dev, it's required that no dependencies be local. Given that, `beagle` dependency in `beagle_components` must be the published one.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/master/doc/contributing/pull_requests.md
