### PR TITLE
fix: Windows environment fix

### DIFF
--- a/tests/bff-server/bff/build.gradle
+++ b/tests/bff-server/bff/build.gradle
@@ -35,7 +35,7 @@ task buildAndPublishBeagleBackendLocally {
         def executableVar = ''
 
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            executableVar = 'gradlew.bat'
+            executableVar = './gradlew.bat'
         } else {
             executableVar = './gradlew'
         }


### PR DESCRIPTION
Adds "./" for Windows systems because it wasn't finding gradlew.bat

