### PR TITLE
feat: Change workflow name

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -2,7 +2,7 @@ name: Check License Lines
 on: [pull_request]
 jobs:
   license-header-check:
-    name: License Header Check
+    name: PR Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
With this name, this workflow will run for every folders and because it has the same name of the backend,android, and ios.
We could put "PR Check" as required even when there is no changes on platform folders