### PR TITLE
fix: iOS - Empting acessibilityValue from Text component

### DIFF
--- a/iOS/Sources/Beagle/Sources/Components/Widget/Text/Text+Extensions.swift
+++ b/iOS/Sources/Beagle/Sources/Components/Widget/Text/Text+Extensions.swift
@@ -28,7 +28,9 @@ extension Text {
         textView.textContainer.lineBreakMode = .byTruncatingTail
         textView.font = .systemFont(ofSize: 16)
         textView.backgroundColor = .clear
-
+        //In order to make it behave like the Android component and the UILabel UIKit component, we removed the `accessibilityValue` from the UITextView.
+        textView.accessibilityValue = String()
+        
         // the order of `observe` here is important (`textColor`should be set before `text`) to avoid a weird UIKit behavior when setting `textColor` to nil (issue: #766)
         renderer.observe(textColor, andUpdate: \.textColor, in: textView) {
             $0.flatMap { UIColor(hex: $0) }


### PR DESCRIPTION
### Related Issues
closes #1761 

### Description and Example

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
